### PR TITLE
chore(release): v0.20.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.20.4",
+  "version": "0.20.5",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Fix: disable fork, use main-thread engine — Node v25 blocks all .ts in node_modules