### PR TITLE
fix: skip vitest in migration task testing steps

### DIFF
--- a/taskplane-tasks/TP-073-worker-incomplete-exit-nudge/PROMPT.md
+++ b/taskplane-tasks/TP-073-worker-incomplete-exit-nudge/PROMPT.md
@@ -87,11 +87,12 @@ In the iteration loop, after `parseStatusMd()` determines remaining steps and be
 
 ### Step 2: Testing & Verification
 
-> ZERO test failures allowed.
+> **SKIP automated test runs for this task.** The test infrastructure is being
+> migrated to node:test in parallel (TP-074/TP-075). Running vitest now may
+> produce false failures. Tests will be validated manually after integration.
 
-- [ ] Run targeted tests: `cd extensions && npx vitest run --changed`
-- [ ] Run full test suite: `cd extensions && npx vitest run`
 - [ ] Build passes: `node bin/taskplane.mjs help`
+- [ ] Verify the nudge prompt is constructed correctly by reading the source
 
 ### Step 3: Documentation & Delivery
 

--- a/taskplane-tasks/TP-073-worker-incomplete-exit-nudge/STATUS.md
+++ b/taskplane-tasks/TP-073-worker-incomplete-exit-nudge/STATUS.md
@@ -27,9 +27,8 @@
 
 ### Step 2: Testing & Verification
 **Status:** ⬜ Not Started
-- [ ] Targeted tests pass
-- [ ] Full test suite passes
 - [ ] Build passes
+- [ ] Source verification of nudge prompt construction
 
 ---
 

--- a/taskplane-tasks/TP-074-node-test-bulk-migration/PROMPT.md
+++ b/taskplane-tasks/TP-074-node-test-bulk-migration/PROMPT.md
@@ -181,13 +181,13 @@ testing:
 
 ### Step 5: Testing & Verification
 
-> ZERO test failures allowed.
+> **SKIP full automated test suite for this task.** The vitest → node:test
+> migration changes the test infrastructure itself. Running vitest on migrated
+> files will fail. Tests will be validated manually after integration.
 
-- [ ] Run migrated tests with node:test: `node --experimental-strip-types --no-warnings --test tests/*.test.ts`
-- [ ] Run integration tests: `node --experimental-strip-types --no-warnings --test tests/*.integration.test.ts`
-- [ ] Run unmigrated tests with vitest: `npx vitest run tests/diagnostic-reports.test.ts tests/non-blocking-engine.test.ts tests/supervisor.test.ts tests/project-config-loader.test.ts tests/auto-integration-deterministic.integration.test.ts`
-- [ ] All tests pass across both runners
 - [ ] Build passes: `node bin/taskplane.mjs help`
+- [ ] Verify a few migrated files work with node:test: `node --experimental-strip-types --no-warnings --test tests/supervisor-template.test.ts tests/context-pressure-cache.test.ts`
+- [ ] Verify expect.ts wrapper loads without errors
 
 ### Step 6: Documentation & Delivery
 

--- a/taskplane-tasks/TP-074-node-test-bulk-migration/STATUS.md
+++ b/taskplane-tasks/TP-074-node-test-bulk-migration/STATUS.md
@@ -49,9 +49,9 @@
 
 ### Step 5: Testing & Verification
 **Status:** ⬜ Not Started
-- [ ] All migrated tests pass with node --test
-- [ ] Unmigrated 5 files pass with vitest
 - [ ] Build passes
+- [ ] Spot-check a few migrated files with node --test
+- [ ] Expect wrapper loads without errors
 
 ---
 

--- a/taskplane-tasks/TP-075-node-test-mocks-cleanup/PROMPT.md
+++ b/taskplane-tasks/TP-075-node-test-mocks-cleanup/PROMPT.md
@@ -112,12 +112,13 @@ Ensure CI still reports pass/fail correctly (node --test exits with non-zero on 
 
 ### Step 4: Testing & Verification
 
-> ZERO test failures allowed.
+> **Run tests with node:test only** — vitest has been removed in Step 2.
+> This is the first full run with the new runner.
 
-- [ ] Run ALL tests with node --test (no vitest fallback): `cd extensions && node --experimental-strip-types --no-warnings --test tests/*.test.ts tests/*.integration.test.ts`
-- [ ] Verify vitest is gone: `npx vitest run` should fail with "command not found" or "not installed"
+- [ ] Run ALL tests with node --test: `cd extensions && node --experimental-strip-types --no-warnings --test tests/*.test.ts tests/*.integration.test.ts`
+- [ ] Verify vitest is gone: `npx vitest run` should fail with "not installed"
 - [ ] Build passes: `node bin/taskplane.mjs help`
-- [ ] Benchmark: record total test time and compare with vitest baseline
+- [ ] Benchmark: record total test time and compare with vitest baseline (~156s)
 
 ### Step 5: Documentation & Delivery
 


### PR DESCRIPTION
TP-073/074/075 testing steps updated to skip vitest runs since the test infrastructure is being migrated. Manual validation after integration.