### PR TITLE
fix: resolve worktree base branch from current HEAD, not default_branch

### DIFF
--- a/extensions/taskplane/waves.ts
+++ b/extensions/taskplane/waves.ts
@@ -567,21 +567,24 @@ export function resolveBaseBranch(
 	batchBaseBranch: string,
 	workspaceConfig?: WorkspaceConfig | null,
 ): string {
-	// Step 1: Per-repo default branch from workspace config
-	if (repoId && workspaceConfig) {
-		const repoConfig = workspaceConfig.repos.get(repoId);
-		if (repoConfig?.defaultBranch) {
-			return repoConfig.defaultBranch;
-		}
-	}
-
-	// Step 2: Detect current branch of this specific repo
-	// In repo mode this is the same repo as the batch, so it's equivalent to batchBaseBranch.
-	// In workspace mode this detects the actual HEAD of each repo independently.
+	// Step 1: Detect current branch of this specific repo.
+	// This is the branch the developer is working on — worktrees should
+	// branch from here so task files committed on this branch are visible.
+	// In repo mode this equals batchBaseBranch. In workspace mode this
+	// detects each repo's actual HEAD independently.
 	if (repoId) {
 		const detected = getCurrentBranch(repoRoot);
 		if (detected) {
 			return detected;
+		}
+	}
+
+	// Step 2: Per-repo default branch from workspace config.
+	// Used when repo HEAD is detached or undetectable.
+	if (repoId && workspaceConfig) {
+		const repoConfig = workspaceConfig.repos.get(repoId);
+		if (repoConfig?.defaultBranch) {
+			return repoConfig.defaultBranch;
 		}
 	}
 


### PR DESCRIPTION
`resolveBaseBranch()` was prioritizing the workspace config's `default_branch` over the repo's actual current branch. This caused worktrees to branch from `develop` instead of the developer's feature branch, so task files committed on the feature branch were missing from worktrees.

### Root cause
Priority order was: default_branch → current branch → batch base branch. Should be: current branch → default_branch → batch base branch.

### Fix
Swap steps 1 and 2 in `resolveBaseBranch()` so the repo's current HEAD is detected first.

### Testing
398/398 tests passing.