### PR TITLE
fix: dashboard reviewer sub-row appears under wrong tasks

### DIFF
--- a/dashboard/public/app.js
+++ b/dashboard/public/app.js
@@ -530,7 +530,10 @@ function renderLanesTasks(batch, tmuxSessions) {
       // Worker stats from lane state sidecar + telemetry badges
       let workerHtml = "";
       const telemBadges = task.status !== "pending" ? telemetryBadgesHtml(tel) : "";
-      const reviewerActive = ls && ls.reviewerStatus === "running";
+      // Reviewer sub-row should only appear under the task currently being reviewed,
+      // not all tasks in the lane. The lane-state sidecar is per-lane (shared by all
+      // tasks in the lane), so check that the sidecar's current taskId matches this task.
+      const reviewerActive = ls && ls.reviewerStatus === "running" && ls.taskId === task.taskId;
       if (ls && ls.workerStatus === "running" && task.status === "running") {
         const elapsed = ls.workerElapsed ? `${Math.round(ls.workerElapsed / 1000)}s` : "";
         const tools = ls.workerToolCount || 0;


### PR DESCRIPTION
The reviewer sub-row appeared under ALL tasks in a lane (including pending/completed ones) instead of just the task being reviewed. The lane-state sidecar is per-lane, so `reviewerStatus === 'running'` was true for every task in the lane.

Fix: gate on `ls.taskId === task.taskId` so the sub-row only appears under the active task.