### PR TITLE
fix: normalize merge result status to uppercase before validation

### DIFF
--- a/extensions/taskplane/merge.ts
+++ b/extensions/taskplane/merge.ts
@@ -78,6 +78,9 @@ export function parseMergeResult(resultPath: string): MergeResult {
 				);
 			}
 
+			// Normalize status to uppercase (merge agents may write lowercase)
+			parsed.status = String(parsed.status).toUpperCase();
+
 			// Validate status value
 			if (!VALID_MERGE_STATUSES.has(parsed.status)) {
 				execLog("merge", "parse", `unknown merge status "${parsed.status}" — treating as BUILD_FAILURE`, {


### PR DESCRIPTION
Merge agents may write lowercase status values (e.g., `"success"` instead of `"SUCCESS"`). The parser's case-sensitive Set lookup treated these as unknown and fell back to `BUILD_FAILURE`, causing false merge failures even when the merge succeeded.

### Fix
Add `parsed.status = String(parsed.status).toUpperCase()` before the validation check.

### Testing
398/398 tests passing.