### PR TITLE
docs: update orchestration docs for orch-managed branch model

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -15,8 +15,8 @@ This design keeps shipped code upgradeable while keeping project behavior custom
                          User Project
 ┌─────────────────────────────────────────────────────────────────┐
 │                                                                 │
-│  .pi/task-runner.yaml      .pi/task-orchestrator.yaml          │
-│  .pi/agents/*.md           task folders (PROMPT.md/STATUS.md)  │
+│  .pi/taskplane-config.json    .pi/agents/*.md                  │
+│  task folders (PROMPT.md / STATUS.md / .DONE)                  │
 │                                                                 │
 │         ┌───────────────────────┐                               │
 │         │      pi session       │                               │
@@ -27,7 +27,10 @@ This design keeps shipped code upgradeable while keeping project behavior custom
 │                     │                                           │
 │                     │ spawns workers/reviewers/mergers          │
 │                     ▼                                           │
-│              git worktrees + lane sessions                      │
+│       orch branch (orch/{opId}-{batchId})                      │
+│       ├── lane worktrees + tmux sessions                       │
+│       ├── merge worktrees (per wave)                           │
+│       └── /orch-integrate → user's working branch              │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 
@@ -113,10 +116,14 @@ Upgraded by `pi update`.
 
 Created by `taskplane init`:
 
-- `.pi/task-runner.yaml`
-- `.pi/task-orchestrator.yaml`
-- `.pi/agents/*.md`
+- `.pi/taskplane-config.json` — unified project configuration (JSON, camelCase keys)
+- `.pi/agents/*.md` — agent system prompts
 - task directories (`PROMPT.md`, `STATUS.md`, area `CONTEXT.md`)
+
+Legacy `.pi/task-runner.yaml` and `.pi/task-orchestrator.yaml` are still supported
+as fallback but `taskplane-config.json` takes precedence when present.
+
+User preferences in `~/.pi/agent/taskplane/preferences.json` override project config.
 
 Customized per repository.
 
@@ -125,7 +132,7 @@ Customized per repository.
 ## Data and control flow
 
 1. User invokes command in pi (`/task` or `/orch*`)
-2. Extension loads config from `.pi/*.yaml`
+2. Extension loads config from `.pi/taskplane-config.json` (or YAML fallback)
 3. Runner/orchestrator performs execution
 4. Progress is persisted to files (`STATUS.md`, `.DONE`, `.pi/batch-state.json`, lane sidecars)
 5. Dashboard reads persisted/sidecar state for live visualization

--- a/docs/explanation/persistence-and-resume.md
+++ b/docs/explanation/persistence-and-resume.md
@@ -68,13 +68,16 @@ This keeps recovery point close to live execution.
 
 ## Resume eligibility
 
-`/orch-resume` only resumes batches in resumable phases:
+`/orch-resume` resumes batches based on their phase:
 
-- `paused`
-- `executing`
-- `merging`
-
-Non-resumable phases (for example `failed`, `stopped`, `completed`) require cleanup/new batch.
+| Phase | Resumable | Notes |
+|-------|-----------|-------|
+| `paused` | ✅ | Standard resume |
+| `executing` | ✅ | Crash recovery — reconciles in-flight tasks |
+| `merging` | ✅ | Interrupted merge recovery |
+| `stopped` | ⚠️ | Requires `--force` (planned) |
+| `failed` | ⚠️ | Requires `--force` (planned) |
+| `completed` | ❌ | Terminal — start a new batch |
 
 ---
 

--- a/docs/explanation/waves-lanes-and-worktrees.md
+++ b/docs/explanation/waves-lanes-and-worktrees.md
@@ -2,209 +2,311 @@
 
 Parallel orchestration (`/orch`) is built on three concepts:
 
-- **waves**: dependency-safe task groups
-- **lanes**: parallel execution slots
-- **worktrees**: isolated git checkouts per lane
+- **waves**: dependency-safe task groups executed sequentially
+- **lanes**: parallel execution slots within a wave
+- **worktrees**: isolated git checkouts where workers run
+
+Together with the **orch-managed branch model**, these concepts enable safe
+parallel task execution without touching the user's working branch.
 
 ---
 
 ## 1) Dependency graph
 
-Orchestrator discovers pending tasks and builds a DAG:
+The orchestrator discovers pending tasks and builds a directed acyclic graph (DAG):
 
-- nodes = pending tasks
-- edges = dependency references from `PROMPT.md`
-- completed tasks are treated as pre-satisfied dependencies
+- **Nodes** = pending tasks (no `.DONE` file)
+- **Edges** = dependency references from the `## Dependencies` section of each `PROMPT.md`
+- Completed tasks (`.DONE` exists) are treated as pre-satisfied dependencies
 
-Validation includes:
+Validation catches:
 
-- self-dependencies
-- duplicate dependencies
-- unresolved dependency targets
-- circular dependencies
+- Self-dependencies
+- Duplicate dependencies
+- Unresolved dependency targets
+- Circular dependencies (cycle detection)
 
-If validation fails, planning stops.
+If validation fails, planning stops with a diagnostic message.
 
 ---
 
 ## 2) Wave computation
 
-Waves are computed with topological-sort logic (Kahn-style):
+Waves are computed using topological-sort logic (Kahn-style):
 
 - **Wave 1**: tasks with no unmet dependencies
-- **Wave N+1**: tasks whose dependencies are satisfied by earlier waves/completed tasks
+- **Wave N+1**: tasks whose dependencies were all satisfied by earlier waves or pre-completed tasks
 
 Properties:
 
-- deterministic ordering by task ID within a wave
-- cycle detection if tasks cannot be placed
+- Deterministic ordering by task ID within a wave
+- Waves execute **sequentially** — Wave 2 doesn't start until Wave 1's merge completes
+- All tasks within a wave may execute **in parallel** (across lanes)
+
+### Example: current resilience batch (TP-025 through TP-035)
+
+```
+Wave 1:  TP-025 (RPC wrapper)       TP-028 (partial progress)    TP-029 (cleanup)
+              │  \        \
+Wave 2:  TP-026  TP-030  TP-034
+              │    │  \      \
+Wave 3:  TP-027  TP-031  TP-032  TP-035
+                           │
+Wave 4:                 TP-033
+```
+
+TP-025 has no dependencies so it's in Wave 1. TP-026 depends on TP-025, so it
+must wait for Wave 2. TP-033 depends on both TP-030 and TP-032, which are in
+Waves 2 and 3 respectively, so it lands in Wave 4.
 
 ---
 
-## 3) Lane assignment
+## 3) Lane assignment and file-scope affinity
 
-Each wave is assigned to up to `max_lanes`.
+Each wave's tasks are assigned to **lanes** (parallel execution slots) up to the
+configured `max_lanes` limit.
 
-Configurable strategy:
+### Assignment strategies
 
-- `affinity-first`
-- `round-robin`
-- `load-balanced`
+| Strategy | Behavior |
+|----------|----------|
+| `affinity-first` (default) | Tasks sharing overlapping `## File Scope` entries are grouped onto the same lane to avoid merge conflicts |
+| `round-robin` | Tasks distributed evenly across lanes |
+| `load-balanced` | Tasks distributed by estimated size (`size_weights`: S=1, M=2, L=4) |
 
-`size_weights` provide relative load estimates (`S/M/L`) for balancing.
+### Why affinity matters
+
+When two tasks modify the same files, running them in parallel (different lanes)
+would produce merge conflicts. Affinity-first serialization puts them on the
+**same lane** so they execute sequentially, with each task building directly on
+the previous task's committed work.
+
+For example, in the current batch, TP-025, TP-028, and TP-029 all touch files in
+`extensions/taskplane/`. The orchestrator assigns them to a single lane:
+
+```
+Wave 1, Lane 1: TP-025 → TP-028 → TP-029 (serial, shared worktree)
+```
+
+TP-028 starts working in the same worktree where TP-025 already committed its
+code — it sees TP-025's new `diagnostics.ts` file and can import from it directly.
+
+### Size weights
+
+`size_weights` provide relative estimates for load balancing:
+
+```yaml
+size_weights:
+  S: 1    # ~30 minutes
+  M: 2    # ~60 minutes
+  L: 4    # ~120 minutes
+```
 
 ### Repo-scoped allocation (workspace mode)
 
-When a workspace configuration is active, tasks are grouped by their resolved
-repository ID before lane assignment. Each repo group receives independent
-allocation: its own affinity groups, its own `max_lanes` budget, and its own
-strategy application. Lane numbers are globally unique across all repo groups
-within a wave.
-
-In single-repo mode (no workspace config), all tasks land in one group and
-behavior is identical to the original model.
+In polyrepo workspaces, tasks are grouped by their resolved repository ID
+**before** lane assignment. Each repo group gets its own `max_lanes` budget and
+independent affinity analysis. Lane numbers are globally unique across all repo
+groups within a wave.
 
 ---
 
-## 4) Worktree isolation
+## 4) Orch-managed branch model
 
-Each lane executes in its own git worktree and branch.
+The orchestrator creates a dedicated **orch branch** for each batch:
 
-Typical branch format:
-
-```text
-task/lane-<N>-<batchId>
+```
+orch/{operatorId}-{batchId}
 ```
 
-Typical worktree directory:
+All task work is merged onto this branch — the user's working branch (e.g.,
+`main` or `develop`) is **never modified** during execution. This design:
 
-- `subdirectory` mode: `.worktrees/<prefix>-<N>`
-- `sibling` mode: `../<prefix>-<N>`
+- Keeps the user's branch stable for VS Code, manual work, or other tools
+- Allows safe concurrent operation
+- Provides a clean integration point when the batch completes
+
+### Branch lifecycle
+
+```
+1. /orch all
+   └─ Creates orch/henrylach-20260319T174500 from current branch
+   └─ Creates lane branches: task/henrylach-lane-1-20260319T174500, etc.
+
+2. Wave execution
+   └─ Workers commit to lane branches in worktrees
+   └─ After each wave, lane branches merge into the orch branch
+
+3. Batch completes
+   └─ All work is on the orch branch
+   └─ User's branch is untouched
+
+4. /orch-integrate
+   └─ Fast-forwards (or merges) user's branch to the orch branch
+   └─ Cleans up orch branch and batch state
+```
+
+In workspace mode, the orch branch is created in **every** workspace repo that
+has tasks, and `/orch-integrate` integrates across all repos.
+
+---
+
+## 5) Worktree isolation
+
+Each lane runs in its own **git worktree** — a separate working directory with
+its own checked-out branch, sharing the same `.git` history as the main checkout.
+
+### Batch-scoped containers
+
+Worktrees are organized in batch-scoped containers to prevent collisions between
+concurrent batches:
+
+```
+.worktrees/{operatorId}-{batchId}/
+├── lane-1/     ← worktree for lane 1
+├── lane-2/     ← worktree for lane 2
+└── merge/      ← temporary merge worktree (created during wave merge)
+```
+
+### Lane branches
+
+Each lane gets a dedicated branch:
+
+```
+task/{operatorId}-lane-{N}-{batchId}
+```
+
+Workers commit to this branch. After the wave completes, the lane branch is
+merged into the orch branch via a temporary merge worktree.
+
+### Why worktrees
+
+- **No file conflicts**: parallel workers can't clobber each other's files
+- **Independent git history**: each lane has its own commit log
+- **Safe inspection**: if a lane fails, its worktree and branch are preserved for debugging
+- **Clean merges**: lane → orch branch merges happen in isolated merge worktrees
 
 ### Repo-scoped worktrees (workspace mode)
 
-When workspace mode is active, worktrees are created per repo group.
-Each repo group's lanes are provisioned against that repo's root directory
-with its resolved base branch. The base branch resolution follows a
-fallback chain: per-repo config override → detected repo HEAD → batch-level
-base branch.
+In workspace mode, worktrees are created per-repo:
 
-If worktree creation fails for any repo group, all previously-created
-worktrees across all repos are rolled back (atomic wave provisioning).
+```
+api-service/.worktrees/{opId}-{batchId}/lane-1/
+web-client/.worktrees/{opId}-{batchId}/lane-2/
+shared-libs/.worktrees/{opId}-{batchId}/lane-3/
+```
 
-Lane identifiers include the repo context:
-
-| Identifier | Repo mode | Workspace mode |
-|------------|-----------|----------------|
-| `laneId` | `lane-{N}` | `{repoId}/lane-{N}` |
-| `tmuxSessionName` | `{prefix}-lane-{N}` | `{prefix}-{repoId}-lane-{N}` |
-
-Why this matters:
-
-- no file write conflicts between parallel workers
-- independent git history per lane
-- safer recovery and post-failure inspection
-- each repo maintains its own worktree/branch lifecycle
+Each repo's worktrees branch from that repo's base branch. If provisioning fails
+for any repo, all previously-created worktrees across all repos are rolled back
+(atomic wave provisioning).
 
 ---
 
-## 5) Wave execution flow
+## 6) Wave execution flow
 
 For each wave:
 
-1. allocate/prepare lane worktrees
-2. launch lane execution sessions
-3. monitor status/heartbeats and `.DONE`
-4. collect per-task outcomes
-5. merge successful lane branches
-6. reset/recycle worktrees for next wave
+```
+1. Provision  ─  Create lane worktrees and branches for this wave's tasks
+2. Execute    ─  Launch tmux sessions with task-runner instances per lane
+3. Monitor    ─  Poll STATUS.md and .DONE; update dashboard
+4. Collect    ─  Gather per-task outcomes (succeeded, failed, blocked)
+5. Merge      ─  Merge successful lane branches into orch branch (per-repo)
+6. Artifact   ─  Stage .DONE and STATUS.md into merge worktree, commit to orch branch
+7. Cleanup    ─  Remove lane worktrees and branches
+8. Advance    ─  Mark wave complete, proceed to next wave
+```
+
+Tasks on the same lane execute **serially** in a shared worktree. Each task sees
+the previous task's committed work.
+
+Tasks on different lanes (or in different repos) execute **in parallel** in
+separate worktrees.
 
 ---
 
-## 6) Merge stage
+## 7) Merge stage
 
-After lane execution in a wave:
+After all lanes in a wave complete, the orchestrator merges their work into the
+orch branch.
 
-- successful lanes are merged into integration branch
-- merge order follows configured policy
-- optional merge verification commands run
+### Per-repo merge (workspace mode)
 
-On merge failure:
+In workspace mode, merges happen independently per repository:
 
-- `on_merge_failure: pause` → preserve state and allow `/orch-resume`
-- `on_merge_failure: abort` → stop batch
+1. For each repo that had lanes in this wave:
+   - Create a temporary merge worktree on the orch branch
+   - Merge each lane branch sequentially (configurable order: `fewest-files-first`, etc.)
+   - Run optional verification commands (`merge.verify`)
+   - Stage task artifacts (`.DONE`, `STATUS.md`) into the merge worktree
+   - Update the orch branch ref via `update-ref`
+   - Clean up the merge worktree
+
+2. If merge fails:
+   - `on_merge_failure: pause` → batch enters `paused` phase, preserves state for resume
+   - `on_merge_failure: abort` → batch stops
+
+### Artifact staging
+
+Workers write `.DONE` and update `STATUS.md` in the canonical task folder (which
+lives in the config repo in workspace mode). These files are copied into the
+merge worktree and committed to the orch branch alongside the code changes.
+
+### Merge verification
+
+If `merge.verify` commands are configured, they run after merge in the merge
+worktree. Failures follow the `on_merge_failure` policy.
 
 ---
 
-## 7) Failure propagation
+## 8) Integration (`/orch-integrate`)
 
-`on_task_failure` policy controls dependent tasks:
+When the batch completes, all work lives on the orch branch. The user integrates
+it into their working branch:
 
-- `skip-dependents` (default)
-- `stop-wave`
-- `stop-all`
+```
+/orch-integrate              # auto-detect orch branch, fast-forward
+/orch-integrate --merge      # three-way merge instead of ff
+/orch-integrate --pr         # push and create a pull request
+```
 
-Blocked/skipped tasks are tracked in batch state counters.
+In workspace mode, `/orch-integrate` loops over all repos that have an orch
+branch and integrates each one.
+
+After successful integration:
+- The local orch branch is deleted
+- Batch state is preserved (for diagnostics) but marked completed
 
 ---
 
-## 8) Why this model works
+## 9) Failure propagation
+
+The `on_task_failure` policy controls what happens to tasks that depend on a
+failed task:
+
+| Policy | Behavior |
+|--------|----------|
+| `skip-dependents` (default) | Failed task's dependents are blocked; other tasks continue |
+| `stop-wave` | Remaining tasks in the current wave are cancelled |
+| `stop-all` | Entire batch stops immediately |
+
+Blocked and skipped tasks are tracked in batch state counters and visible in the
+dashboard.
+
+---
+
+## 10) Why this model works
 
 Compared to running many agents in one working directory:
 
-- **Isolation**: no clobbering shared files
-- **Determinism**: explicit dependency boundaries via waves
-- **Scalability**: parallelism bounded by lanes
-- **Debuggability**: each lane has independent branch/worktree/session history
-
----
-
-## 9) Repo-scoped lane allocation (workspace mode)
-
-When workspace mode is active (multiple repositories), lane allocation and
-worktree management become **repo-scoped**. In single-repo mode (default),
-all behavior is unchanged.
-
-### Repo grouping
-
-Before lane assignment, wave tasks are grouped by `resolvedRepoId`:
-
-- Each repo group gets its own `max_lanes` budget
-- Affinity grouping operates within each repo group independently
-- Groups are sorted by `repoId` ascending for deterministic ordering
-
-### Lane identity
-
-Lane identifiers include the repo dimension in workspace mode:
-
-| Component | Repo mode | Workspace mode |
-|-----------|-----------|----------------|
-| `laneId` | `lane-{N}` | `{repoId}/lane-{N}` |
-| TMUX session | `{prefix}-lane-{N}` | `{prefix}-{repoId}-lane-{N}` |
-
-`N` is the local lane number within the repo group (1-indexed).
-`laneNumber` (global) remains unique across all repos in a wave.
-
-### Per-repo worktree provisioning
-
-Each repo group resolves its own:
-
-- **Repo root**: from `workspaceConfig.repos.get(repoId).path`
-- **Base branch**: fallback chain of per-repo config → detected branch → batch default
-
-Worktrees are created per-group with the group-specific root and branch.
-
-### Cross-repo rollback
-
-If worktree provisioning fails for any repo group, all previously-created
-worktrees from earlier groups in the same wave are rolled back. This provides
-atomic wave allocation: all lanes succeed or none remain.
-
-### Abort compatibility
-
-Session matching handles both name formats. Lane ID enrichment during abort
-sources from persisted `PersistedLaneRecord` (keyed by `tmuxSessionName`)
-to preserve the repo dimension.
+| Concern | Taskplane | Shared directory |
+|---------|-----------|-----------------|
+| **File conflicts** | Impossible — worktree isolation | Frequent — agents overwrite each other |
+| **Merge safety** | Explicit lane → orch branch merge with verification | No merge step — conflicts accumulate |
+| **User branch safety** | Untouched until `/orch-integrate` | Modified directly, no rollback |
+| **Debugging** | Each lane has its own branch, worktree, and session | One tangled history |
+| **Resumability** | File-backed state survives any crash | Lost on restart |
+| **Parallelism** | Bounded by lanes, safe by design | Unbounded and unsafe |
 
 ---
 
@@ -213,3 +315,5 @@ to preserve the repo dimension.
 - [Architecture](architecture.md)
 - [Execution Model](execution-model.md)
 - [Persistence and Resume](persistence-and-resume.md)
+- [Commands Reference](../reference/commands.md) — `/orch`, `/orch-integrate` details
+- [Resilience & Diagnostics Roadmap](../specifications/taskplane/resilience-and-diagnostics-roadmap.md) — planned improvements


### PR DESCRIPTION
Comprehensive update to explanation docs reflecting v0.5.x architecture: orch branches, /orch-integrate, file-scope affinity, batch-scoped worktrees, per-repo merge, JSON config precedence.