### PR TITLE
fix: dashboard NaN heartbeat (#129) and lockfile batchId stuck (#130)

### DIFF
--- a/dashboard/public/app.js
+++ b/dashboard/public/app.js
@@ -17,9 +17,11 @@ function formatDuration(ms) {
   return `${m}m ${String(s).padStart(2, "0")}s`;
 }
 
-function relativeTime(epochMs) {
-  if (!epochMs) return "";
-  const diff = Date.now() - epochMs;
+function relativeTime(epochOrIso) {
+  if (!epochOrIso) return "";
+  const ts = typeof epochOrIso === "string" ? new Date(epochOrIso).getTime() : epochOrIso;
+  if (isNaN(ts)) return "";
+  const diff = Date.now() - ts;
   if (diff < 60000) return `${Math.floor(diff / 1000)}s ago`;
   if (diff < 3600000) return `${Math.floor(diff / 60000)}m ago`;
   return `${Math.floor(diff / 3600000)}h ago`;

--- a/extensions/taskplane/supervisor.ts
+++ b/extensions/taskplane/supervisor.ts
@@ -3045,11 +3045,16 @@ export function startHeartbeat(
 			return;
 		}
 
-		// Update heartbeat
+		// Update heartbeat (and refresh batchId if it was initially unknown)
 		try {
 			const lock = readLockfile(stateRoot);
 			if (lock && lock.sessionId === sessionId) {
 				lock.heartbeat = new Date().toISOString();
+				// TP-130: batchId may have been "(initializing)" at lock creation
+				// because the batch hadn't started yet. Refresh from live state ref.
+				if (state.batchStateRef?.batchId && lock.batchId !== state.batchStateRef.batchId) {
+					lock.batchId = state.batchStateRef.batchId;
+				}
 				writeLockfile(stateRoot, lock);
 			}
 		} catch {


### PR DESCRIPTION
Two small supervisor/dashboard fixes:

**#129** — Dashboard `relativeTime()` did `Date.now() - isoString` = NaN. Now parses ISO strings before computing the diff.

**#130** — Supervisor lockfile `batchId` was set at activation time before the batch existed, stuck at `(initializing)`. Heartbeat tick now refreshes it from the live batch state reference.

No overlap with TP-047/TP-048 file scope.