### PR TITLE
chore(release): v0.20.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.20.5",
+  "version": "0.20.6",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Engine fork re-enabled using jiti — .ts loading in node_modules works reliably. Supervisor main thread stays free for TUI interaction.