### PR TITLE
chore(release): prepare v0.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- No unreleased changes yet.
+
+## [0.1.13] - 2026-03-15
+
+### Added
 - `taskplane init --tasks-root <relative-path>` to target an existing task directory (for example `docs/task-management`) instead of creating an alternate task area path.
 
 ### Changed
@@ -51,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Dashboard root resolution based on runtime `--root` instead of hardcoded repo path
 
-[Unreleased]: https://github.com/HenryLach/taskplane/compare/v0.1.12...HEAD
+[Unreleased]: https://github.com/HenryLach/taskplane/compare/v0.1.13...HEAD
+[0.1.13]: https://github.com/HenryLach/taskplane/releases/tag/v0.1.13
 [0.1.12]: https://github.com/HenryLach/taskplane/releases/tag/v0.1.12
 [0.1.11]: https://github.com/HenryLach/taskplane/releases/tag/v0.1.11

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
## Summary
Prepare release v0.1.13.

## Changes
- bump package version to `0.1.13`
- roll `Unreleased` notes into `0.1.13` changelog section
- update changelog compare/release links

## Validation
- `npm pack --dry-run`
- `npm publish --dry-run`
- `node bin/taskplane.mjs version`

## Notes
Tagging, npm publish, and GitHub release creation will happen after merge from protected `main`.
