### PR TITLE
fix: write state/sidecar files to workspaceRoot in workspace mode

### DIFF
--- a/extensions/taskplane/engine.ts
+++ b/extensions/taskplane/engine.ts
@@ -48,6 +48,9 @@ export async function executeOrchBatch(
 	workspaceRoot?: string,
 ): Promise<void> {
 	const repoRoot = cwd;
+	// State files (.pi/batch-state.json, lane-state, etc.) belong in the workspace root,
+	// which is where .pi/ config lives. In repo mode, workspaceRoot === repoRoot.
+	const stateRoot = workspaceRoot ?? cwd;
 
 	// ── Phase 1: Planning ────────────────────────────────────────
 	batchState.phase = "planning";
@@ -187,7 +190,7 @@ export async function executeOrchBatch(
 	batchState.phase = "executing";
 
 	// ── TS-009: Persist state on batch start (after wave computation) ──
-	persistRuntimeState("batch-start", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, repoRoot);
+	persistRuntimeState("batch-start", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
 
 	for (let waveIdx = 0; waveIdx < rawWaves.length; waveIdx++) {
 		// Check pause signal before starting each wave
@@ -196,14 +199,14 @@ export async function executeOrchBatch(
 			execLog("batch", batchState.batchId, `batch paused before wave ${waveIdx + 1}`);
 			onNotify(`⏸️  Batch paused before wave ${waveIdx + 1}. Resume not yet implemented (TS-009).`, "warning");
 			// ── TS-009: Persist state on pause ──
-			persistRuntimeState("pause-before-wave", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, repoRoot);
+			persistRuntimeState("pause-before-wave", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
 			break;
 		}
 
 		batchState.currentWaveIndex = waveIdx;
 
 		// ── TS-009: Persist state on wave index change ──
-		persistRuntimeState("wave-index-change", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, repoRoot);
+		persistRuntimeState("wave-index-change", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
 
 		// Filter wave tasks against blockedTaskIds
 		let waveTasks = rawWaves[waveIdx].filter(
@@ -234,7 +237,7 @@ export async function executeOrchBatch(
 		const handleWaveMonitorUpdate: MonitorUpdateCallback = (monitorState) => {
 			const changed = syncTaskOutcomesFromMonitor(monitorState, allTaskOutcomes);
 			if (changed) {
-				persistRuntimeState("task-transition", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, repoRoot);
+				persistRuntimeState("task-transition", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
 			}
 			onMonitorUpdate?.(monitorState);
 		};
@@ -255,7 +258,7 @@ export async function executeOrchBatch(
 				latestAllocatedLanes = lanes;
 				batchState.currentLanes = lanes;
 				if (seedPendingOutcomesForAllocatedLanes(lanes, allTaskOutcomes)) {
-					persistRuntimeState("wave-lanes-allocated", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, repoRoot);
+					persistRuntimeState("wave-lanes-allocated", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
 				}
 			},
 			workspaceConfig,
@@ -283,7 +286,7 @@ export async function executeOrchBatch(
 		}
 
 		// ── TS-009: Persist state after wave execution ──
-		persistRuntimeState("wave-execution-complete", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, repoRoot);
+		persistRuntimeState("wave-execution-complete", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
 
 		const elapsedSec = Math.round((waveResult.endedAt - waveResult.startedAt) / 1000);
 		onNotify(
@@ -302,14 +305,14 @@ export async function executeOrchBatch(
 			if (waveResult.policyApplied === "stop-all") {
 				batchState.phase = "stopped";
 				// ── TS-009: Persist state on stop-all ──
-				persistRuntimeState("stop-all", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, repoRoot);
+				persistRuntimeState("stop-all", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
 				onNotify(ORCH_MESSAGES.orchBatchStopped(batchState.batchId, "stop-all"), "error");
 				break;
 			}
 			if (waveResult.policyApplied === "stop-wave") {
 				batchState.phase = "stopped";
 				// ── TS-009: Persist state on stop-wave ──
-				persistRuntimeState("stop-wave", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, repoRoot);
+				persistRuntimeState("stop-wave", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
 				onNotify(ORCH_MESSAGES.orchBatchStopped(batchState.batchId, "stop-wave"), "error");
 				break;
 			}
@@ -347,7 +350,7 @@ export async function executeOrchBatch(
 			if (mergeableLaneCount > 0) {
 				batchState.phase = "merging";
 				// ── TS-009: Persist state on executing→merging transition ──
-				persistRuntimeState("merge-start", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, repoRoot);
+				persistRuntimeState("merge-start", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
 				onNotify(ORCH_MESSAGES.orchMergeStart(waveIdx + 1, mergeableLaneCount), "info");
 
 				mergeResult = mergeWaveByRepo(
@@ -359,12 +362,13 @@ export async function executeOrchBatch(
 					batchState.batchId,
 					batchState.baseBranch,
 					workspaceConfig,
+					stateRoot,
 				);
 				allMergeResults.push(mergeResult);
 				batchState.mergeResults.push(mergeResult);
 
 				// Persist state after merge so dashboard shows wave merge results
-				persistRuntimeState("merge-complete", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, repoRoot);
+				persistRuntimeState("merge-complete", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
 
 				// Emit per-lane merge notifications
 				for (const lr of mergeResult.laneResults) {
@@ -424,7 +428,7 @@ export async function executeOrchBatch(
 				// Restore phase to executing (may be overridden below by failure handling)
 				batchState.phase = "executing";
 				// ── TS-009: Persist state after merge (merging→executing) ──
-				persistRuntimeState("merge-complete", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, repoRoot);
+				persistRuntimeState("merge-complete", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
 			} else if (mixedOutcomeLanes.length > 0) {
 				const mixedIds = mixedOutcomeLanes.map(l => `lane-${l.laneNumber}`).join(", ");
 				mergeResult = {
@@ -460,7 +464,7 @@ export async function executeOrchBatch(
 
 			batchState.phase = policyResult.targetPhase;
 			batchState.errors.push(policyResult.errorMessage);
-			persistRuntimeState(policyResult.persistTrigger, batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, repoRoot);
+			persistRuntimeState(policyResult.persistTrigger, batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
 			onNotify(policyResult.notifyMessage, policyResult.notifyLevel);
 			// DO NOT cleanup/reset worktrees — preserve state for debugging/resume
 			preserveWorktreesForResume = true;
@@ -516,7 +520,7 @@ export async function executeOrchBatch(
 	// ── Save batch history (before cleanup deletes sidecar files) ────
 	try {
 		// Read token data from sidecar files while they still exist
-		const piDir = join(repoRoot, ".pi");
+		const piDir = join(stateRoot, ".pi");
 		const laneTokens = new Map<string, TokenCounts>();
 		try {
 			const files = readdirSync(piDir).filter(f => f.startsWith("lane-state-") && f.endsWith(".json"));
@@ -625,7 +629,7 @@ export async function executeOrchBatch(
 			waves: waveSummaries,
 		};
 
-		saveBatchHistory(repoRoot, summary);
+		saveBatchHistory(stateRoot, summary);
 	} catch (err) {
 		execLog("batch", batchState.batchId, `failed to save batch history: ${err}`);
 	}
@@ -650,7 +654,7 @@ export async function executeOrchBatch(
 		}
 
 		// Clean up sidecar files (lane state, worker conversation, merge artifacts)
-		const piDir = join(repoRoot, ".pi");
+		const piDir = join(stateRoot, ".pi");
 		try {
 			const sidecarFiles = readdirSync(piDir).filter(
 				f => f.startsWith("lane-state-") ||
@@ -745,7 +749,7 @@ export async function executeOrchBatch(
 	}
 
 	// ── TS-009: Persist terminal state ──
-	persistRuntimeState("batch-terminal", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, repoRoot);
+	persistRuntimeState("batch-terminal", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
 
 	if (batchState.phase === "paused" || batchState.phase === "stopped") {
 		execLog("batch", batchState.batchId, "batch ended in non-terminal execution state; completion banner suppressed", {
@@ -767,7 +771,7 @@ export async function executeOrchBatch(
 		// ── TS-009: Delete state file on clean completion (no failures) ──
 		if (batchState.phase === "completed") {
 			try {
-				deleteBatchState(repoRoot);
+				deleteBatchState(stateRoot);
 				execLog("state", batchState.batchId, "state file deleted on clean completion");
 			} catch (err: unknown) {
 				const msg = err instanceof Error ? err.message : String(err);

--- a/extensions/taskplane/execution.ts
+++ b/extensions/taskplane/execution.ts
@@ -134,7 +134,7 @@ export function buildLaneEnvVars(
 		TASK_AUTOSTART: relativePath,
 		TASK_RUNNER_SPAWN_MODE: "subprocess",
 		TASK_RUNNER_TMUX_PREFIX: lane.tmuxSessionName,
-		ORCH_SIDECAR_DIR: join(repoRoot, ".pi"),
+		ORCH_SIDECAR_DIR: join(workspaceRoot || repoRoot, ".pi"),
 		NODE_PATH: nodePath,
 		// Pi's TUI (ink/react) hangs silently with TERM=tmux-256color (tmux default).
 		// Force xterm-256color so pi can render and start execution.

--- a/extensions/taskplane/merge.ts
+++ b/extensions/taskplane/merge.ts
@@ -269,6 +269,7 @@ export function spawnMergeAgent(
 	mergeWorkDir: string,
 	mergeRequestPath: string,
 	config: OrchestratorConfig,
+	stateRoot?: string,
 ): void {
 	execLog("merge", sessionName, "preparing to spawn merge agent", {
 		mergeWorkDir,
@@ -303,7 +304,7 @@ export function spawnMergeAgent(
 		"pi --no-session",
 		modelArgs,
 		toolsArgs,
-		`--append-system-prompt ${shellQuote(join(repoRoot, ".pi", "agents", "task-merger.md"))}`,
+		`--append-system-prompt ${shellQuote(join(stateRoot ?? repoRoot, ".pi", "agents", "task-merger.md"))}`,
 		`@${shellQuote(mergeRequestPath)}`,
 	].filter(Boolean).join(" ");
 
@@ -507,6 +508,7 @@ export function mergeWave(
 	repoRoot: string,
 	batchId: string,
 	baseBranch: string,
+	stateRoot?: string,
 ): MergeWaveResult {
 	const startTime = Date.now();
 	const tmuxPrefix = config.orchestrator.tmux_prefix;
@@ -613,9 +615,10 @@ export function mergeWave(
 		const laneStart = Date.now();
 		const sessionName = `${tmuxPrefix}-${opId}-merge-${lane.laneNumber}`;
 		const resultFileName = `merge-result-w${waveIndex}-lane${lane.laneNumber}-${opId}-${batchId}.json`;
-		const resultFilePath = join(repoRoot, ".pi", resultFileName);
+		const piDir = stateRoot ?? repoRoot;
+		const resultFilePath = join(piDir, ".pi", resultFileName);
 		const requestFileName = `merge-request-w${waveIndex}-lane${lane.laneNumber}-${opId}-${batchId}.txt`;
-		const requestFilePath = join(repoRoot, ".pi", requestFileName);
+		const requestFilePath = join(piDir, ".pi", requestFileName);
 
 		execLog("merge", sessionName, `starting merge for lane ${lane.laneNumber}`, {
 			sourceBranch: lane.branch,
@@ -645,7 +648,7 @@ export function mergeWave(
 			writeFileSync(requestFilePath, mergeRequestContent, "utf-8");
 
 			// Spawn merge agent in the isolated merge worktree
-			spawnMergeAgent(sessionName, repoRoot, mergeWorkDir, requestFilePath, config);
+			spawnMergeAgent(sessionName, repoRoot, mergeWorkDir, requestFilePath, config, stateRoot);
 
 			// Wait for result
 			const mergeResult = waitForMergeResult(resultFilePath, sessionName);
@@ -890,6 +893,7 @@ export function mergeWaveByRepo(
 	batchId: string,
 	baseBranch: string,
 	workspaceConfig?: WorkspaceConfig | null,
+	stateRoot?: string,
 ): MergeWaveResult {
 	const startTime = Date.now();
 
@@ -942,6 +946,7 @@ export function mergeWaveByRepo(
 			repoRoot,
 			batchId,
 			baseBranch,
+			stateRoot,
 		);
 		// Attach empty repoResults for consistent shape
 		return { ...result, repoResults: [] };
@@ -985,6 +990,7 @@ export function mergeWaveByRepo(
 			groupRepoRoot,
 			batchId,
 			groupBaseBranch,
+			stateRoot,
 		);
 
 		// Accumulate lane results


### PR DESCRIPTION
In workspace mode, all state files (batch-state.json, lane-state, merge results, merge requests) were written to `repoRoot/.pi/` instead of `workspaceRoot/.pi/`. The dashboard reads from the workspace root's `.pi/` directory, so it never saw any state — the dashboard appeared empty during workspace mode orchestration.

### Fix
- `engine.ts`: Introduce `stateRoot` (= `workspaceRoot ?? cwd`), use for all persistence, history, and sidecar file operations
- `merge.ts`: Thread `stateRoot` through `mergeWave`/`mergeWaveByRepo`/`spawnMergeAgent` for result files, request files, and agent prompt paths
- `execution.ts`: Set `ORCH_SIDECAR_DIR` to `workspaceRoot/.pi/`

In repo mode, `stateRoot === repoRoot`, so behavior is unchanged.

### Testing
398/398 tests passing.