### PR TITLE
feat: authoritative context usage from pi get_session_stats (pi ≥ 0.63.0)

### DIFF
--- a/bin/rpc-wrapper.mjs
+++ b/bin/rpc-wrapper.mjs
@@ -331,6 +331,8 @@ function createSessionState() {
 		currentTool: null,
 		error: null,
 		agentEnded: false,
+		/** Authoritative context usage from pi get_session_stats (null if unavailable) */
+		contextUsage: null,
 	};
 }
 
@@ -414,6 +416,10 @@ function applyEvent(state, event) {
 			if (event.success === false && event.error) {
 				state.error = event.error;
 			}
+			// get_session_stats response — extract authoritative contextUsage
+			if (event.success === true && event.data?.contextUsage) {
+				state.contextUsage = event.data.contextUsage;
+			}
 			break;
 		}
 
@@ -455,6 +461,8 @@ function buildExitSummary(state, exitCode, exitSignal, errorOverride, startTime)
 		durationSec,
 		lastToolCall: state.lastToolCall,
 		error: finalError,
+		// Authoritative context usage from pi ≥ 0.63.0 (null if unavailable)
+		contextUsage: state.contextUsage || null,
 	};
 
 	return redactSummary(rawSummary);
@@ -614,6 +622,22 @@ function closeStdin() {
 	}
 }
 
+/**
+ * Query pi for authoritative session stats including contextUsage.
+ * Available in pi ≥ 0.63.0 (RPC get_session_stats exposes contextUsage).
+ * Safe to call on older versions — the command is ignored or returns
+ * without the field, and state.contextUsage stays null.
+ */
+function querySessionStats() {
+	try {
+		if (proc.stdin && !proc.stdin.destroyed) {
+			proc.stdin.write(JSON.stringify({ type: "get_session_stats" }) + "\n");
+		}
+	} catch {
+		// stdin may be closed — ignore
+	}
+}
+
 // ── Route RPC events ─────────────────────────────────────────────────
 
 function handleEvent(event) {
@@ -628,6 +652,13 @@ function handleEvent(event) {
 	// Side effects that depend on the event type (IO, stdin lifecycle, display)
 	switch (event.type) {
 		case "message_end":
+			displayProgress(state);
+			// Query pi for authoritative context usage (pi ≥ 0.63.0).
+			// Falls back gracefully: older pi versions ignore the command
+			// or return a response without contextUsage — state.contextUsage stays null.
+			querySessionStats();
+			break;
+
 		case "tool_execution_start":
 			displayProgress(state);
 			break;

--- a/extensions/task-runner.ts
+++ b/extensions/task-runner.ts
@@ -1367,6 +1367,8 @@ interface SidecarTelemetryDelta {
 	lastRetryError: string;
 	/** Whether any sidecar events were parsed in this tick (used for callback gating) */
 	hadEvents: boolean;
+	/** Authoritative context usage from pi get_session_stats (pi ≥ 0.63.0, null if unavailable) */
+	contextUsage: { percentUsed: number; totalTokens: number; maxTokens: number } | null;
 }
 
 /**
@@ -1385,7 +1387,7 @@ function tailSidecarJsonl(filePath: string, tailState: SidecarTailState): Sideca
 		inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0,
 		cost: 0, latestTotalTokens: 0, toolCalls: 0, lastTool: "",
 		retryActive: tailState.retryActive, retriesStarted: 0, lastRetryError: "",
-		hadEvents: false,
+		hadEvents: false, contextUsage: null,
 	};
 
 	// Gracefully handle missing file (wrapper hasn't written yet)
@@ -1494,6 +1496,21 @@ function tailSidecarJsonl(filePath: string, tailState: SidecarTailState): Sideca
 
 			case "auto_retry_end": {
 				tailState.retryActive = false;
+				break;
+			}
+
+			case "response": {
+				// get_session_stats response from pi ≥ 0.63.0 — authoritative context usage
+				if (event.success === true && event.data?.contextUsage) {
+					const cu = event.data.contextUsage;
+					if (typeof cu.percentUsed === "number") {
+						delta.contextUsage = {
+							percentUsed: cu.percentUsed,
+							totalTokens: cu.totalTokens || 0,
+							maxTokens: cu.maxTokens || 0,
+						};
+					}
+				}
 				break;
 			}
 		}
@@ -2405,8 +2422,10 @@ export default function (pi: ExtensionAPI) {
 								state.reviewerLastTool = delta.lastTool;
 							}
 
-							// Context %
-							if (delta.latestTotalTokens > 0 && contextWindow > 0) {
+							// Context % — prefer authoritative contextUsage (pi ≥ 0.63.0)
+							if (delta.contextUsage) {
+								state.reviewerContextPct = delta.contextUsage.percentUsed;
+							} else if (delta.latestTotalTokens > 0 && contextWindow > 0) {
 								state.reviewerContextPct = (delta.latestTotalTokens / contextWindow) * 100;
 							}
 
@@ -2566,7 +2585,10 @@ export default function (pi: ExtensionAPI) {
 								state.reviewerCostUsd += delta.cost;
 								state.reviewerToolCount += delta.toolCalls;
 								if (delta.lastTool) state.reviewerLastTool = delta.lastTool;
-								if (delta.latestTotalTokens > 0 && contextWindow > 0) {
+								// Context % — prefer authoritative contextUsage (pi ≥ 0.63.0)
+								if (delta.contextUsage) {
+									state.reviewerContextPct = delta.contextUsage.percentUsed;
+								} else if (delta.latestTotalTokens > 0 && contextWindow > 0) {
 									state.reviewerContextPct = (delta.latestTotalTokens / contextWindow) * 100;
 								}
 								writeLaneState(state);
@@ -3140,18 +3162,24 @@ export default function (pi: ExtensionAPI) {
 						state.workerLastRetryError = delta.lastRetryError;
 					}
 
-					// Context % (same as subprocess onContextPct)
-					// totalTokens is cumulative from the most recent message_end
-					if (delta.latestTotalTokens > 0 && contextWindow > 0) {
-						const pct = (delta.latestTotalTokens / contextWindow) * 100;
-						state.workerContextPct = pct;
-						if (pct >= warnPct) {
-							writeWrapUpSignal(`Wrap up (context ${Math.round(pct)}%)`);
-						}
-						if (pct >= killPct && state.workerStatus === "running") {
-							console.error(`[task-runner] tmux worker: context limit (${Math.round(pct)}%) — killing session '${sessionName}'`);
-							killReason = "context";
-							spawned.kill();
+					// Context % — prefer authoritative contextUsage from pi ≥ 0.63.0,
+					// fall back to manual calculation from totalTokens + cacheRead.
+					{
+						const pct = delta.contextUsage
+							? delta.contextUsage.percentUsed
+							: (delta.latestTotalTokens > 0 && contextWindow > 0)
+								? (delta.latestTotalTokens / contextWindow) * 100
+								: 0;
+						if (pct > 0) {
+							state.workerContextPct = pct;
+							if (pct >= warnPct) {
+								writeWrapUpSignal(`Wrap up (context ${Math.round(pct)}%)`);
+							}
+							if (pct >= killPct && state.workerStatus === "running") {
+								console.error(`[task-runner] tmux worker: context limit (${Math.round(pct)}%) — killing session '${sessionName}'`);
+								killReason = "context";
+								spawned.kill();
+							}
 						}
 					}
 

--- a/extensions/tests/rpc-wrapper.test.ts
+++ b/extensions/tests/rpc-wrapper.test.ts
@@ -1268,8 +1268,11 @@ process.stdin.on('end', () => {
 		writeFileSync(mockPiScript, `
 import process from 'process';
 
+let responded = false;
 process.stdin.setEncoding('utf8');
 process.stdin.on('data', (chunk) => {
+	if (responded) return; // Ignore get_session_stats and other follow-up commands
+	responded = true;
 	// Emit one event then crash
 	process.stdout.write(JSON.stringify({ type: "agent_start" }) + '\\n');
 	process.stdout.write(JSON.stringify({

--- a/extensions/tests/sidecar-tailing.test.ts
+++ b/extensions/tests/sidecar-tailing.test.ts
@@ -617,3 +617,52 @@ describe("tailSidecarJsonl — poll loop integration simulation", () => {
 		expect(retryCount).toBe(1);
 	});
 });
+
+describe("tailSidecarJsonl — contextUsage from get_session_stats (pi ≥ 0.63.0)", () => {
+	it("extracts contextUsage from response event", () => {
+		const state = createSidecarTailState();
+		writeEvents(
+			{ type: "response", success: true, data: {
+				contextUsage: { percentUsed: 42.5, totalTokens: 425000, maxTokens: 1000000 },
+			}},
+		);
+		const delta = tailSidecarJsonl(sidecarPath, state);
+		expect(delta.contextUsage).not.toBe(null);
+		expect(delta.contextUsage!.percentUsed).toBe(42.5);
+		expect(delta.contextUsage!.totalTokens).toBe(425000);
+		expect(delta.contextUsage!.maxTokens).toBe(1000000);
+	});
+
+	it("contextUsage is null when response has no contextUsage (older pi)", () => {
+		const state = createSidecarTailState();
+		writeEvents(
+			{ type: "response", success: true, data: {} },
+		);
+		const delta = tailSidecarJsonl(sidecarPath, state);
+		expect(delta.contextUsage).toBe(null);
+	});
+
+	it("contextUsage is null when response is an error", () => {
+		const state = createSidecarTailState();
+		writeEvents(
+			{ type: "response", success: false, error: "something broke" },
+		);
+		const delta = tailSidecarJsonl(sidecarPath, state);
+		expect(delta.contextUsage).toBe(null);
+	});
+
+	it("contextUsage takes precedence over manual calculation when present", () => {
+		const state = createSidecarTailState();
+		// message_end gives manual tokens AND response gives authoritative contextUsage
+		writeEvents(
+			{ type: "message_end", message: { usage: { input: 100, output: 50, totalTokens: 150 } } },
+			{ type: "response", success: true, data: {
+				contextUsage: { percentUsed: 87.3, totalTokens: 873000, maxTokens: 1000000 },
+			}},
+		);
+		const delta = tailSidecarJsonl(sidecarPath, state);
+		// Both should be present — consumer decides which to use
+		expect(delta.latestTotalTokens).toBe(150);
+		expect(delta.contextUsage!.percentUsed).toBe(87.3);
+	});
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.20.5",
+  "version": "0.20.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.20.5",
+      "version": "0.20.6",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",


### PR DESCRIPTION
Query pi's get_session_stats RPC after each message_end to get the
authoritative contextUsage (percentUsed, totalTokens, maxTokens).
Falls back to the existing manual calculation on older pi versions.

Changes:
- rpc-wrapper.mjs: sends get_session_stats after message_end, captures
  contextUsage from response, includes it in exit summary
- task-runner.ts: SidecarTelemetryDelta gains contextUsage field,
  sidecar tailer parses response events, all three consumer sites
  (worker, persistent reviewer, fresh-spawn reviewer) prefer
  authoritative contextUsage over manual totalTokens/contextWindow calc
- 4 new tests for contextUsage parsing and precedence
