### PR TITLE
fix: re-export resolveConfigRoot from config barrel

### DIFF
--- a/extensions/taskplane/config.ts
+++ b/extensions/taskplane/config.ts
@@ -12,7 +12,7 @@
  */
 
 import { loadProjectConfig, toOrchestratorConfig, toTaskRunnerConfig, hasConfigFiles } from "./config-loader.ts";
-export { hasConfigFiles } from "./config-loader.ts";
+export { hasConfigFiles, resolveConfigRoot } from "./config-loader.ts";
 import type { OrchestratorConfig, TaskRunnerConfig } from "./types.ts";
 import type { SupervisorConfig } from "./supervisor.ts";
 import { DEFAULT_SUPERVISOR_CONFIG } from "./supervisor.ts";


### PR DESCRIPTION
Fixes: `(0, _index.resolveConfigRoot) is not a function` crash on `/orch` with no args.\n\n`resolveConfigRoot` was exported from `config-loader.ts` but not re-exported through `config.ts` → `index.ts` barrel. The TP-042 routing code imported it via the barrel and crashed at runtime.