### PR TITLE
chore: stage TP-074 + TP-075 — node:test migration

### DIFF
--- a/taskplane-tasks/CONTEXT.md
+++ b/taskplane-tasks/CONTEXT.md
@@ -2,7 +2,7 @@
 
 **Last Updated:** 2026-03-15
 **Status:** Active
-**Next Task ID:** TP-074
+**Next Task ID:** TP-076
 
 ---
 

--- a/taskplane-tasks/TP-074-node-test-bulk-migration/PROMPT.md
+++ b/taskplane-tasks/TP-074-node-test-bulk-migration/PROMPT.md
@@ -1,0 +1,230 @@
+# Task: TP-074 - Migrate Tests to Node.js Native Test Runner (Bulk)
+
+**Created:** 2026-03-26
+**Size:** L
+
+## Review Level: 1 (Plan Only)
+
+**Assessment:** Mechanical migration of 52 test files from vitest to node:test. No logic changes — only imports and assertion syntax. Low risk per file, high volume.
+**Score:** 2/8 — Blast radius: 1, Pattern novelty: 1, Security: 0, Reversibility: 0
+
+## Canonical Task Folder
+
+```
+taskplane-tasks/TP-074-node-test-bulk-migration/
+├── PROMPT.md
+├── STATUS.md
+├── .reviews/
+└── .DONE
+```
+
+## Mission
+
+Migrate the 52 non-mock test files from vitest to Node.js native test runner (`node:test` + `node:assert`). This eliminates the vitest/esbuild transform pipeline that adds 100-230 seconds of overhead per test run.
+
+**Design spec:** `docs/specifications/taskplane/migrate-to-node-test-runner.md`
+
+**Target:** Full suite under 15 seconds, fast suite under 5 seconds.
+
+## Dependencies
+
+- **None**
+
+## Context to Read First
+
+**Tier 2:**
+- `taskplane-tasks/CONTEXT.md`
+
+**Tier 3 (load only if needed):**
+- `docs/specifications/taskplane/migrate-to-node-test-runner.md` — full migration spec with assertion mapping table, loader strategy, and conventions
+- `extensions/vitest.config.ts` — current config (aliases, plugins)
+- `extensions/tests/` — existing test files to migrate
+
+## Environment
+
+- **Workspace:** `extensions/`
+- **Services required:** None
+
+## File Scope
+
+- `extensions/tests/expect.ts` (new — expect() compatibility wrapper)
+- `extensions/tests/loader.mjs` (new — module alias resolver)
+- `extensions/tests/*.test.ts` (52 files — all non-mock test files)
+- `extensions/tests/*.integration.test.ts` (9 files)
+- `extensions/vitest.config.ts` (keep for now — removed in TP-075)
+
+## Steps
+
+### Step 0: Preflight
+
+- [ ] Read the migration spec at `docs/specifications/taskplane/migrate-to-node-test-runner.md`
+- [ ] Verify `node --test` works: `node --experimental-strip-types --no-warnings --test extensions/tests/_any-file.ts`
+- [ ] Identify which 5 files use `vi.mock()`/`vi.fn()` — these are excluded from this task (handled in TP-075)
+- [ ] Verify Node.js version supports all needed features: `node:test` describe/it/before/after/mock
+
+### Step 1: Create Expect Compatibility Wrapper
+
+Create `extensions/tests/expect.ts` — a lightweight `expect()` function that mimics vitest's API using `node:assert`:
+
+```typescript
+import assert from "node:assert";
+
+export function expect(actual: unknown) {
+    return {
+        toBe: (expected: unknown) => assert.strictEqual(actual, expected),
+        toContain: (needle: unknown) => { /* string.includes or array.includes */ },
+        toEqual: (expected: unknown) => assert.deepStrictEqual(actual, expected),
+        toHaveLength: (n: number) => assert.strictEqual((actual as any).length, n),
+        toBeDefined: () => assert.notStrictEqual(actual, undefined),
+        toBeUndefined: () => assert.strictEqual(actual, undefined),
+        toBeNull: () => assert.strictEqual(actual, null),
+        toBeGreaterThan: (n: number) => assert.ok((actual as number) > n),
+        toBeGreaterThanOrEqual: (n: number) => assert.ok((actual as number) >= n),
+        toBeLessThan: (n: number) => assert.ok((actual as number) < n),
+        toMatch: (re: RegExp) => assert.match(actual as string, re),
+        toBeInstanceOf: (cls: any) => assert.ok(actual instanceof cls),
+        toHaveProperty: (key: string) => assert.ok(key in (actual as object)),
+        toThrow: (expected?: string | RegExp) => { /* assert.throws wrapper */ },
+        not: {
+            toBe: (expected: unknown) => assert.notStrictEqual(actual, expected),
+            toContain: (needle: unknown) => { /* negated */ },
+            toEqual: (expected: unknown) => assert.notDeepStrictEqual(actual, expected),
+            toBeDefined: () => assert.strictEqual(actual, undefined),
+            toBeNull: () => assert.notStrictEqual(actual, null),
+            toThrow: () => { /* assert.doesNotThrow */ },
+        },
+    };
+}
+```
+
+Cover ALL assertion patterns found in the spec's usage table. Test the wrapper itself with a small self-test.
+
+**Artifacts:**
+- `extensions/tests/expect.ts` (new)
+
+### Step 2: Create Module Alias Loader
+
+Create `extensions/tests/loader.mjs` to handle the two package aliases currently in vitest.config.ts:
+
+```javascript
+export function resolve(specifier, context, nextResolve) {
+    if (specifier === "@mariozechner/pi-coding-agent") {
+        // Resolve to mock file
+    }
+    if (specifier === "@mariozechner/pi-tui") {
+        // Resolve to mock file
+    }
+    return nextResolve(specifier, context);
+}
+```
+
+Test that it works: `node --experimental-strip-types --loader tests/loader.mjs --test tests/some-file.ts`
+
+Handle Windows path quirks (file:// URLs with drive letters).
+
+**Artifacts:**
+- `extensions/tests/loader.mjs` (new)
+
+### Step 3: Migrate Non-Mock Test Files
+
+For each of the ~52 test files that do NOT use `vi.mock()` or `vi.fn()`:
+
+1. Replace `import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "vitest"` with:
+   ```typescript
+   import { describe, it, before, after, beforeEach, afterEach } from "node:test";
+   import { expect } from "./expect.ts";
+   ```
+2. Rename `beforeAll` → `before`, `afterAll` → `after`
+3. No assertion changes needed (expect wrapper handles them)
+
+**Skip these 5 files** (they use vi.mock/vi.fn — handled in TP-075):
+- `diagnostic-reports.test.ts`
+- `non-blocking-engine.test.ts`
+- `auto-integration-deterministic.integration.test.ts`
+- `project-config-loader.test.ts`
+- `supervisor.test.ts`
+
+Also migrate the 9 `*.integration.test.ts` files (same mechanical change).
+
+**Artifacts:**
+- 52+ test files modified (import lines only)
+
+### Step 4: Add npm Scripts and Test Runner Config
+
+Add to `extensions/package.json` (or create a script):
+
+```json
+{
+    "scripts": {
+        "test": "node --experimental-strip-types --no-warnings --test tests/*.test.ts tests/*.integration.test.ts",
+        "test:fast": "node --experimental-strip-types --no-warnings --test tests/*.test.ts",
+        "test:vitest": "npx vitest run"
+    }
+}
+```
+
+Keep `test:vitest` as fallback for the 5 unmigrated files.
+
+Update `.pi/task-runner.yaml` test commands (project-level, NOT shipped templates):
+```yaml
+testing:
+    commands:
+        test: "cd extensions && node --experimental-strip-types --no-warnings --test tests/*.test.ts tests/*.integration.test.ts"
+        test_fast: "cd extensions && node --experimental-strip-types --no-warnings --test tests/*.test.ts"
+```
+
+**Important:** Do NOT modify `templates/config/task-runner.yaml` or any shipped templates. The test runner choice is project-specific. Shipped templates use generic placeholders.
+
+**Artifacts:**
+- `extensions/package.json` (modified)
+- `.pi/task-runner.yaml` (modified — project-level only)
+
+### Step 5: Testing & Verification
+
+> ZERO test failures allowed.
+
+- [ ] Run migrated tests with node:test: `node --experimental-strip-types --no-warnings --test tests/*.test.ts`
+- [ ] Run integration tests: `node --experimental-strip-types --no-warnings --test tests/*.integration.test.ts`
+- [ ] Run unmigrated tests with vitest: `npx vitest run tests/diagnostic-reports.test.ts tests/non-blocking-engine.test.ts tests/supervisor.test.ts tests/project-config-loader.test.ts tests/auto-integration-deterministic.integration.test.ts`
+- [ ] All tests pass across both runners
+- [ ] Build passes: `node bin/taskplane.mjs help`
+
+### Step 6: Documentation & Delivery
+
+- [ ] Update `docs/maintainers/development-setup.md` with new test commands
+- [ ] Discoveries logged in STATUS.md
+
+## Documentation Requirements
+
+**Must Update:**
+- `docs/maintainers/development-setup.md` — new test commands for developers
+- `.pi/task-runner.yaml` — project-level test commands
+
+**Do NOT Update:**
+- `templates/agents/task-worker.md` — generic, references project test command
+- `templates/config/task-runner.yaml` — generic, users fill in their own command
+- `skills/create-taskplane-task/` — generic, uses `[test command]` placeholder
+
+## Completion Criteria
+
+- [ ] 52+ test files migrated to node:test + expect wrapper
+- [ ] expect.ts wrapper covers all assertion patterns
+- [ ] Module alias loader works on Windows
+- [ ] Migrated tests pass with node --test
+- [ ] Unmigrated 5 files still pass with vitest
+- [ ] Build passes
+
+## Git Commit Convention
+
+- **Step completion:** `perf(TP-074): complete Step N — description`
+
+## Do NOT
+
+- Modify any shipped templates (task-worker.md, task-runner.yaml template, skills)
+- Change test logic or assertions — only change the runner infrastructure
+- Remove vitest yet — that happens in TP-075 after mock files are migrated
+- Rewrite expect() calls to assert — the wrapper handles this; bulk rewrite is not worth the effort
+
+---
+
+## Amendments

--- a/taskplane-tasks/TP-074-node-test-bulk-migration/STATUS.md
+++ b/taskplane-tasks/TP-074-node-test-bulk-migration/STATUS.md
@@ -1,0 +1,82 @@
+# TP-074: Migrate Tests to Node.js Native Test Runner (Bulk) — Status
+
+**Current Step:** Not Started
+**Status:** 🔵 Ready for Execution
+**Last Updated:** 2026-03-26
+**Review Level:** 1
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** L
+
+---
+
+### Step 0: Preflight
+**Status:** ⬜ Not Started
+- [ ] Read migration spec
+- [ ] Verify node --test works
+- [ ] Identify 5 mock-heavy files to skip
+
+---
+
+### Step 1: Create Expect Compatibility Wrapper
+**Status:** ⬜ Not Started
+- [ ] Create expect.ts covering all assertion patterns
+- [ ] Self-test the wrapper
+
+---
+
+### Step 2: Create Module Alias Loader
+**Status:** ⬜ Not Started
+- [ ] Create loader.mjs for pi package aliases
+- [ ] Verify Windows path handling
+
+---
+
+### Step 3: Migrate Non-Mock Test Files
+**Status:** ⬜ Not Started
+- [ ] Migrate ~52 unit/source test files (import changes only)
+- [ ] Migrate 9 integration test files
+- [ ] Skip 5 mock-heavy files
+
+---
+
+### Step 4: Add npm Scripts and Test Runner Config
+**Status:** ⬜ Not Started
+- [ ] Add test/test:fast/test:vitest npm scripts
+- [ ] Update .pi/task-runner.yaml (project-level only)
+
+---
+
+### Step 5: Testing & Verification
+**Status:** ⬜ Not Started
+- [ ] All migrated tests pass with node --test
+- [ ] Unmigrated 5 files pass with vitest
+- [ ] Build passes
+
+---
+
+### Step 6: Documentation & Delivery
+**Status:** ⬜ Not Started
+- [ ] Update docs/maintainers/development-setup.md
+- [ ] Discoveries logged
+
+---
+
+## Reviews
+
+| # | Type | Step | Verdict | File |
+|---|------|------|---------|------|
+
+---
+
+## Execution Log
+
+| Timestamp | Action | Outcome |
+|-----------|--------|---------|
+| 2026-03-26 | Task staged | PROMPT.md and STATUS.md created |
+
+---
+
+## Blockers
+
+*None*

--- a/taskplane-tasks/TP-075-node-test-mocks-cleanup/PROMPT.md
+++ b/taskplane-tasks/TP-075-node-test-mocks-cleanup/PROMPT.md
@@ -1,0 +1,159 @@
+# Task: TP-075 - Migrate Mock Tests + Remove Vitest
+
+**Created:** 2026-03-26
+**Size:** M
+
+## Review Level: 2 (Plan and Code)
+
+**Assessment:** Migrates the 5 remaining mock-heavy test files from vi.mock/vi.fn to node:test mock.module/mock.fn. Then removes vitest dependency entirely. Higher review level because mock migration can subtly change test behavior.
+**Score:** 4/8 — Blast radius: 2, Pattern novelty: 1, Security: 0, Reversibility: 1
+
+## Canonical Task Folder
+
+```
+taskplane-tasks/TP-075-node-test-mocks-cleanup/
+├── PROMPT.md
+├── STATUS.md
+├── .reviews/
+└── .DONE
+```
+
+## Mission
+
+Complete the vitest → node:test migration by:
+1. Migrating the 5 mock-heavy test files that TP-074 skipped
+2. Removing vitest, vite, and esbuild from devDependencies
+3. Removing vitest.config.ts
+4. Updating CI to use node --test
+
+## Dependencies
+
+- **Task:** TP-074 (bulk migration must be done first)
+
+## Context to Read First
+
+**Tier 2:**
+- `taskplane-tasks/CONTEXT.md`
+
+**Tier 3 (load only if needed):**
+- `docs/specifications/taskplane/migrate-to-node-test-runner.md` — spec section 3.4 on mock usage
+- `extensions/tests/diagnostic-reports.test.ts` — heaviest mock user (22 vi.mock/vi.fn calls)
+- `extensions/tests/non-blocking-engine.test.ts` — 21 mock calls
+- Node.js docs on `mock.module()` and `mock.fn()`: https://nodejs.org/api/test.html#mocking
+
+## Environment
+
+- **Workspace:** `extensions/`
+- **Services required:** None
+
+## File Scope
+
+- `extensions/tests/diagnostic-reports.test.ts`
+- `extensions/tests/non-blocking-engine.test.ts`
+- `extensions/tests/auto-integration-deterministic.integration.test.ts`
+- `extensions/tests/project-config-loader.test.ts`
+- `extensions/tests/supervisor.test.ts`
+- `extensions/vitest.config.ts` (deleted)
+- `extensions/package.json` (remove vitest deps)
+- `.github/workflows/ci.yml` (update test command)
+
+## Steps
+
+### Step 0: Preflight
+
+- [ ] Read each of the 5 mock-heavy files — understand what they mock and why
+- [ ] Read Node.js `mock.module()` and `mock.fn()` docs
+- [ ] Verify `mock.module()` is available: `node -e "import { mock } from 'node:test'; console.log(typeof mock.module)"`
+- [ ] Determine if any vi.mock patterns can't be mapped to mock.module
+
+### Step 1: Migrate Mock-Heavy Test Files
+
+For each of the 5 files:
+
+1. Replace `import { vi } from "vitest"` with `import { mock } from "node:test"`
+2. Replace `vi.fn()` → `mock.fn()`
+3. Replace `vi.mock("module", () => ({ ... }))` → `mock.module("module", { namedExports: { ... } })`
+4. Replace `vi.spyOn()` → `mock.method()` if applicable
+5. Replace `vi.clearAllMocks()` / `vi.restoreAllMocks()` → `mock.restoreAll()` in afterEach
+6. Replace vitest imports with node:test + expect wrapper (same as TP-074)
+
+**If `mock.module()` can't handle a specific pattern:** Refactor the test to not need module mocking. Many vi.mock uses can be replaced with dependency injection (pass the function as a parameter instead of importing it).
+
+**Artifacts:**
+- 5 test files modified
+
+### Step 2: Remove Vitest
+
+1. Delete `extensions/vitest.config.ts`
+2. Remove from `extensions/package.json`:
+   - `vitest` from devDependencies
+   - `vite` if present
+   - Any `@vitest/*` packages
+3. Remove `test:vitest` npm script (added in TP-074 as fallback)
+4. Run `npm install` to clean lockfile
+
+**Artifacts:**
+- `extensions/vitest.config.ts` (deleted)
+- `extensions/package.json` (modified)
+
+### Step 3: Update CI
+
+Update `.github/workflows/ci.yml`:
+
+```yaml
+- name: Run tests
+  run: cd extensions && node --experimental-strip-types --no-warnings --test tests/*.test.ts tests/*.integration.test.ts
+```
+
+Ensure CI still reports pass/fail correctly (node --test exits with non-zero on failure).
+
+**Artifacts:**
+- `.github/workflows/ci.yml` (modified)
+
+### Step 4: Testing & Verification
+
+> ZERO test failures allowed.
+
+- [ ] Run ALL tests with node --test (no vitest fallback): `cd extensions && node --experimental-strip-types --no-warnings --test tests/*.test.ts tests/*.integration.test.ts`
+- [ ] Verify vitest is gone: `npx vitest run` should fail with "command not found" or "not installed"
+- [ ] Build passes: `node bin/taskplane.mjs help`
+- [ ] Benchmark: record total test time and compare with vitest baseline
+
+### Step 5: Documentation & Delivery
+
+- [ ] Update `docs/maintainers/development-setup.md` — remove all vitest references
+- [ ] Discoveries logged in STATUS.md
+
+## Documentation Requirements
+
+**Must Update:**
+- `docs/maintainers/development-setup.md` — final test command documentation
+- `.github/workflows/ci.yml` — CI test command
+
+**Do NOT Update:**
+- Any shipped templates or skills (same boundary as TP-074)
+
+## Completion Criteria
+
+- [ ] All 5 mock-heavy files migrated to node:test mock API
+- [ ] vitest.config.ts deleted
+- [ ] vitest removed from devDependencies
+- [ ] CI uses node --test
+- [ ] ALL 2690 tests pass with node --test (zero vitest dependency)
+- [ ] Build passes
+- [ ] Test time benchmark recorded
+
+## Git Commit Convention
+
+- **Step completion:** `perf(TP-075): complete Step N — description`
+
+## Do NOT
+
+- Modify shipped templates or skills
+- Change test logic — only migration infrastructure
+- Skip tests that can't be easily migrated — refactor them instead
+- Leave vitest as a fallback — this task fully removes it
+
+---
+
+## Amendments

--- a/taskplane-tasks/TP-075-node-test-mocks-cleanup/STATUS.md
+++ b/taskplane-tasks/TP-075-node-test-mocks-cleanup/STATUS.md
@@ -1,0 +1,77 @@
+# TP-075: Migrate Mock Tests + Remove Vitest — Status
+
+**Current Step:** Not Started
+**Status:** 🔵 Ready for Execution
+**Last Updated:** 2026-03-26
+**Review Level:** 2
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** M
+
+---
+
+### Step 0: Preflight
+**Status:** ⬜ Not Started
+- [ ] Read 5 mock-heavy files and understand mock patterns
+- [ ] Verify mock.module() availability in Node.js
+- [ ] Identify any unmappable vi.mock patterns
+
+---
+
+### Step 1: Migrate Mock-Heavy Test Files
+**Status:** ⬜ Not Started
+- [ ] Migrate diagnostic-reports.test.ts (22 mock calls)
+- [ ] Migrate non-blocking-engine.test.ts (21 mock calls)
+- [ ] Migrate auto-integration-deterministic.integration.test.ts (4 mock calls)
+- [ ] Migrate project-config-loader.test.ts (2 mock calls)
+- [ ] Migrate supervisor.test.ts (1 mock call)
+
+---
+
+### Step 2: Remove Vitest
+**Status:** ⬜ Not Started
+- [ ] Delete vitest.config.ts
+- [ ] Remove vitest/vite from devDependencies
+- [ ] Clean npm lockfile
+
+---
+
+### Step 3: Update CI
+**Status:** ⬜ Not Started
+- [ ] Update ci.yml test command to node --test
+
+---
+
+### Step 4: Testing & Verification
+**Status:** ⬜ Not Started
+- [ ] ALL tests pass with node --test only
+- [ ] vitest fully removed
+- [ ] Benchmark recorded
+
+---
+
+### Step 5: Documentation & Delivery
+**Status:** ⬜ Not Started
+- [ ] Update maintainer docs
+- [ ] Discoveries logged
+
+---
+
+## Reviews
+
+| # | Type | Step | Verdict | File |
+|---|------|------|---------|------|
+
+---
+
+## Execution Log
+
+| Timestamp | Action | Outcome |
+|-----------|--------|---------|
+| 2026-03-26 | Task staged | PROMPT.md and STATUS.md created |
+
+---
+
+## Blockers
+
+*None*

--- a/taskplane-tasks/dependencies.json
+++ b/taskplane-tasks/dependencies.json
@@ -1,8 +1,10 @@
 {
   "version": 1,
-  "generatedAt": "2026-03-26T10:00:00.000Z",
+  "generatedAt": "2026-03-26T14:00:00.000Z",
   "source": "prompt",
   "tasks": {
-    "TP-073": []
+    "TP-073": [],
+    "TP-074": [],
+    "TP-075": ["TP-074"]
   }
 }


### PR DESCRIPTION
Two-phase test runner migration:
- TP-074 (L): Migrate 52+ test files, create expect wrapper, module alias loader
- TP-075 (M): Migrate 5 mock-heavy files, remove vitest entirely

TP-073 (worker nudge) also pending — runs in parallel with TP-074.