### PR TITLE
chore(release): v0.20.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.20.2",
+  "version": "0.20.3",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Fix: engine uses child_process.fork() instead of worker_threads — resolves .ts in node_modules crash on Node v25