### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.1.18",
+  "version": "0.2.0",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Version bump for v0.2.0 — polyrepo workspace mode. Package already published to npm.