### PR TITLE
fix: increase merge timeout default from 10 to 90 minutes

### DIFF
--- a/extensions/taskplane/config-loader.ts
+++ b/extensions/taskplane/config-loader.ts
@@ -760,7 +760,7 @@ export function toOrchestratorConfig(config: TaskplaneConfig): import("./types.t
 			tools: o.merge.tools,
 			verify: [...o.merge.verify],
 			order: o.merge.order,
-			timeout_minutes: o.merge.timeoutMinutes ?? 10,
+			timeout_minutes: o.merge.timeoutMinutes ?? 90,
 		},
 		failure: {
 			on_task_failure: o.failure.onTaskFailure,

--- a/extensions/taskplane/config-schema.ts
+++ b/extensions/taskplane/config-schema.ts
@@ -545,7 +545,7 @@ export const DEFAULT_ORCHESTRATOR_SECTION: OrchestratorSection = {
 		tools: "read,write,edit,bash,grep,find,ls",
 		verify: [],
 		order: "fewest-files-first",
-		timeoutMinutes: 10,
+		timeoutMinutes: 90,
 	},
 	failure: {
 		onTaskFailure: "skip-dependents",

--- a/extensions/taskplane/merge.ts
+++ b/extensions/taskplane/merge.ts
@@ -449,7 +449,7 @@ export async function spawnMergeAgent(
 export function reloadMergeTimeoutMs(configRoot: string, pointerConfigRoot?: string): number {
 	try {
 		const freshConfig = loadOrchestratorConfig(configRoot, pointerConfigRoot);
-		const minutes = freshConfig.merge.timeout_minutes ?? 10;
+		const minutes = freshConfig.merge.timeout_minutes ?? 90;
 		return minutes * 60 * 1000;
 	} catch (err: unknown) {
 		// Config re-read is best-effort — fall back to default on failure

--- a/extensions/taskplane/types.ts
+++ b/extensions/taskplane/types.ts
@@ -182,7 +182,7 @@ export const DEFAULT_ORCHESTRATOR_CONFIG: OrchestratorConfig = {
 		tools: "read,write,edit,bash,grep,find,ls",
 		verify: [],
 		order: "fewest-files-first",
-		timeout_minutes: 10,
+		timeout_minutes: 90,
 	},
 	failure: {
 		on_task_failure: "skip-dependents",
@@ -1225,7 +1225,7 @@ export class MergeError extends Error {
  * is generous and covers verification (go build) on large codebases.
  */
 /** Default merge agent timeout. Use config.merge.timeout_minutes to override. */
-export const MERGE_TIMEOUT_MS = 10 * 60 * 1000;
+export const MERGE_TIMEOUT_MS = 90 * 60 * 1000;
 
 /**
  * Polling interval for merge result file (ms).

--- a/extensions/tests/merge-timeout-resilience.test.ts
+++ b/extensions/tests/merge-timeout-resilience.test.ts
@@ -353,15 +353,15 @@ describe("5.x — Config re-read: reloadMergeTimeoutMs on retry", () => {
 		expect(fnBody).toContain("minutes * 60 * 1000");
 	});
 
-	it("5.5: reloadMergeTimeoutMs defaults to 10 minutes when config field is missing", () => {
+	it("5.5: reloadMergeTimeoutMs defaults to 90 minutes when config field is missing", () => {
 		const mergeSource = readSource("merge.ts");
 
 		const fnBody = mergeSource.substring(
 			mergeSource.indexOf("export function reloadMergeTimeoutMs"),
 			mergeSource.indexOf("export function reloadMergeTimeoutMs") + 600,
 		);
-		// Default: freshConfig.merge.timeout_minutes ?? 10
-		expect(fnBody).toContain("?? 10");
+		// Default: freshConfig.merge.timeout_minutes ?? 90
+		expect(fnBody).toContain("?? 90");
 	});
 
 	it("5.6: retry path calls reloadMergeTimeoutMs before computing backoff", () => {
@@ -386,8 +386,8 @@ describe("5.x — Config re-read: reloadMergeTimeoutMs on retry", () => {
 		expect(mergeSource).toContain("const configRoot = stateRoot ?? repoRoot");
 	});
 
-	it("5.8: MERGE_TIMEOUT_MS default is 10 minutes (600000ms)", () => {
-		expect(MERGE_TIMEOUT_MS).toBe(10 * 60 * 1000);
-		expect(MERGE_TIMEOUT_MS).toBe(600_000);
+	it("5.8: MERGE_TIMEOUT_MS default is 90 minutes (5400000ms)", () => {
+		expect(MERGE_TIMEOUT_MS).toBe(90 * 60 * 1000);
+		expect(MERGE_TIMEOUT_MS).toBe(5_400_000);
 	});
 });

--- a/templates/config/task-orchestrator.yaml
+++ b/templates/config/task-orchestrator.yaml
@@ -77,7 +77,7 @@ merge:
   order: "fewest-files-first"
 
   # Merge agent timeout in minutes. Increase for large batches with many files.
-  timeout_minutes: 10
+  timeout_minutes: 90
 
 # ── Failure Handling ──────────────────────────────────────────────────
 


### PR DESCRIPTION
Merge agents running tests can take far longer than 10 minutes. Increases the default across all sources:

- `MERGE_TIMEOUT_MS`: 10min → 90min
- `config-schema.ts` default: 10 → 90
- `config-loader.ts` fallback: 10 → 90
- `types.ts` OrchestratorDefaults: 10 → 90
- `merge.ts` reloadMergeTimeoutMs fallback: 10 → 90
- Template `task-orchestrator.yaml`: 10 → 90
- Updated test assertions

2151 tests passing.