### PR TITLE
feat: stage TP-047 and TP-048 — context window auto-detect + persistent worker context

### DIFF
--- a/taskplane-tasks/CONTEXT.md
+++ b/taskplane-tasks/CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Last Updated:** 2026-03-15
 **Status:** Active
-**Next Task ID:** TP-047
+**Next Task ID:** TP-049
 
 ---
 

--- a/taskplane-tasks/TP-047-context-window-auto-detect/PROMPT.md
+++ b/taskplane-tasks/TP-047-context-window-auto-detect/PROMPT.md
@@ -1,0 +1,152 @@
+# Task: TP-047 - Context Window Auto-Detect
+
+**Created:** 2026-03-23
+**Size:** S
+
+## Review Level: 1 (Plan Only)
+
+**Assessment:** Low-risk config default change. Touches one file's defaulting logic and config schema. No new patterns, no auth, easy revert.
+**Score:** 2/8 — Blast radius: 1, Pattern novelty: 0, Security: 0, Reversibility: 1
+
+## Canonical Task Folder
+
+```
+taskplane-tasks/TP-047-context-window-auto-detect/
+├── PROMPT.md   ← This file (immutable above --- divider)
+├── STATUS.md   ← Execution state (worker updates this)
+├── .reviews/   ← Reviewer output (task-runner creates this)
+└── .DONE       ← Created when complete
+```
+
+## Mission
+
+Replace the hardcoded `worker_context_window: 200000` default with auto-detection
+from pi's model registry. The current 200K default is stale — Claude 4.6 Opus has
+a 1M context window, but our warn/kill signals fire at 70%/85% of 200K (140K/170K
+tokens), wasting 83% of available context. The fix is to read
+`ctx.model.contextWindow` when the user hasn't explicitly configured a value, and
+also update `warn_percent` and `kill_percent` defaults to better utilize the full
+window.
+
+**Issue:** #140 (context window portion only)
+
+## Dependencies
+
+- **None**
+
+## Context to Read First
+
+**Tier 2 (area context):**
+- `taskplane-tasks/CONTEXT.md`
+
+**Tier 3 (load only if needed):**
+- `extensions/task-runner.ts` — main file to modify (context tracking logic, defaults, `runWorker()`, `spawnAgentTmux` telemetry callback)
+- `extensions/taskplane/config-schema.ts` — JSON config schema defaults
+- `extensions/taskplane/config-loader.ts` — config loading and fallback values
+
+## Environment
+
+- **Workspace:** `extensions/`
+- **Services required:** None
+
+## File Scope
+
+- `extensions/task-runner.ts`
+- `extensions/taskplane/config-schema.ts`
+- `extensions/taskplane/config-loader.ts`
+- `extensions/tests/*` (new or modified test file)
+- `templates/config/task-runner.yaml`
+
+## Steps
+
+### Step 0: Preflight
+
+- [ ] Read `extensions/task-runner.ts` and locate all references to `worker_context_window`, `warn_percent`, `kill_percent`
+- [ ] Read `extensions/taskplane/config-schema.ts` and `config-loader.ts` to understand the config loading chain
+- [ ] Verify `ctx.model` is available in the task-runner extension context and check what properties it exposes (especially `contextWindow`)
+
+### Step 1: Auto-detect context window from pi model registry
+
+The current default in `task-runner.ts` line ~167:
+```typescript
+worker_context_window: 200000, warn_percent: 70, kill_percent: 85,
+```
+
+Change the resolution logic so `worker_context_window` is resolved at runtime, not at config parse time:
+
+1. When `worker_context_window` is used (in `runWorker()` and the step loop), resolve it as:
+   ```typescript
+   const contextWindow = config.context.worker_context_window  // explicit user override (non-zero/non-default)
+     ?? ctx.model?.contextWindow   // read real value from pi's model registry
+     ?? 200_000;                   // fallback if pi doesn't expose it
+   ```
+2. The config default should be `0` or `undefined`/`null` to signal "auto-detect". If the user has explicitly set a value in their config, that takes precedence.
+3. Update `config-schema.ts` and `config-loader.ts` defaults to match (use `0` or omit to signal auto-detect).
+4. Log the resolved context window at worker spawn time so the operator can see what value is being used:
+   ```
+   [task-runner] worker context window: 1000000 (auto-detected from anthropic/claude-opus-4-6)
+   ```
+
+### Step 2: Update warn_percent and kill_percent defaults
+
+Change defaults from `warn_percent: 70, kill_percent: 85` to `warn_percent: 85, kill_percent: 95`.
+
+Update in all three locations:
+- `extensions/task-runner.ts` — hardcoded defaults
+- `extensions/taskplane/config-schema.ts` — JSON config schema
+- `extensions/taskplane/config-loader.ts` — config loader fallbacks
+- `templates/config/task-runner.yaml` — template comments/defaults
+
+### Step 3: Testing & Verification
+
+> ZERO test failures allowed.
+
+- [ ] Run tests: `cd extensions && npx vitest run`
+- [ ] Verify no existing tests break from the default changes
+- [ ] Add test(s) for context window resolution logic: explicit config value takes precedence, auto-detect from model works, fallback to 200K when model doesn't expose it
+- [ ] Add test(s) verifying the new warn/kill defaults (85/95)
+
+### Step 4: Documentation & Delivery
+
+- [ ] Update template `task-runner.yaml` comments to explain auto-detect behavior
+- [ ] Discoveries logged in STATUS.md
+- [ ] `.DONE` created in this folder
+
+## Documentation Requirements
+
+**Must Update:**
+- `templates/config/task-runner.yaml` — update `worker_context_window`, `warn_percent`, `kill_percent` comments/defaults
+
+**Check If Affected:**
+- `docs/reference/configuration/task-runner.yaml.md` — update if config docs reference old defaults
+- `docs/explanation/execution-model.md` — update if it discusses context window behavior
+
+## Completion Criteria
+
+- [ ] Context window auto-detected from pi model registry when not explicitly configured
+- [ ] Explicit `worker_context_window` in config still takes precedence
+- [ ] warn_percent default is 85, kill_percent default is 95
+- [ ] Resolved context window logged at worker spawn time
+- [ ] All tests passing
+- [ ] `.DONE` created
+
+## Git Commit Convention
+
+- **Step completion:** `feat(TP-047): complete Step N — description`
+- **Bug fixes:** `fix(TP-047): description`
+- **Tests:** `test(TP-047): description`
+- **Hydration:** `hydrate: TP-047 expand Step N checkboxes`
+
+## Do NOT
+
+- Change the worker iteration loop structure (that's TP-048)
+- Change the per-step worker spawn pattern (that's TP-048)
+- Change reviewer spawn behavior
+- Remove the ability to explicitly configure `worker_context_window`
+- Modify any merge-related code
+
+---
+
+## Amendments (Added During Execution)
+
+<!-- Workers add amendments here if issues discovered during execution. -->

--- a/taskplane-tasks/TP-047-context-window-auto-detect/STATUS.md
+++ b/taskplane-tasks/TP-047-context-window-auto-detect/STATUS.md
@@ -1,0 +1,94 @@
+# TP-047: Context Window Auto-Detect — Status
+
+**Current Step:** Not Started
+**Status:** 🔵 Ready for Execution
+**Last Updated:** 2026-03-23
+**Review Level:** 1
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** S
+
+> **Hydration:** Checkboxes represent meaningful outcomes, not individual code
+> changes. Workers expand steps when runtime discoveries warrant it.
+
+---
+
+### Step 0: Preflight
+**Status:** ⬜ Not Started
+
+- [ ] Read task-runner.ts and locate all `worker_context_window`, `warn_percent`, `kill_percent` references
+- [ ] Read config-schema.ts and config-loader.ts to understand config chain
+- [ ] Verify `ctx.model.contextWindow` is accessible in extension context
+
+---
+
+### Step 1: Auto-detect context window from pi model registry
+**Status:** ⬜ Not Started
+
+- [ ] Change config default to signal "auto-detect" (0 or undefined)
+- [ ] Add runtime resolution: user config → ctx.model.contextWindow → 200K fallback
+- [ ] Update config-schema.ts and config-loader.ts defaults
+- [ ] Log resolved context window at worker spawn time
+
+---
+
+### Step 2: Update warn_percent and kill_percent defaults
+**Status:** ⬜ Not Started
+
+- [ ] Change warn_percent default from 70 to 85
+- [ ] Change kill_percent default from 85 to 95
+- [ ] Update all three source locations (task-runner.ts, config-schema.ts, config-loader.ts)
+- [ ] Update template task-runner.yaml
+
+---
+
+### Step 3: Testing & Verification
+**Status:** ⬜ Not Started
+
+- [ ] All existing tests pass
+- [ ] Tests for context window resolution (explicit > auto-detect > fallback)
+- [ ] Tests for new warn/kill defaults
+
+---
+
+### Step 4: Documentation & Delivery
+**Status:** ⬜ Not Started
+
+- [ ] Template task-runner.yaml updated with auto-detect explanation
+- [ ] Check affected docs
+- [ ] Discoveries logged
+- [ ] `.DONE` created
+
+---
+
+## Reviews
+
+| # | Type | Step | Verdict | File |
+|---|------|------|---------|------|
+
+---
+
+## Discoveries
+
+| Discovery | Disposition | Location |
+|-----------|-------------|----------|
+
+---
+
+## Execution Log
+
+| Timestamp | Action | Outcome |
+|-----------|--------|---------|
+| 2026-03-23 | Task staged | PROMPT.md and STATUS.md created |
+
+---
+
+## Blockers
+
+*None*
+
+---
+
+## Notes
+
+*Reserved for execution notes*

--- a/taskplane-tasks/TP-048-persistent-worker-context/PROMPT.md
+++ b/taskplane-tasks/TP-048-persistent-worker-context/PROMPT.md
@@ -1,0 +1,222 @@
+# Task: TP-048 - Persistent Worker Context Per Task
+
+**Created:** 2026-03-23
+**Size:** L
+
+## Review Level: 2 (Plan and Code)
+
+**Assessment:** Core execution model change. Modifies the main step loop, worker prompt construction, and progress tracking. High blast radius across task execution, moderate pattern novelty (changing from per-step to per-task spawning). Easy to revert (loop structure change, no data model migration).
+**Score:** 5/8 — Blast radius: 2, Pattern novelty: 2, Security: 0, Reversibility: 1
+
+## Canonical Task Folder
+
+```
+taskplane-tasks/TP-048-persistent-worker-context/
+├── PROMPT.md   ← This file (immutable above --- divider)
+├── STATUS.md   ← Execution state (worker updates this)
+├── .reviews/   ← Reviewer output (task-runner creates this)
+└── .DONE       ← Created when complete
+```
+
+## Mission
+
+Change the task-runner's worker execution model from **one worker per step** to
+**one worker per task**. Currently, the step loop spawns a fresh worker context
+for every step, losing all accumulated context and paying full re-hydration cost
+each time. With modern 1M context windows, most tasks (even L-sized) fit in a
+single context.
+
+The worker should be spawned once and told to "work through all remaining steps
+in order, committing at each step boundary." If the context limit is hit mid-task,
+the worker exits and the next iteration picks up from the last completed step via
+STATUS.md — same recovery mechanism as today, just triggered far less often.
+
+**Issue:** #140
+
+## Dependencies
+
+- **Task:** TP-047 (context window auto-detect must be in place — worker needs correct context window to know when it's approaching limits)
+
+## Context to Read First
+
+**Tier 2 (area context):**
+- `taskplane-tasks/CONTEXT.md`
+
+**Tier 3 (load only if needed):**
+- `extensions/task-runner.ts` — primary file: step loop (~line 2080-2190), `runWorker()` (~line 2195), worker prompt construction (~line 2230), progress tracking
+- `templates/agents/task-worker.md` — worker system prompt (needs update for multi-step awareness)
+- `templates/agents/local/task-worker.md` — local worker template (needs same update)
+
+## Environment
+
+- **Workspace:** `extensions/`
+- **Services required:** None
+
+## File Scope
+
+- `extensions/task-runner.ts`
+- `templates/agents/task-worker.md`
+- `templates/agents/local/task-worker.md`
+- `extensions/tests/*` (new or modified test files)
+
+## Steps
+
+### Step 0: Preflight
+
+- [ ] Read the current step loop in `task-runner.ts` (around line 2080-2190) — understand how steps are iterated, how workers are spawned per step, and how progress is tracked
+- [ ] Read `runWorker()` and the worker prompt construction to understand what the worker is told
+- [ ] Read the worker agent template (`templates/agents/task-worker.md`) to understand what behavior the worker expects
+- [ ] Identify all places where "Work ONLY on Step N" or step-scoped instructions are injected
+
+### Step 1: Restructure the step loop to spawn worker once per task
+
+The current structure (simplified):
+```
+for each step:
+    plan review (if applicable)
+    for iter in max_worker_iterations:
+        runWorker(step)  ← fresh context each call
+        check progress
+    code review (if applicable)
+```
+
+Change to:
+```
+for iter in max_worker_iterations:
+    runWorker(allRemainingSteps)  ← one worker handles all steps
+    check which steps completed
+    run reviews for newly completed steps
+    if all steps complete: break
+```
+
+Key design decisions:
+- The worker is prompted with ALL remaining unchecked steps, not just one
+- The worker is instructed to work through them in order, committing at each step boundary
+- After the worker exits (naturally or via wrap-up/kill), the outer loop checks what was completed
+- Reviews for completed steps are run before the next iteration (if any)
+- If all steps are complete, the task is done
+- If the worker exited due to context limit, the next iteration picks up from the first incomplete step
+
+### Step 2: Update worker prompt for multi-step execution
+
+Change the worker prompt from:
+```
+Execute Step {N}: {name}
+...
+Work ONLY on Step {N}. Do not proceed to other steps.
+```
+
+To something like:
+```
+Execute all remaining steps for task {taskId}.
+...
+Steps remaining: Step 1 (name), Step 3 (name), Step 4 (name)
+[Step 2 already complete — skip]
+
+Work through these steps in order. For each step:
+1. Read STATUS.md to find unchecked items
+2. Complete all items for the step
+3. Update STATUS.md step status to "complete"
+4. Commit your changes: feat({taskId}): complete Step N — description
+5. Check for wrap-up signal files before starting the next step
+6. Proceed to the next incomplete step
+
+If you receive a wrap-up signal, finish your current checkpoint and stop.
+```
+
+Also update the worker agent templates (`task-worker.md` and `local/task-worker.md`)
+to reflect multi-step awareness in the system prompt.
+
+### Step 3: Update progress tracking and stall detection
+
+Current progress tracking checks `afterChecked <= prevChecked` per iteration per step.
+With the new model:
+
+- Progress is checked **per iteration** (after the worker exits), not per step
+- Count total checkboxes checked across ALL steps before and after the iteration
+- If no new checkboxes were checked in the entire iteration → increment `noProgressCount`
+- `no_progress_limit` (default 3) still applies: 3 full iterations with zero progress → blocked
+- Log which steps were completed in each iteration for operator visibility
+
+### Step 4: Integrate reviews with the new loop
+
+Reviews still happen per-step, but now they run after the worker exits, for each
+step that was completed during that iteration:
+
+```
+After worker exits:
+    for each step that changed from incomplete → complete during this iteration:
+        run plan review (if level ≥ 1 and not low-risk)
+        run code review (if level ≥ 2 and not low-risk)
+        if code review verdict is REVISE:
+            mark step as needing rework
+            (next iteration will re-process it)
+```
+
+If a code review returns REVISE, the step is marked incomplete again and the next
+worker iteration will address the reviewer's feedback. This preserves the current
+REVISE → rework behavior.
+
+### Step 5: Testing & Verification
+
+> ZERO test failures allowed.
+
+- [ ] Run tests: `cd extensions && npx vitest run`
+- [ ] Verify all existing tests pass (many tests reference the step loop behavior)
+- [ ] Add tests for: worker spawned once per task (not per step)
+- [ ] Add tests for: progress tracking across multiple steps in one iteration
+- [ ] Add tests for: stall detection (no progress across full iterations)
+- [ ] Add tests for: reviews run for completed steps after worker exits
+- [ ] Add tests for: REVISE verdict triggers rework in next iteration
+- [ ] Add tests for: context limit mid-task → next iteration picks up from incomplete step
+
+### Step 6: Documentation & Delivery
+
+- [ ] Update worker agent templates with multi-step awareness
+- [ ] Discoveries logged in STATUS.md
+- [ ] `.DONE` created in this folder
+
+## Documentation Requirements
+
+**Must Update:**
+- `templates/agents/task-worker.md` — multi-step execution awareness
+- `templates/agents/local/task-worker.md` — same
+
+**Check If Affected:**
+- `docs/explanation/execution-model.md` — describes step loop behavior
+- `docs/explanation/review-loop.md` — describes review timing relative to steps
+
+## Completion Criteria
+
+- [ ] Worker spawns once per task, handles all remaining steps in a single context
+- [ ] Worker commits at each step boundary
+- [ ] Worker checks for wrap-up signals between steps
+- [ ] Reviews run per-step after worker exits (not during)
+- [ ] REVISE verdict triggers rework in next iteration
+- [ ] Progress tracking works across multi-step iterations
+- [ ] Stall detection (no_progress_limit) still functional
+- [ ] Context limit mid-task → clean recovery on next iteration
+- [ ] All tests passing (existing + new)
+- [ ] `.DONE` created
+
+## Git Commit Convention
+
+- **Step completion:** `feat(TP-048): complete Step N — description`
+- **Bug fixes:** `fix(TP-048): description`
+- **Tests:** `test(TP-048): description`
+- **Hydration:** `hydrate: TP-048 expand Step N checkboxes`
+
+## Do NOT
+
+- Change reviewer agent spawn behavior (that's issue #146)
+- Change merge agent behavior
+- Remove the iteration mechanism — it's the safety net for context overflow
+- Change STATUS.md format or checkpoint conventions
+- Modify orchestrator code (execution.ts, engine.ts, etc.)
+- Remove `max_worker_iterations` or `no_progress_limit` config options
+
+---
+
+## Amendments (Added During Execution)
+
+<!-- Workers add amendments here if issues discovered during execution. -->

--- a/taskplane-tasks/TP-048-persistent-worker-context/STATUS.md
+++ b/taskplane-tasks/TP-048-persistent-worker-context/STATUS.md
@@ -1,0 +1,119 @@
+# TP-048: Persistent Worker Context Per Task — Status
+
+**Current Step:** Not Started
+**Status:** 🔵 Ready for Execution
+**Last Updated:** 2026-03-23
+**Review Level:** 2
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** L
+
+> **Hydration:** Checkboxes represent meaningful outcomes, not individual code
+> changes. Workers expand steps when runtime discoveries warrant it.
+
+---
+
+### Step 0: Preflight
+**Status:** ⬜ Not Started
+
+- [ ] Understand current step loop structure (line ~2080-2190 in task-runner.ts)
+- [ ] Understand runWorker() and worker prompt construction
+- [ ] Understand worker agent template expectations
+- [ ] Identify all step-scoped instructions in prompts
+
+---
+
+### Step 1: Restructure the step loop to spawn worker once per task
+**Status:** ⬜ Not Started
+
+> ⚠️ Hydrate: Expand based on exact loop structure found in Step 0
+
+- [ ] Refactor outer loop: iterate on worker iterations, not steps
+- [ ] Worker receives all remaining steps in prompt, not single step
+- [ ] After worker exits, determine which steps were completed
+- [ ] Preserve wrap-up signal and kill mechanics across the new loop
+
+---
+
+### Step 2: Update worker prompt for multi-step execution
+**Status:** ⬜ Not Started
+
+- [ ] Change worker prompt from "Execute Step N only" to "Execute all remaining steps"
+- [ ] Include list of remaining steps with completion status
+- [ ] Add per-step commit and wrap-up check instructions
+- [ ] Update task-worker.md and local/task-worker.md templates
+
+---
+
+### Step 3: Update progress tracking and stall detection
+**Status:** ⬜ Not Started
+
+- [ ] Track total checkboxes across all steps before/after each iteration
+- [ ] noProgressCount applies per iteration (not per step)
+- [ ] Log which steps completed in each iteration
+
+---
+
+### Step 4: Integrate reviews with the new loop
+**Status:** ⬜ Not Started
+
+- [ ] After worker exits, run reviews for each newly completed step
+- [ ] REVISE verdict marks step incomplete for rework in next iteration
+- [ ] Plan and code reviews still respect review level and low-risk skip logic
+
+---
+
+### Step 5: Testing & Verification
+**Status:** ⬜ Not Started
+
+- [ ] All existing tests pass
+- [ ] Tests for single-spawn-per-task behavior
+- [ ] Tests for multi-step progress tracking
+- [ ] Tests for stall detection across iterations
+- [ ] Tests for review timing (after worker exit, per completed step)
+- [ ] Tests for REVISE → rework in next iteration
+- [ ] Tests for context limit → recovery on next iteration
+
+---
+
+### Step 6: Documentation & Delivery
+**Status:** ⬜ Not Started
+
+- [ ] Worker agent templates updated
+- [ ] Check affected docs (execution-model.md, review-loop.md)
+- [ ] Discoveries logged
+- [ ] `.DONE` created
+
+---
+
+## Reviews
+
+| # | Type | Step | Verdict | File |
+|---|------|------|---------|------|
+
+---
+
+## Discoveries
+
+| Discovery | Disposition | Location |
+|-----------|-------------|----------|
+
+---
+
+## Execution Log
+
+| Timestamp | Action | Outcome |
+|-----------|--------|---------|
+| 2026-03-23 | Task staged | PROMPT.md and STATUS.md created |
+
+---
+
+## Blockers
+
+*None*
+
+---
+
+## Notes
+
+*Reserved for execution notes*

--- a/taskplane-tasks/dependencies.json
+++ b/taskplane-tasks/dependencies.json
@@ -1,8 +1,9 @@
 {
   "version": 1,
-  "generatedAt": "2026-03-23T21:00:00.000Z",
+  "generatedAt": "2026-03-23T23:30:00.000Z",
   "source": "prompt",
   "tasks": {
-    "TP-046": []
+    "TP-047": [],
+    "TP-048": ["TP-047"]
   }
 }


### PR DESCRIPTION
Stages two tasks for execution:

**TP-047** (S, no deps) — Context window auto-detect: replace hardcoded 200K default with `ctx.model.contextWindow`, update warn/kill to 85%/95%.

**TP-048** (L, depends on TP-047) — Persistent worker context: one worker per task instead of per step. Worker handles all remaining steps in a single context window.

Issue #140, #146