### PR TITLE
docs: bump Node.js requirement from 20 to 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Taskplane turns your coding project into an AI-managed task board. You define ta
 
 ## Install
 
-Taskplane is a [pi package](https://github.com/badlogic/pi-mono). You need [Node.js](https://nodejs.org/) ≥ 20 and [pi](https://github.com/badlogic/pi-mono) installed first.
+Taskplane is a [pi package](https://github.com/badlogic/pi-mono). You need [Node.js](https://nodejs.org/) ≥ 22 and [pi](https://github.com/badlogic/pi-mono) installed first.
 
 ### Prerequisites
 
 | Dependency | Required | Notes |
 |-----------|----------|-------|
-| [Node.js](https://nodejs.org/) ≥ 20 | Yes | Runtime |
+| [Node.js](https://nodejs.org/) ≥ 22 | Yes | Runtime |
 | [pi](https://github.com/badlogic/pi-mono) | Yes | Agent framework |
 | [Git](https://git-scm.com/) | Yes | Version control, worktrees |
 | **tmux** | **Strongly recommended** | Required for `/orch` parallel execution |

--- a/bin/taskplane.mjs
+++ b/bin/taskplane.mjs
@@ -1249,10 +1249,10 @@ function cmdDoctor() {
 	const checks = [
 		{ label: "pi installed", check: () => commandExists("pi"), detail: () => getVersion("pi") },
 		{
-			label: "Node.js >= 20.0.0",
+			label: "Node.js >= 22.0.0",
 			check: () => {
 				const v = process.versions.node;
-				return parseInt(v.split(".")[0]) >= 20;
+				return parseInt(v.split(".")[0]) >= 22;
 			},
 			detail: () => `v${process.versions.node}`,
 		},

--- a/docs/how-to/troubleshoot-common-issues.md
+++ b/docs/how-to/troubleshoot-common-issues.md
@@ -158,7 +158,7 @@ pi --version
 node --version
 ```
 
-Taskplane requires Node 20+ and compatible pi runtime.
+Taskplane requires Node 22+ and compatible pi runtime.
 
 ---
 

--- a/docs/maintainers/development-setup.md
+++ b/docs/maintainers/development-setup.md
@@ -4,7 +4,7 @@ This guide is for contributors working on Taskplane itself.
 
 ## Prerequisites
 
-- Node.js 20+
+- Node.js 22+
 - Git
 - pi
 - Optional: `just` for convenience commands

--- a/docs/maintainers/release-process.md
+++ b/docs/maintainers/release-process.md
@@ -20,7 +20,7 @@ Best practice for Taskplane is to keep them aligned:
 
 - npm publish access for `taskplane`
 - clean git working tree
-- Node.js 20+
+- Node.js 22+
 
 ---
 

--- a/docs/tutorials/install-from-source.md
+++ b/docs/tutorials/install-from-source.md
@@ -4,7 +4,7 @@ Use this path when developing Taskplane itself or testing local changes before p
 
 ## Prerequisites
 
-- Node.js 20+
+- Node.js 22+
 - Git
 - pi
 

--- a/docs/tutorials/install.md
+++ b/docs/tutorials/install.md
@@ -4,7 +4,7 @@ This tutorial gets Taskplane running in a project and verifies that `/task` and 
 
 ## Prerequisites
 
-- Node.js **20+**
+- Node.js **22+**
 - [pi](https://github.com/badlogic/pi-mono)
 - Git
 - **tmux** (strongly recommended — required for `/orch` parallel execution)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "files": [
     "bin/",


### PR DESCRIPTION
Bumps the minimum Node.js version from 20 to 22 across all docs, the doctor check, and package.json engines field.

### Files updated
- README.md (2 references)
- docs/tutorials/install.md
- docs/tutorials/install-from-source.md
- docs/maintainers/development-setup.md
- docs/maintainers/release-process.md
- docs/how-to/troubleshoot-common-issues.md
- bin/taskplane.mjs (doctor check label + version gate)
- package.json (engines field)