### PR TITLE
fix: return child instead of worker in startBatchInWorker

### DIFF
--- a/extensions/taskplane/extension.ts
+++ b/extensions/taskplane/extension.ts
@@ -1074,7 +1074,7 @@ export function startBatchInWorker(
 		settle();
 	});
 
-	return worker;
+	return child;
 }
 
 // ── TP-043 R002-2: Integration Executor Builder ─────────────────────


### PR DESCRIPTION
Rename miss from the fork() refactor — local var renamed to child
but the return statement still referenced worker.
