### PR TITLE
docs: clarify mode terminology — single-repo mode vs workspace mode

### DIFF
--- a/docs/explanation/waves-lanes-and-worktrees.md
+++ b/docs/explanation/waves-lanes-and-worktrees.md
@@ -9,6 +9,28 @@ Parallel orchestration (`/orch`) is built on three concepts:
 Together with the **orch-managed branch model**, these concepts enable safe
 parallel task execution without touching the user's working branch.
 
+### Single-repo mode vs workspace mode
+
+Taskplane operates in one of two modes depending on your project structure:
+
+**Single-repo mode** is the default. Your project lives in one git repository
+and all tasks, configuration, and code share that single repo. This is the
+common setup for most projects — think of a typical monorepo or standalone
+application. Taskplane creates worktrees, branches, and merges entirely within
+that one repository.
+
+**Workspace mode** is for polyrepo projects — multiple independent git
+repositories that are developed together (e.g., a frontend app, a backend API,
+and a shared library in separate repos). In workspace mode, a lightweight
+pointer file (`taskplane-pointer.json`) in the workspace root tells Taskplane
+where to find the configuration repo, and a workspace config maps repo IDs to
+directory paths. Tasks can target specific repos via `## Execution Target` in
+their PROMPT.md, and the orchestrator creates worktrees, branches, and merges
+independently in each repo.
+
+Everything in this document applies to both modes. Sections that describe
+workspace-specific behavior are called out explicitly.
+
 ---
 
 ## 1) Dependency graph

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -461,9 +461,9 @@ Scaffold Taskplane project files. Auto-detects repo vs workspace layout and runs
 
 **Mode detection:**
 
-- **Repo mode** — current directory is a git repo with no git repo subdirectories. Scaffolds config in `.pi/`.
+- **Single-repo mode** — current directory is a git repo with no git repo subdirectories. Scaffolds config in `.pi/`.
 - **Workspace mode** — current directory is not a git repo but contains git repo subdirectories. Scaffolds config in `<config-repo>/.taskplane/` and creates a pointer file.
-- **Ambiguous** — git repo with git repo subdirectories. Prompts interactively; defaults to repo mode in non-interactive modes (`--preset`, `--dry-run`).
+- **Ambiguous** — git repo with git repo subdirectories. Prompts interactively; defaults to single-repo mode in non-interactive modes (`--preset`, `--dry-run`).
 
 **Common options**
 

--- a/docs/reference/configuration/task-orchestrator.yaml.md
+++ b/docs/reference/configuration/task-orchestrator.yaml.md
@@ -119,7 +119,7 @@ The resolved value is sanitized (lowercase, alphanumeric + hyphens only) and tru
 
 | Artifact | Pattern | Example |
 |---|---|---|
-| TMUX session (repo mode) | `{tmux_prefix}-{opId}-lane-{N}` | `orch-alice-lane-1` |
+| TMUX session (single-repo mode) | `{tmux_prefix}-{opId}-lane-{N}` | `orch-alice-lane-1` |
 | TMUX session (workspace) | `{tmux_prefix}-{opId}-{repoId}-lane-{N}` | `orch-alice-api-lane-1` |
 | Merge session | `{tmux_prefix}-{opId}-merge-{N}` | `orch-alice-merge-1` |
 | Worktree directory | `{worktree_prefix}-{opId}-{N}` | `taskplane-wt-alice-1` |

--- a/docs/specifications/taskplane/resilience-and-diagnostics-roadmap.md
+++ b/docs/specifications/taskplane/resilience-and-diagnostics-roadmap.md
@@ -32,7 +32,7 @@ These gaps compound in polyrepo workspaces where failures can occur across
 multiple repos, branches, and worktrees simultaneously.
 
 **Goal:** Make the system self-diagnosing, self-recovering for known failures,
-and quality-verified — in both repo mode and workspace mode.
+and quality-verified — in both single-repo mode and workspace mode.
 
 ---
 
@@ -190,7 +190,7 @@ must be scoped using the existing naming contract from `naming.ts`:
 
 - Operator-scoped: `{opId}` in all artifact paths
 - Batch-scoped: `{batchId}` prevents cross-batch collision
-- Repo-scoped: `{repoId}` for workspace mode (defaults to `"default"` in repo mode)
+- Repo-scoped: `{repoId}` for workspace mode (defaults to `"default"` in single-repo mode)
 - Lane-scoped: `lane-{N}` where applicable
 
 Pattern: `.pi/{artifactType}-{opId}-{batchId}-{repoId}[-lane-{N}].{ext}`
@@ -295,7 +295,7 @@ interface TaskExitDiagnostic {
   durationSec: number;
   lastKnownStep: number | null;
   lastKnownCheckbox: string | null;
-  repoId: string;           // "default" in repo mode, repo key in workspace mode
+  repoId: string;           // "default" in single-repo mode, repo key in workspace mode
 }
 ```
 
@@ -400,7 +400,7 @@ When a task fails without `.DONE` but has commits on its lane branch:
 - In workspace mode, the task's `resolvedRepoId` determines which repo to check
 - The save operation must use the correct repo root, not workspace root
 - Saved branch naming includes `{repoId}` in workspace mode:
-  `saved/{opId}-{taskId}-{batchId}` in repo mode,
+  `saved/{opId}-{taskId}-{batchId}` in single-repo mode,
   `saved/{opId}-{repoId}-{taskId}-{batchId}` in workspace mode
 
 #### 2b. Stale Worktree Cleanup Fallback
@@ -802,7 +802,7 @@ in guarded mode.
 Every phase in this roadmap must work correctly in workspace mode. Key
 invariants:
 
-| Concern | Repo Mode | Workspace Mode |
+| Concern | Single-Repo Mode | Workspace Mode |
 |---------|-----------|----------------|
 | Telemetry sidecar path | `.pi/telemetry/{opId}-...` | `{workspaceRoot}/.pi/telemetry/{opId}-...` |
 | Diagnostic path | `.pi/diagnostics/{opId}-...` | `{workspaceRoot}/.pi/diagnostics/{opId}-...` |
@@ -880,7 +880,7 @@ resilience:
 9. Execution commands fail fast with actionable tmux prerequisite guidance when
    tmux is missing
 10. Operator time lost per incident drops from ~25 min average to < 5 min
-11. All of the above work identically in repo mode and workspace mode
+11. All of the above work identically in single-repo mode and workspace mode
 
 ---
 

--- a/docs/tutorials/install.md
+++ b/docs/tutorials/install.md
@@ -94,12 +94,12 @@ Or:
 
 | Layout | Mode | What happens |
 |--------|------|-------------|
-| Single git repo (or monorepo) | **Repo mode** | Config scaffolded into `.pi/` in the current directory |
+| Single git repo (or monorepo) | **Single-repo mode** | Config scaffolded into `.pi/` in the current directory |
 | Directory with git repo subdirectories | **Workspace mode** | Config scaffolded into `.taskplane/` inside a chosen config repo; pointer file created in workspace root |
 | Git repo **and** git repo subdirectories | **Ambiguous** | Interactive prompt asks you to choose repo or workspace mode (defaults to repo with `--preset`) |
 | No git repo found | **Error** | Init exits with a message asking you to run from a git repo |
 
-In ambiguous cases, preset/dry-run/non-interactive modes default to repo mode without prompting.
+In ambiguous cases, preset/dry-run/non-interactive modes default to single-repo mode without prompting.
 
 ### Repo Mode (Standard)
 


### PR DESCRIPTION
Adds intro paragraph defining modes. Renames 'repo mode' to 'single-repo mode' everywhere — the old term was confusing since workspace mode also involves repos.