### PR TITLE
feat(init): support existing task folder via --tasks-root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- No unreleased changes yet.
+- `taskplane init --tasks-root <relative-path>` to target an existing task directory (for example `docs/task-management`) instead of creating an alternate task area path.
+
+### Changed
+- When `--tasks-root` is provided, sample task packets are skipped by default; pass `--include-examples` to scaffold examples intentionally into that directory.
 
 ## [0.1.12] - 2026-03-15
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ taskplane init --preset full
 
 This creates config files in `.pi/`, agent prompts, and two example tasks.
 
+Already have a task folder (for example `docs/task-management`)? Use:
+
+```bash
+taskplane init --preset full --tasks-root docs/task-management
+```
+
+When `--tasks-root` is provided, example task packets are skipped by default. Add `--include-examples` if you explicitly want examples in that folder.
+
 ### 2. Launch the dashboard (recommended)
 
 In a separate terminal:

--- a/bin/taskplane.mjs
+++ b/bin/taskplane.mjs
@@ -529,11 +529,43 @@ async function cmdInit(args) {
 	const projectRoot = process.cwd();
 	const force = args.includes("--force");
 	const dryRun = args.includes("--dry-run");
-	const noExamples = args.includes("--no-examples");
+	const noExamplesFlag = args.includes("--no-examples");
+	const includeExamples = args.includes("--include-examples");
 	const presetIdx = args.indexOf("--preset");
 	const preset = presetIdx !== -1 ? args[presetIdx + 1] : null;
+	const tasksRootIdx = args.indexOf("--tasks-root");
+	const tasksRootRaw = tasksRootIdx !== -1 ? args[tasksRootIdx + 1] : null;
+
+	if (noExamplesFlag && includeExamples) {
+		die("Choose either --no-examples or --include-examples, not both.");
+	}
+
+	if (tasksRootIdx !== -1 && (!tasksRootRaw || tasksRootRaw.startsWith("--"))) {
+		die("Missing value for --tasks-root <relative-path>.");
+	}
+
+	let tasksRootOverride = null;
+	if (tasksRootRaw) {
+		if (path.isAbsolute(tasksRootRaw)) {
+			die("--tasks-root must be relative to the project root (absolute paths are not allowed).");
+		}
+		tasksRootOverride = tasksRootRaw.trim().replace(/\\/g, "/").replace(/^\.\/+/, "").replace(/\/+$/, "");
+		if (!tasksRootOverride || tasksRootOverride === ".") {
+			die("--tasks-root must not be empty.");
+		}
+		if (tasksRootOverride === ".." || tasksRootOverride.startsWith("../")) {
+			die("--tasks-root must stay within the project root (paths starting with .. are not allowed).");
+		}
+	}
+
+	const noExamples = noExamplesFlag || (!!tasksRootOverride && !includeExamples);
 
 	console.log(`\n${c.bold}Taskplane Init${c.reset}\n`);
+
+	if (tasksRootOverride && !noExamplesFlag && !includeExamples) {
+		console.log(`  ${INFO} Using custom --tasks-root (${tasksRootOverride}); skipping example tasks by default.`);
+		console.log(`     Use --include-examples to scaffold examples into that directory.\n`);
+	}
 
 	// Check for existing config
 	const hasConfig =
@@ -552,10 +584,14 @@ async function cmdInit(args) {
 	// Gather config values
 	let vars;
 	if (preset === "minimal" || preset === "full" || preset === "runner-only") {
-		vars = getPresetVars(preset, projectRoot);
-		console.log(`  Using preset: ${c.cyan}${preset}${c.reset}\n`);
+		vars = getPresetVars(preset, projectRoot, tasksRootOverride);
+		console.log(`  Using preset: ${c.cyan}${preset}${c.reset}`);
+		if (tasksRootOverride) {
+			console.log(`  Task directory: ${c.cyan}${tasksRootOverride}${c.reset}`);
+		}
+		console.log();
 	} else {
-		vars = await getInteractiveVars(projectRoot);
+		vars = await getInteractiveVars(projectRoot, tasksRootOverride);
 	}
 
 	const exampleTemplateDirs = noExamples ? [] : listExampleTaskTemplates();
@@ -655,7 +691,7 @@ async function cmdInit(args) {
 	console.log();
 }
 
-function getPresetVars(preset, projectRoot) {
+function getPresetVars(preset, projectRoot, tasksRootOverride = null) {
 	const dirName = path.basename(projectRoot);
 	const slug = slugify(dirName);
 	const { test: test_cmd, build: build_cmd } = detectStack(projectRoot);
@@ -665,7 +701,7 @@ function getPresetVars(preset, projectRoot) {
 		max_lanes: 3,
 		worktree_prefix: `${slug}-wt`,
 		tmux_prefix: `${slug}-orch`,
-		tasks_root: "taskplane-tasks",
+		tasks_root: tasksRootOverride || "taskplane-tasks",
 		default_area: "general",
 		default_prefix: "TP",
 		test_cmd,
@@ -674,14 +710,14 @@ function getPresetVars(preset, projectRoot) {
 	};
 }
 
-async function getInteractiveVars(projectRoot) {
+async function getInteractiveVars(projectRoot, tasksRootOverride = null) {
 	const dirName = path.basename(projectRoot);
 	const detected = detectStack(projectRoot);
 
 	const project_name = await ask("Project name", dirName);
 	const integration_branch = await ask("Default branch (fallback — orchestrator uses your current branch at runtime)", "main");
 	const max_lanes = parseInt(await ask("Max parallel lanes", "3")) || 3;
-	const tasks_root = await ask("Tasks directory", "taskplane-tasks");
+	const tasks_root = tasksRootOverride || await ask("Tasks directory", "taskplane-tasks");
 	const default_area = await ask("Default area name", "general");
 	const default_prefix = await ask("Task ID prefix", "TP");
 	const test_cmd = await ask("Test command (agents run this to verify work — blank to skip)", detected.test || "");
@@ -934,10 +970,12 @@ ${c.bold}Commands:${c.reset}
   ${c.cyan}help${c.reset}        Show this help message
 
 ${c.bold}Init options:${c.reset}
-  --preset <name>   Use a preset: minimal, full, runner-only
-  --no-examples     Skip example tasks scaffolding
-  --force           Overwrite existing files without prompting
-  --dry-run         Show what would be created without writing
+  --preset <name>       Use a preset: minimal, full, runner-only
+  --tasks-root <path>   Relative tasks directory to use (e.g. docs/task-management)
+  --no-examples         Skip example tasks scaffolding
+  --include-examples    With --tasks-root, include example tasks (default is skip)
+  --force               Overwrite existing files without prompting
+  --dry-run             Show what would be created without writing
 
 ${c.bold}Dashboard options:${c.reset}
   --port <number>   Port to listen on (default: 8099)
@@ -956,6 +994,8 @@ ${c.bold}Uninstall options:${c.reset}
 ${c.bold}Examples:${c.reset}
   taskplane init                        # Interactive project setup
   taskplane init --preset full          # Quick setup with defaults
+  taskplane init --preset full --tasks-root docs/task-management
+                                        # Use existing task area path
   taskplane init --dry-run              # Preview what would be created
   taskplane doctor                      # Check installation health
   taskplane dashboard                   # Launch web dashboard

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -328,6 +328,20 @@ These are shell commands (not pi slash commands).
 
 Scaffold Taskplane project files (`.pi/`, agents, task templates).
 
+**Common options**
+
+- `--preset <name>` — use `minimal`, `full`, or `runner-only`
+- `--tasks-root <relative-path>` — use an existing task directory (for example `docs/task-management`)
+- `--no-examples` — skip example task scaffolding
+- `--include-examples` — when `--tasks-root` is used, include examples in that directory (default is skip)
+- `--force` — overwrite existing files
+- `--dry-run` — preview files without writing
+
+**Notes**
+
+- `--tasks-root` must be relative to project root.
+- When `--tasks-root` is passed, Taskplane skips sample tasks by default to avoid polluting an existing task area.
+
 ### `taskplane doctor`
 
 Validate installation and project configuration.

--- a/docs/tutorials/install.md
+++ b/docs/tutorials/install.md
@@ -66,6 +66,14 @@ For a non-interactive default setup:
 taskplane init --preset full
 ```
 
+If your project already has a task folder, point init at it:
+
+```bash
+taskplane init --preset full --tasks-root docs/task-management
+```
+
+When `--tasks-root` is provided, Taskplane skips sample task packets by default to avoid polluting an existing task area. Add `--include-examples` if you explicitly want them.
+
 This scaffolds:
 
 - `.pi/task-runner.yaml`


### PR DESCRIPTION
## Summary
Add a first-class `taskplane init` flag for projects that already have a task folder.

## Changes
- add `--tasks-root <relative-path>` init option
- validate that `--tasks-root` is relative and stays within project root
- default to skipping example task packets when `--tasks-root` is provided
- add `--include-examples` to opt back into example scaffolding with custom root
- update CLI help and docs (`README`, install tutorial, commands reference)
- update changelog `Unreleased`

## Why
This supports existing setups like `docs/task-management` without creating an alternate `taskplane-tasks/` area by default.

## Validation
- `node bin/taskplane.mjs help`
- `node bin/taskplane.mjs init --preset full --tasks-root docs/task-management --dry-run --force`
- `node bin/taskplane.mjs init --preset full --tasks-root docs/task-management --include-examples --dry-run --force`
- absolute path rejection + conflicting flags rejection
- markdown relative link check
