### PR TITLE
fix: state persist log spam (#166) and reviewer sub-row scoping

### DIFF
--- a/extensions/taskplane/persistence.ts
+++ b/extensions/taskplane/persistence.ts
@@ -170,13 +170,15 @@ export function syncTaskOutcomesFromMonitor(
 		}
 
 		// Completed tasks => succeeded
+		// Use existing endTime if already set — prevents changed=true on every
+		// poll tick (lastPollTime differs each tick, causing persist log spam).
 		for (const taskId of lane.completedTasks) {
 			const existing = outcomes.find(o => o.taskId === taskId);
 			changed = upsertTaskOutcome(outcomes, {
 				taskId,
 				status: "succeeded",
 				startTime: existing?.startTime ?? null,
-				endTime: monitorState.lastPollTime,
+				endTime: existing?.endTime ?? monitorState.lastPollTime,
 				exitReason: existing?.exitReason || ".DONE file created by task-runner",
 				sessionName: existing?.sessionName || lane.sessionName,
 				doneFileFound: true,
@@ -193,7 +195,7 @@ export function syncTaskOutcomesFromMonitor(
 				taskId,
 				status: "failed",
 				startTime: existing?.startTime ?? null,
-				endTime: monitorState.lastPollTime,
+				endTime: existing?.endTime ?? monitorState.lastPollTime,
 				exitReason: existing?.exitReason || "Task failed or stalled",
 				sessionName: existing?.sessionName || lane.sessionName,
 				doneFileFound: false,


### PR DESCRIPTION
Two fixes:

1. **Persist log spam** — `endTime` for completed tasks was set to `lastPollTime` on every poll tick, triggering `changed=true` → persist → log every tick. Now freezes `endTime` once set. Closes #166.

2. **Reviewer sub-row** — appeared under all tasks in a lane instead of just the active one. Now checks `ls.taskId === task.taskId`.

2309 tests passing.