### PR TITLE
docs: update for v0.9.x — execution model, review loop, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ The taskplane dashboard runs on a local port on your system and gives you elegan
 ### Key Features
 
 - **Task Orchestrator** — Parallel multi-task execution using git worktrees for full filesystem isolation. Dependency-aware wave scheduling. Automated merges into a dedicated orch branch — your working branch stays stable until you choose to integrate.
-- **Task Runner** — What the Orchestrator uses for autonomous single-task execution. Worker agents run in fresh-context loops with STATUS.md as persistent memory. Every checkbox gets a git checkpoint. Cross-model reviewer agents catch what the worker agents missed.
-- **Web Dashboard** — Live browser-based monitoring via `taskplane dashboard`. SSE streaming, lane/task progress, wave visualization, batch history.
+- **Persistent Worker Context** — Workers handle all steps in a single context, auto-detecting the model's context window (1M for Claude 4.6 Opus, 200K for Bedrock). Only iterates on context overflow. Dramatic reduction in spawn count and token cost.
+- **Worker-Driven Inline Reviews** — Workers invoke a `review_step` tool at step boundaries. Reviewer agents spawn in tmux sessions with full telemetry. REVISE feedback is addressed inline without losing context.
+- **Supervisor Agent** — Conversational supervisor monitors batch progress, handles failures, and can invoke orchestrator commands autonomously (resume, integrate, pause, abort).
+- **Web Dashboard** — Live browser-based monitoring via `taskplane dashboard`. SSE streaming, lane/task progress, reviewer activity, merge telemetry, batch history.
 - **Structured Tasks** — PROMPT.md defines the mission, steps, and constraints. STATUS.md tracks progress. Agents follow the plan, not vibes.
-- **Checkpoint Discipline** — Every completed checkbox item triggers a git commit. Work is never lost, even if a worker crashes mid-task.
+- **Checkpoint Discipline** — Step boundary commits ensure work is never lost, even if a worker crashes mid-task.
 - **Cross-Model Review** — Reviewer agent uses a different model than the worker agent (highly recommended, not enforced). Independent quality gate before merge.
 
 ## Install
@@ -117,27 +119,17 @@ Inside the pi session:
 
 `/orch` with no arguments is the universal entry point — it detects your project state and activates the supervisor for guided interaction (onboarding, batch planning, health checks, or retrospective). The default scaffold includes two independent example tasks, so `/orch all` gives you an immediate orchestrator + dashboard experience.
 
-### 4. Optional: run one task directly
+### 4. Run a single task with isolation
 
-`/task` is still useful for single-task execution and focused debugging:
-
-```
-/task taskplane-tasks/EXAMPLE-001-hello-world/PROMPT.md
-/task-status
-```
-
-Important distinction:
-
-- `/task` runs in your **current branch/worktree**.
-- `/orch` runs tasks in **isolated worktrees** on a dedicated orch branch — your working branch is never touched until you integrate.
-
-Because workers checkpoint with git commits, `/task` can capture unrelated local edits if you're changing files in parallel. For safer isolation (even with one task), prefer:
+For a single task with full worktree isolation, dashboard, and reviews:
 
 ```text
 /orch taskplane-tasks/EXAMPLE-001-hello-world/PROMPT.md
 ```
 
-Orchestrator lanes execute tasks through task-runner under the hood, so `/task` and `/orch` share the same core task execution model.
+This uses the same orchestrator infrastructure as a full batch — isolated worktree, orch branch, supervisor, dashboard, inline reviews — but for just one task.
+
+> **Note:** The `/task` command still exists for direct single-task execution in the current branch, but `/orch` is recommended for all workflows. `/task` does not provide worktree isolation, dashboard, or inline reviews.
 
 ## Commands
 
@@ -200,9 +192,7 @@ Orchestrator lanes execute tasks through task-runner under the hood, so `/task` 
           └─────────────┘
 ```
 
-**Single task** (`/task`): Worker iterates in fresh-context loops. STATUS.md is persistent memory. Each checkbox → git checkpoint. Reviewer validates on completion.
-
-**Parallel batch** (`/orch`): Tasks are sorted into dependency waves. Each wave runs in parallel across lanes (git worktrees). Completed lanes merge into a dedicated orch branch. When the batch completes, use `/orch-integrate` to bring the results into your working branch (or configure auto-integration).
+**How it works:** Tasks are sorted into dependency waves. Each wave runs in parallel across lanes (git worktrees). Workers handle all steps in a single context, calling `review_step` at step boundaries for inline reviews. Completed lanes merge into a dedicated orch branch. A supervisor agent monitors progress and can autonomously resume, integrate, or abort. When the batch completes, use `/orch-integrate` to bring the results into your working branch (or configure auto-integration).
 
 ## Documentation
 

--- a/docs/explanation/execution-model.md
+++ b/docs/explanation/execution-model.md
@@ -1,11 +1,12 @@
-# Execution Model (`/task`)
+# Execution Model
 
-Taskplane task execution is a **fresh-context loop** with file-backed memory.
+Taskplane task execution is a **persistent-context loop** with file-backed memory.
 
 Core idea:
 
 - each worker iteration starts with fresh model context
 - the worker handles **all remaining steps** in a single context
+- the worker drives reviews inline via the `review_step` tool
 - `STATUS.md` is the persistent execution memory
 - progress is checkpointed continuously
 
@@ -14,31 +15,39 @@ Core idea:
 ## Lifecycle overview
 
 ```text
-/task <PROMPT.md>
+/orch <task or area>
+  → allocate lane (isolated git worktree)
   → parse task
   → load or generate STATUS.md
   → iteration loop:
       spawn worker with all remaining steps
-      worker works through steps in order, committing at each step boundary
-      after worker exits, run reviews for each newly completed step
-      if REVISE → mark step incomplete for rework in next iteration
+      worker works through steps in order:
+        - plan review (via review_step tool, if level ≥ 1)
+        - implement step
+        - commit changes
+        - code review (via review_step tool, if level ≥ 2)
+        - if REVISE: address feedback, commit fixes
+        - proceed to next step
+      after worker exits, check what was completed
       if all steps complete → break
+      if context limit hit → next iteration picks up from incomplete step
   → (optional) quality gate review
   → create .DONE
-  → complete
+  → merge into orch branch
 ```
 
 ---
 
 ## Phase 1: Task initialization
 
-When `/task` starts:
+When a task starts executing in a lane:
 
 1. Resolve and parse `PROMPT.md`
-2. Load `.pi/task-runner.yaml`
+2. Load config (JSON first, YAML fallback)
 3. Ensure `STATUS.md` exists (generate if missing)
 4. Ensure `.reviews/` directory exists
 5. Enter `running` phase
+6. Context window auto-detected from pi model registry (v0.8.0+)
 
 If `STATUS.md` already exists, review counter and iteration values are rehydrated.
 
@@ -57,29 +66,34 @@ Each iteration:
 
 1. Identify all incomplete steps
 2. Spawn worker with the full list of remaining steps
-3. Worker works through steps sequentially, committing at each step boundary
+3. Worker works through steps sequentially:
+   - Calls `review_step(type="plan")` before implementing (if review level ≥ 1)
+   - Implements the step
+   - Commits at step boundary
+   - Calls `review_step(type="code")` after implementing (if review level ≥ 2)
+   - If REVISE: reads feedback, addresses issues, commits fixes
+   - Proceeds to next step
 4. Worker exits (naturally, via wrap-up signal, or context limit)
 5. Runner determines which steps were newly completed
-6. For each newly completed step, run transition reviews (plan + code)
-7. If a review returns REVISE, mark the step incomplete for rework
-8. If all steps complete, task is done; otherwise start next iteration
+6. If all steps complete, task is done; otherwise start next iteration
 
-### Review levels
+### Worker-driven reviews (v0.9.0+)
 
-- `0`: no review
-- `1`: plan review on first completion of a step
-- `2+`: plan review + code review on step completion
+Reviews are driven by the **worker agent** via the `review_step` extension tool.
+The worker decides when to review based on the task's review level. The reviewer
+spawns in a separate tmux session with full RPC telemetry and the worker's
+context is preserved across the tool call.
 
-Reviews are **transition-based**: they run after the worker exits, for each step
-that transitioned from incomplete to complete during that iteration. Plan reviews
-run only on first completion (not on rework cycles). Code reviews run on every
-completion.
+- **Review Level 0:** No reviews
+- **Review Level 1:** Plan review before implementing each step
+- **Review Level 2:** Plan review + code review after implementing
+- **Review Level 3:** Plan + code + test reviews
 
 **Low-risk step exception:** Step 0 (Preflight) and the final step
-(Documentation & Delivery) always skip both plan and code reviews, regardless
-of the configured review level. These steps perform file reading and `.DONE`
-creation respectively — cross-model review adds overhead without catching
-meaningful issues. Middle steps are unaffected by this exception.
+(Documentation & Delivery) always skip reviews. The worker template instructs
+this and the tool handler enforces it as a safety net.
+
+See [Review Loop](review-loop.md) for full details.
 
 ---
 
@@ -90,7 +104,7 @@ Each iteration:
 1. Re-read `STATUS.md`
 2. Determine all remaining incomplete steps
 3. Spawn worker agent with task context + project context + remaining steps list
-4. Worker works through steps in order, checking off items and committing per step
+4. Worker works through steps in order, invoking reviews inline
 5. Worker updates `STATUS.md` and checkpoints changes continuously
 6. Runner checks total progress across all steps after worker exits
 
@@ -98,10 +112,17 @@ Guardrails:
 
 - `max_worker_iterations`
 - `no_progress_limit` (checked per iteration across all steps)
-- context pressure thresholds (`warn_percent`, `kill_percent`)
-- optional wall-clock cap (`max_worker_minutes`)
+- context pressure thresholds (`warn_percent` default 85%, `kill_percent` default 95%)
+- optional wall-clock cap (`max_worker_minutes`, default 120 min)
 
 If no progress repeats beyond limit, the task is marked blocked/error.
+
+### Context window auto-detect (v0.8.0+)
+
+The worker's context window is auto-detected from pi's model registry. For
+Claude 4.6 Opus, this is 1M tokens; for Bedrock variants, 200K. The hardcoded
+200K default is only a fallback when pi doesn't report the model's context size.
+Users can still override via `worker_context_window` in config.
 
 ### Context overflow recovery
 
@@ -132,7 +153,7 @@ Taskplane's worker prompt enforces checkpoint behavior:
 
 - complete one checkbox item
 - update STATUS checkbox
-- commit checkpoint in git
+- commit checkpoint at step boundaries
 
 This makes progress granular, auditable, and recoverable.
 
@@ -140,16 +161,15 @@ This makes progress granular, auditable, and recoverable.
 
 ## Pause and resume
 
-- `/task-pause`: sets phase to paused; current iteration finishes first
-- `/task-resume`: restarts loop from persisted state
-
-On pi session restart, previously loaded task is restored as paused (if available), then resumed manually.
+- `/orch-pause`: sets pause signal; current tasks finish before pausing
+- `/orch-resume [--force]`: restarts from persisted state
+- On batch failure, the supervisor can resume programmatically via the `orch_resume` tool
 
 ---
 
 ## Completion semantics
 
-A task is complete when runner finishes all steps and writes:
+A task is complete when the worker finishes all steps and writes:
 
 - `<task-folder>/.DONE`
 
@@ -166,14 +186,13 @@ When disabled (default), `.DONE` is created immediately after all steps complete
 
 See [task-runner.yaml Reference](../reference/configuration/task-runner.yaml.md#quality_gate) for configuration details.
 
-In non-orchestrated mode, task folder may be archived after completion.
-In orchestrated mode, runner avoids archive moves and lets orchestrator handle post-merge lifecycle.
+In orchestrated mode, the runner creates `.DONE` and lets the orchestrator handle post-merge lifecycle.
 
 ---
 
 ## Failure semantics
 
-Task can enter `error` phase due to:
+Tasks can enter `error` phase due to:
 
 - parse failures
 - worker/reviewer spawn errors
@@ -181,23 +200,28 @@ Task can enter `error` phase due to:
 - iteration limits exceeded
 - explicit runtime errors
 
-Status and logs remain on disk for diagnosis.
+Status and logs remain on disk for diagnosis. The supervisor agent can diagnose failures and offer recovery options.
 
 ---
 
-## Why fresh-context loops
+## Why persistent-context loops
 
-Fresh-context execution reduces state drift and hallucinated memory by forcing each loop to re-ground from files.
+The persistent-context model (v0.8.0+) spawns one worker per task instead of
+per step. The worker maintains full context across step boundaries, eliminating
+costly re-hydration. If the context window is exhausted mid-task, the iteration
+mechanism provides a clean recovery path via STATUS.md.
 
 Tradeoff:
 
-- more explicit disk updates required
-- but stronger determinism/restart safety
+- workers use more of the context window per iteration
+- but dramatically fewer spawns and lower token cost
+- reviews happen inline with full context (worker addresses REVISE immediately)
 
 ---
 
 ## Related
 
+- [Review Loop](review-loop.md)
 - [Task Format Reference](../reference/task-format.md)
 - [Commands Reference](../reference/commands.md)
 - [Persistence and Resume](persistence-and-resume.md)

--- a/docs/explanation/review-loop.md
+++ b/docs/explanation/review-loop.md
@@ -30,12 +30,14 @@ Reviewer verdicts:
 - `APPROVE`
 - `REVISE`
 - `RETHINK`
+- `UNAVAILABLE`
 
 Interpretation:
 
-- `APPROVE`: continue
-- `REVISE`: run remediation pass
-- `RETHINK`: approach concerns (warning/escalation path)
+- `APPROVE`: continue to next step
+- `REVISE`: worker addresses feedback inline (same context), then proceeds
+- `RETHINK`: plan concerns — worker reconsiders approach
+- `UNAVAILABLE`: reviewer failed to produce output — worker proceeds with caution
 
 ---
 
@@ -44,11 +46,9 @@ Interpretation:
 Task `Review Level` controls review rigor:
 
 - `0`: no review loop
-- `1`: plan review
+- `1`: plan review only
 - `2`: plan + code review
 - `3`: full rigor policy level (project may treat as highest scrutiny)
-
-Current runner behavior applies plan review at `>=1` and code review at `>=2`.
 
 **Exception:** Step 0 (Preflight) and the final step (Documentation & Delivery)
 always skip both plan and code reviews, regardless of review level. These
@@ -56,31 +56,53 @@ low-risk steps don't benefit from cross-model review.
 
 ---
 
-## Loop mechanics in task-runner
+## Worker-driven inline reviews (v0.9.0+)
 
-Reviews are **transition-based**: they run after the worker exits, for each step
-that was newly completed during that iteration.
+Reviews are **worker-driven**: the worker agent invokes the `review_step` tool
+at step boundaries, based on the task's review level. The reviewer spawns in
+a separate tmux session with full RPC telemetry, and the worker's context is
+preserved across the tool call.
 
 ```text
-After worker exits:
-    for each step that changed from incomplete → complete:
-        plan review (if level ≥ 1, not low-risk, first completion only)
-        code review (if level ≥ 2, not low-risk)
-        if REVISE: mark step incomplete → rework in next iteration
+Worker executing all steps in one context:
+
+  For each substantive step (not Step 0 or final step):
+    if review level ≥ 1:
+      call review_step(step=N, type="plan")    → plan feedback
+    implement the step
+    commit changes
+    if review level ≥ 2:
+      call review_step(step=N, type="code", baseline=<pre-step SHA>)    → code feedback
+      if REVISE: address feedback, commit fixes
+    proceed to next step
 ```
 
 Key behaviors:
 
-- **Plan review** runs only on a step's first completion (not on rework cycles)
-- **Code review** runs on every completion (including after rework)
-- **REVISE** marks the step incomplete; the next worker iteration addresses
-  the reviewer's feedback alongside any other remaining steps
+- **Worker keeps context** — reviews happen mid-execution via a tool call.
+  The worker doesn't lose its accumulated understanding of the codebase.
+- **Reviewer spawns in tmux** — named session (e.g., `orch-lane-1-reviewer`)
+  with RPC wrapper for structured telemetry. Attachable for operator inspection.
+- **REVISE handled inline** — the worker reads the review file in `.reviews/`
+  and addresses feedback immediately, in the same context that wrote the code.
+- **Plan reviews** run before implementation to catch design issues early.
+- **Code reviews** receive a baseline commit SHA so the reviewer sees only
+  the step's changes (not the full cumulative diff).
 - **Low-risk steps** (Step 0/Preflight and final step) skip all reviews
+  automatically — both in the worker's review protocol and as a safety net
+  in the tool handler.
 
-Counters/limits:
+### Dashboard visibility
 
-- `max_review_cycles`
-- `review_counter` in `STATUS.md`
+During a review, the dashboard shows a **reviewer sub-row** below the active
+task with live metrics: elapsed time, tool count, last tool, cost, and context%.
+The worker row shows `[awaiting review]` until the reviewer finishes.
+
+### Orchestrated vs standalone mode
+
+The `review_step` tool is only registered in orchestrated mode (`/orch`).
+In standalone `/task` mode, reviews are not available (the `/task` command
+is deprecated in favor of `/orch` for all workflows).
 
 ---
 
@@ -89,10 +111,11 @@ Counters/limits:
 Typical on-disk artifacts:
 
 - `.reviews/` directory in task folder
-- review output files containing structured verdict and findings
-- review rows appended to `STATUS.md`
+- `request-R00N.md` — generated review request
+- `R00N-plan-stepN.md` / `R00N-code-stepN.md` — reviewer output with verdict
+- Review rows appended to `STATUS.md` Reviews table
 
-This keeps audit trail local to the task.
+This keeps the audit trail local to the task.
 
 ---
 
@@ -102,12 +125,13 @@ Benefits:
 
 - catches mistakes before merge
 - enforces standards consistently
-- provides explainable quality gates
+- worker addresses REVISE feedback with full context (no re-hydration)
+- reviewer activity visible in dashboard
 
 Costs:
 
-- additional tokens/time
-- more operational complexity
+- additional tokens/time per step
+- reviewer model cost (mitigated by skipping low-risk steps)
 
 Projects tune this via review levels and review-cycle limits.
 

--- a/taskplane-tasks/TP-053-supervisor-orch-tools/STATUS.md
+++ b/taskplane-tasks/TP-053-supervisor-orch-tools/STATUS.md
@@ -1,7 +1,7 @@
 # TP-053: Expose Orchestrator Commands as Tools for Supervisor Agent — Status
 
-**Current Step:** Not Started
-**Status:** 🔵 Ready for Execution
+**Current Step:** Step 1
+**Status:** 🟡 In Progress
 **Last Updated:** 2026-03-24
 **Review Level:** 2
 **Review Counter:** 0
@@ -11,27 +11,41 @@
 ---
 
 ### Step 0: Preflight
-**Status:** ⬜ Not Started
+**Status:** ✅ Done
 
-- [ ] Read each command handler (resume, integrate, pause, abort, status)
-- [ ] Read review_step tool registration as pattern reference
-- [ ] Understand pi registerTool() API
-- [ ] Identify execCtx dependencies per command
+- [x] Read each command handler (resume, integrate, pause, abort, status)
+- [x] Read review_step tool registration as pattern reference
+- [x] Understand pi registerTool() API
+- [x] Identify execCtx dependencies per command
 
 ---
 
 ### Step 1: Register orchestrator tools
-**Status:** ⬜ Not Started
+**Status:** 🟡 In Progress
 
-> ⚠️ Hydrate: Expand based on exact command handler structure found in Step 0
+**Design decisions (from R001 review):**
+- **Shared reporter pattern:** Each extracted helper takes a `report(text, level)` callback. Command handlers pass `ctx.ui.notify`. Tool handlers accumulate messages into an array and return them as a single text result.
+- **Integrate mode mapping:** Tool param `mode: "fast-forward"|"merge"|"pr"` maps to internal `"ff"|"merge"|"pr"`. Default `"fast-forward"`.
+- **Resume return semantics:** Tool returns **immediate initiation/guard result only** (e.g., "Batch resume initiated" or guard rejection). Downstream progress is asynchronous via engine events.
+- **Integrate helper boundary:** Full command parity — includes branch-protection check, multi-repo iteration, cleanup/acceptance, supervisor summary/deactivation.
+- **Tools registered unconditionally** (not gated on orchestrated mode — supervisor runs in main session).
 
-- [ ] Extract shared logic from each command handler into internal functions
-- [ ] Register orch_resume tool with force parameter
-- [ ] Register orch_integrate tool with mode/force/branch parameters
-- [ ] Register orch_pause tool
-- [ ] Register orch_abort tool with hard parameter
-- [ ] Register orch_status tool
-- [ ] All tools return text results, catch errors gracefully
+**Checklist:**
+
+- [ ] Add `import { Type } from "@mariozechner/pi-ai"` to extension.ts
+- [ ] Extract `doOrchStatus(orchBatchState, execCtx, stateRoot)` → returns formatted text
+- [ ] Extract `doOrchPause(orchBatchState, updateOrchWidget)` → returns status message
+- [ ] Extract `doOrchAbort(...)` → captures all notify output, returns collected text
+- [ ] Extract `doOrchResume(force, ...)` → guard checks + fire-and-forget launch, returns immediate result
+- [ ] Extract `doOrchIntegrate(mode, force, branch, ...)` → full parity with command handler including cleanup and supervisor lifecycle
+- [ ] Register `orch_status` tool (no params)
+- [ ] Register `orch_pause` tool (no params)
+- [ ] Register `orch_abort` tool (`hard?: boolean`)
+- [ ] Register `orch_resume` tool (`force?: boolean`)
+- [ ] Register `orch_integrate` tool (`mode?: "fast-forward"|"merge"|"pr"`, `force?: boolean`, `branch?: string`)
+- [ ] Each tool has description, promptSnippet, promptGuidelines
+- [ ] All tools catch errors and return text (no throws)
+- [ ] Existing command handlers call the shared helpers (no duplication)
 
 ---
 
@@ -74,6 +88,11 @@
 
 | Discovery | Disposition | Location |
 |-----------|-------------|----------|
+| `Type` from `@mariozechner/pi-ai` must be imported in extension.ts (not currently imported) | Add import | extension.ts:1 |
+| `orchBatchState`, `execCtx`, `orchConfig`, etc. are all closure-scoped inside `export default function(pi)` | Tools must be registered inside the same closure | extension.ts:1206 |
+| `orch-pause` doesn't need execCtx, `orch-status` doesn't need execCtx, `orch-abort` doesn't need execCtx | Only resume/integrate need execCtx guard | Command handlers |
+| `orch-resume` has complex onTerminal callback with supervisor integration—tool should wrap the command handler pattern but return a simple result | Extract doResume as internal function | extension.ts:1811 |
+| `orch-integrate` is the most complex—depends on execCtx, ws config, repo iteration, cleanup | Tool handler can invoke the same code path | extension.ts:2330 |
 
 ---
 

--- a/taskplane-tasks/dependencies.json
+++ b/taskplane-tasks/dependencies.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2026-03-24T14:30:00.000Z",
+  "generatedAt": "2026-03-24T15:00:08.427Z",
   "source": "prompt",
   "tasks": {
     "TP-053": []


### PR DESCRIPTION
Major doc refresh for v0.8.0–v0.9.3 changes:

- **execution-model.md** — rewritten: persistent worker context, worker-driven inline reviews, context window auto-detect, /orch-centric lifecycle
- **review-loop.md** — rewritten: review_step tool model replaces deferred transition-based reviews
- **README.md** — updated key features, single-task guidance, architecture description

These are the docs users see first on GitHub.