### PR TITLE
fix: resolve task area paths from workspaceRoot in discovery

### DIFF
--- a/extensions/taskplane/engine.ts
+++ b/extensions/taskplane/engine.ts
@@ -34,6 +34,7 @@ import { deleteBranchBestEffort, forceCleanupWorktree, formatPreflightResults, l
  * @param onNotify    - Callback for user-facing messages
  * @param onMonitorUpdate - Optional callback for dashboard updates
  * @param workspaceConfig - Workspace configuration for repo routing (null = repo mode)
+ * @param workspaceRoot - Workspace root for resolving task area paths (defaults to cwd)
  */
 export async function executeOrchBatch(
 	args: string,
@@ -44,6 +45,7 @@ export async function executeOrchBatch(
 	onNotify: (message: string, level: "info" | "warning" | "error") => void,
 	onMonitorUpdate?: MonitorUpdateCallback,
 	workspaceConfig?: WorkspaceConfig | null,
+	workspaceRoot?: string,
 ): Promise<void> {
 	const repoRoot = cwd;
 
@@ -94,8 +96,10 @@ export async function executeOrchBatch(
 		return;
 	}
 
-	// Discovery
-	const discovery = runDiscovery(args, runnerConfig.task_areas, cwd, {
+	// Discovery — task area paths in task-runner.yaml are workspace-relative.
+	// In repo mode workspaceRoot === repoRoot, so this is always correct.
+	const discoveryRoot = workspaceRoot ?? cwd;
+	const discovery = runDiscovery(args, runnerConfig.task_areas, discoveryRoot, {
 		refreshDependencies: false,
 		dependencySource: orchConfig.dependencies.source,
 		useDependencyCache: orchConfig.dependencies.cache,

--- a/extensions/taskplane/extension.ts
+++ b/extensions/taskplane/extension.ts
@@ -207,6 +207,7 @@ export default function (pi: ExtensionAPI) {
 					if (changed) updateOrchWidget(); // Only refresh on actual state change
 				},
 				execCtx!.workspaceConfig,
+				execCtx!.workspaceRoot,
 			);
 
 			// Final widget update after batch completes
@@ -257,9 +258,9 @@ export default function (pi: ExtensionAPI) {
 			if (!preflight.passed) return;
 
 			// ── Section 2: Discovery ─────────────────────────────────
-			// Discovery uses repoRoot for consistency with engine.ts and resume.ts
-			// which both call runDiscovery with their cwd (= repoRoot).
-			const discovery = runDiscovery(cleanArgs, runnerConfig.task_areas, execCtx!.repoRoot, {
+			// Discovery resolves task area paths relative to workspaceRoot (not repoRoot),
+			// because task_areas in task-runner.yaml are workspace-relative paths.
+			const discovery = runDiscovery(cleanArgs, runnerConfig.task_areas, execCtx!.workspaceRoot, {
 				refreshDependencies: hasRefresh,
 				dependencySource: orchConfig.dependencies.source,
 				useDependencyCache: orchConfig.dependencies.cache,
@@ -608,8 +609,8 @@ export default function (pi: ExtensionAPI) {
 			}
 
 			// Run discovery (no preflight needed for deps view).
-			// Uses repoRoot for consistency with engine.ts and resume.ts.
-			const discovery = runDiscovery(cleanArgs, runnerConfig.task_areas, execCtx!.repoRoot, {
+			// Task area paths are workspace-relative, so use workspaceRoot.
+			const discovery = runDiscovery(cleanArgs, runnerConfig.task_areas, execCtx!.workspaceRoot, {
 				refreshDependencies: hasRefresh,
 				dependencySource: orchConfig.dependencies.source,
 				useDependencyCache: orchConfig.dependencies.cache,


### PR DESCRIPTION
In workspace mode, task area paths in `task-runner.yaml` are relative to the workspace root directory, not the default repo root. Discovery was resolving them from `repoRoot`, causing double-pathing (e.g., `platform-docs/platform-docs/task-management/...`).

### Fix
- `extension.ts`: Pass `execCtx.workspaceRoot` to `runDiscovery()` instead of `execCtx.repoRoot`
- `engine.ts`: Add `workspaceRoot` parameter to `executeOrchBatch()`, use it for discovery path resolution
- In repo mode, `workspaceRoot === repoRoot` so behavior is unchanged

### Testing
398/398 tests passing. Tested against real polyrepo workspace with task areas nested inside a repo subdirectory.