### PR TITLE
chore: remove .DONE checkbox from task templates

### DIFF
--- a/skills/create-taskplane-task/references/prompt-template.md
+++ b/skills/create-taskplane-task/references/prompt-template.md
@@ -100,7 +100,6 @@ Copy this template when creating a new task. Replace all `[bracketed]` fields.
 - [ ] "Must Update" docs modified
 - [ ] "Check If Affected" docs reviewed
 - [ ] Discoveries logged in STATUS.md
-- [ ] `.DONE` created in this folder
 
 ## Documentation Requirements
 
@@ -115,7 +114,6 @@ Copy this template when creating a new task. Replace all `[bracketed]` fields.
 - [ ] All steps complete
 - [ ] All tests passing
 - [ ] Documentation updated
-- [ ] `.DONE` created
 
 ## Git Commit Convention
 
@@ -208,7 +206,6 @@ this from PROMPT.md.
 - [ ] "Must Update" docs modified
 - [ ] "Check If Affected" docs reviewed
 - [ ] Discoveries logged
-- [ ] `.DONE` created
 
 ---
 

--- a/templates/tasks/EXAMPLE-001-hello-world/PROMPT.md
+++ b/templates/tasks/EXAMPLE-001-hello-world/PROMPT.md
@@ -68,7 +68,7 @@ _No additional context needed._
 
 ### Step 3: Delivery
 
-- [ ] `.DONE` created in this folder
+
 
 ## Documentation Requirements
 
@@ -79,7 +79,6 @@ _No additional context needed._
 
 - [ ] `hello-taskplane.md` exists in the project root
 - [ ] `hello-taskplane.md` includes a title, task ID (`EXAMPLE-001`), and current date
-- [ ] `.DONE` exists in the task folder
 
 ## Git Commit Convention
 

--- a/templates/tasks/EXAMPLE-001-hello-world/STATUS.md
+++ b/templates/tasks/EXAMPLE-001-hello-world/STATUS.md
@@ -36,7 +36,7 @@
 ### Step 3: Delivery
 **Status:** ⬜ Not Started
 
-- [ ] `.DONE` created
+
 
 ---
 

--- a/templates/tasks/EXAMPLE-002-parallel-smoke/PROMPT.md
+++ b/templates/tasks/EXAMPLE-002-parallel-smoke/PROMPT.md
@@ -67,7 +67,7 @@ _No additional context needed._
 
 ### Step 3: Delivery
 
-- [ ] `.DONE` created in this folder
+
 
 ## Documentation Requirements
 
@@ -78,7 +78,6 @@ _No additional context needed._
 
 - [ ] `hello-taskplane-2.md` exists in the project root
 - [ ] `hello-taskplane-2.md` includes a title, task ID (`EXAMPLE-002`), and a parallel-safe note
-- [ ] `.DONE` exists in the task folder
 
 ## Git Commit Convention
 

--- a/templates/tasks/EXAMPLE-002-parallel-smoke/STATUS.md
+++ b/templates/tasks/EXAMPLE-002-parallel-smoke/STATUS.md
@@ -36,7 +36,7 @@
 ### Step 3: Delivery
 **Status:** ⬜ Not Started
 
-- [ ] `.DONE` created
+
 
 ---
 


### PR DESCRIPTION
The `.DONE` file is created by the task-runner, not the worker. Remove the redundant checkbox from PROMPT/STATUS templates and example tasks.