### PR TITLE
fix: engine worker thread fails with --experimental-strip-types

### DIFF
--- a/extensions/taskplane/extension.ts
+++ b/extensions/taskplane/extension.ts
@@ -940,7 +940,10 @@ export function startBatchInWorker(
 
 	let worker: Worker;
 	try {
-		worker = new Worker(workerPath, { workerData: wkData });
+		worker = new Worker(workerPath, {
+			workerData: wkData,
+			execArgv: ["--experimental-transform-types", "--no-warnings"],
+		});
 	} catch (spawnErr: unknown) {
 		const errMsg = spawnErr instanceof Error ? spawnErr.message : String(spawnErr);
 		ctx.ui.notify(


### PR DESCRIPTION
The Worker inherits the parent's execArgv which includes
--experimental-strip-types. This flag doesn't transform .ts files
inside node_modules, causing immediate failure when taskplane is
installed as a package.

Fix: explicitly pass --experimental-transform-types to the Worker
constructor, which handles node_modules .ts files correctly.
