### PR TITLE
fix: worker thread entry point uses .mjs to avoid node_modules .ts rejection

### DIFF
--- a/extensions/taskplane/engine-worker-entry.mjs
+++ b/extensions/taskplane/engine-worker-entry.mjs
@@ -1,0 +1,10 @@
+/**
+ * Thin entry point for the engine worker thread.
+ *
+ * Node's Worker constructor rejects .ts files inside node_modules when
+ * --experimental-strip-types is active (the default in Node v25+).
+ * This .mjs wrapper avoids the restriction — Node loads .mjs files
+ * without TypeScript processing, then --experimental-transform-types
+ * (passed via execArgv) handles subsequent .ts imports.
+ */
+import "./engine-worker.ts";

--- a/extensions/taskplane/extension.ts
+++ b/extensions/taskplane/extension.ts
@@ -897,7 +897,7 @@ function resolveEngineWorkerPath(): string {
 	} catch {
 		thisDir = __dirname;
 	}
-	return join(thisDir, "engine-worker.ts");
+	return join(thisDir, "engine-worker-entry.mjs");
 }
 
 /**

--- a/extensions/tests/engine-worker-thread.test.ts
+++ b/extensions/tests/engine-worker-thread.test.ts
@@ -325,12 +325,12 @@ describe("4.x — Extension worker thread integration", () => {
 		expect(fnBody).toContain(".catch(");
 	});
 
-	it("4.11: resolveEngineWorkerPath resolves engine-worker.ts path", () => {
+	it("4.11: resolveEngineWorkerPath resolves engine-worker-entry.mjs path", () => {
 		const src = readSource("extension.ts");
 		expect(src).toContain("function resolveEngineWorkerPath()");
 		const fnStart = src.indexOf("function resolveEngineWorkerPath()");
 		const fnBody = src.substring(fnStart, fnStart + 300);
-		expect(fnBody).toContain("engine-worker.ts");
+		expect(fnBody).toContain("engine-worker-entry.mjs");
 	});
 });
 


### PR DESCRIPTION
Node v25 enables --experimental-strip-types by default, which rejects
.ts files inside node_modules. The Worker entry point must be .mjs so
Node loads it without TypeScript processing. The .mjs wrapper then
imports engine-worker.ts, handled by --experimental-transform-types
in the Worker's execArgv.
