### PR TITLE
fix: rename /settings to /taskplane-settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.0] - 2026-03-17
 
 ### Added
-- **`/settings` TUI command** — interactive config editor with section navigation, source indicators (project/user/default), type-specific controls, and validation. Primary config interface — users rarely need to edit files directly.
+- **`/taskplane-settings` TUI command** — interactive config editor with section navigation, source indicators (project/user/default), type-specific controls, and validation. Primary config interface — users rarely need to edit files directly.
 - **JSON config schema** — unified `taskplane-config.json` replaces both YAML files. Unified loader with YAML fallback for backward compatibility.
 - **`taskplane init` v2** — auto-detects repo vs workspace mode (no `--workspace` flag needed). Enforces selective gitignore entries. Detects and offers to untrack accidentally committed runtime artifacts. Defaults `spawn_mode` to `"tmux"` when available.
 - **Pointer file resolution** — workspace mode uses `taskplane-pointer.json` to locate config, agents, and state in the designated config repo. All subsystems (task-runner, orchestrator, dashboard, merge agent) follow the pointer.
 - **User preferences** — `~/.pi/agent/taskplane/preferences.json` for personal settings (operator ID, models, tmux prefix, dashboard port). Merged with project config at load time.
 - **Doctor enhancements** — gitignore validation, tracked artifact detection, workspace pointer chain validation, config repo default branch check, legacy YAML migration warning, tmux vs `spawn_mode` mismatch detection.
-- Configurable merge agent timeout (`merge.timeout_minutes`, default: 10 min, was hardcoded 5 min). Exposed in `/settings` TUI.
+- Configurable merge agent timeout (`merge.timeout_minutes`, default: 10 min, was hardcoded 5 min). Exposed in `/taskplane-settings` TUI.
 
 ### Changed
 - **Per-step git commits** replace per-checkbox commits — reduces git overhead by ~70-80% without losing recovery capability. STATUS.md is still updated after each checkbox.

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Orchestrator lanes execute tasks through task-runner under the hood, so `/task` 
 | `/orch-abort [--hard]` | Abort batch (graceful or immediate) |
 | `/orch-deps <areas\|paths\|all>` | Show dependency graph |
 | `/orch-sessions` | List active worker sessions |
-| `/settings` | View and edit taskplane configuration interactively |
+| `/taskplane-settings` | View and edit taskplane configuration interactively |
 
 ### CLI Commands
 

--- a/bin/taskplane.mjs
+++ b/bin/taskplane.mjs
@@ -2565,7 +2565,7 @@ function cmdDoctor() {
 
 		if ((hasYamlRunner || hasYamlOrchestrator) && !hasJsonConfig) {
 			console.log(`  ${WARN} legacy YAML config detected in ${configLocation.label}`);
-			console.log(`     ${c.dim}→ Run /settings to migrate to taskplane-config.json${c.reset}`);
+			console.log(`     ${c.dim}→ Run /taskplane-settings to migrate to taskplane-config.json${c.reset}`);
 		}
 	}
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2,7 +2,7 @@
 
 This page documents Taskplane command surfaces:
 
-1. pi session slash commands (`/task`, `/orch*`, `/settings`)
+1. pi session slash commands (`/task`, `/orch*`, `/taskplane-settings`)
 2. CLI shell commands (`taskplane ...`)
 
 > Slash commands are registered by Taskplane extensions when loaded in pi.
@@ -322,14 +322,14 @@ List active orchestrator tmux sessions.
 
 ## Configuration Commands
 
-### `/settings`
+### `/taskplane-settings`
 
 Open the interactive settings TUI for viewing and editing taskplane configuration.
 
 **Syntax**
 
 ```text
-/settings
+/taskplane-settings
 ```
 
 **Behavior**
@@ -365,7 +365,7 @@ Open the interactive settings TUI for viewing and editing taskplane configuratio
 **Example**
 
 ```text
-/settings
+/taskplane-settings
 ```
 
 Opens the settings TUI in the current pi session. No arguments needed.

--- a/docs/tutorials/install.md
+++ b/docs/tutorials/install.md
@@ -243,7 +243,7 @@ Optional single-task check:
 To review or customize your configuration interactively:
 
 ```
-/settings
+/taskplane-settings
 ```
 
 ---

--- a/extensions/taskplane/extension.ts
+++ b/extensions/taskplane/extension.ts
@@ -649,7 +649,7 @@ export default function (pi: ExtensionAPI) {
 
 	// ── Settings TUI ─────────────────────────────────────────────────
 
-	pi.registerCommand("settings", {
+	pi.registerCommand("taskplane-settings", {
 		description: "View and edit taskplane configuration",
 		handler: async (_args, ctx) => {
 			if (!requireExecCtx(ctx)) return;

--- a/extensions/taskplane/settings-tui.ts
+++ b/extensions/taskplane/settings-tui.ts
@@ -1,7 +1,7 @@
 /**
  * Settings TUI — interactive configuration viewer and editor.
  *
- * Provides a `/settings` command that renders a two-level navigation:
+ * Provides a `/taskplane-settings` command that renders a two-level navigation:
  *   1. Section selector (12 sections)
  *   2. Per-section SettingsList with field display, source badges,
  *      and inline editing for enum/boolean/string/number fields
@@ -911,7 +911,7 @@ function summarizeArray(arr: any[]): string {
 /**
  * Open the settings TUI.
  *
- * This is the main entry point called from the /settings command handler.
+ * This is the main entry point called from the /taskplane-settings command handler.
  * Uses a two-level navigation:
  *   1. SelectList for section navigation
  *   2. SettingsList for per-section field display and editing


### PR DESCRIPTION
Pi owns `/settings`. Our command was colliding with it. Renamed to `/taskplane-settings` across all code, docs, and references.