### PR TITLE
fix: supervisor migration uses config root, not hardcoded .pi/

### DIFF
--- a/extensions/taskplane/extension.ts
+++ b/extensions/taskplane/extension.ts
@@ -1675,7 +1675,7 @@ export default function (pi: ExtensionAPI) {
 		// TP-063: Run additive migrations before batch start (primary trigger).
 		// Non-fatal — failures warn but never block batch execution.
 		try {
-			const migrationResult = runMigrations(execCtx.repoRoot);
+			const migrationResult = runMigrations(execCtx.repoRoot, undefined, execCtx.pointer?.configRoot);
 			if (migrationResult.messages.length > 0) {
 				ctx.ui.notify(migrationResult.messages.join("\n"), "info");
 			}
@@ -3134,7 +3134,7 @@ export default function (pi: ExtensionAPI) {
 		// This ensures migrations run even if the user doesn't invoke /orch.
 		// Non-fatal — failures are silently swallowed so startup is never blocked.
 		try {
-			const migrationResult = runMigrations(execCtx.repoRoot);
+			const migrationResult = runMigrations(execCtx.repoRoot, undefined, execCtx.pointer?.configRoot);
 			if (migrationResult.messages.length > 0) {
 				ctx.ui.notify(migrationResult.messages.join("\n"), "info");
 			}

--- a/extensions/taskplane/migrations.ts
+++ b/extensions/taskplane/migrations.ts
@@ -31,10 +31,11 @@ export interface Migration {
 	 *
 	 * @param projectRoot - Project root directory
 	 * @param packageRoot - Taskplane package root (for template resolution)
+	 * @param configRoot - Config root directory (e.g., ".pi" in repo mode, "shared-libs/.taskplane" in workspace mode)
 	 * @returns A short message describing what was created, or null if skipped (already exists)
 	 * @throws If the migration cannot complete (e.g., missing template source)
 	 */
-	run(projectRoot: string, packageRoot: string): string | null;
+	run(projectRoot: string, packageRoot: string, configRoot: string): string | null;
 }
 
 /**
@@ -165,9 +166,9 @@ export function resolvePackageRoot(importMetaUrl?: string): string {
 export const MIGRATION_REGISTRY: Migration[] = [
 	{
 		id: "add-supervisor-local-template-v1",
-		description: "Create .pi/agents/supervisor.md from template if missing",
-		run(projectRoot: string, packageRoot: string): string | null {
-			const targetPath = join(projectRoot, ".pi", "agents", "supervisor.md");
+		description: "Create agents/supervisor.md from template if missing",
+		run(projectRoot: string, packageRoot: string, configRoot: string): string | null {
+			const targetPath = join(configRoot, "agents", "supervisor.md");
 
 			// Skip if file already exists — never overwrite
 			if (existsSync(targetPath)) {
@@ -187,7 +188,7 @@ export const MIGRATION_REGISTRY: Migration[] = [
 			mkdirSync(dirname(targetPath), { recursive: true });
 			copyFileSync(templatePath, targetPath);
 
-			return "Created .pi/agents/supervisor.md from template";
+			return `Created ${targetPath} from template`;
 		},
 	},
 ];
@@ -213,8 +214,10 @@ export const MIGRATION_REGISTRY: Migration[] = [
 export function runMigrations(
 	projectRoot: string,
 	packageRoot?: string,
+	configRoot?: string,
 ): MigrationRunResult {
 	const pkgRoot = packageRoot ?? resolvePackageRoot();
+	const cfgRoot = configRoot ?? join(projectRoot, ".pi");
 	const result: MigrationRunResult = {
 		applied: [],
 		skipped: [],
@@ -236,7 +239,7 @@ export function runMigrations(
 		}
 
 		try {
-			const message = migration.run(projectRoot, pkgRoot);
+			const message = migration.run(projectRoot, pkgRoot, cfgRoot);
 
 			// Record as applied (whether it created something or skipped)
 			migrationState.applied[migration.id] = {

--- a/extensions/tests/migrations.test.ts
+++ b/extensions/tests/migrations.test.ts
@@ -182,6 +182,21 @@ describe("migrations", () => {
 
 			rmSync(fakePackageRoot, { recursive: true, force: true });
 		});
+
+		it("uses configRoot for supervisor.md in workspace mode", () => {
+			// Simulate workspace mode: configRoot is a different directory than .pi
+			const configRoot = join(tempDir, "shared-libs", ".taskplane");
+			mkdirSync(join(configRoot, "agents"), { recursive: true });
+			setupProjectDir(tempDir); // creates .pi/taskplane.json
+
+			const result = runMigrations(tempDir, packageRoot, configRoot);
+
+			expect(result.applied).toContain("add-supervisor-local-template-v1");
+
+			// File should be in configRoot, NOT in .pi
+			expect(existsSync(join(configRoot, "agents", "supervisor.md"))).toBe(true);
+			expect(existsSync(join(tempDir, ".pi", "agents", "supervisor.md"))).toBe(false);
+		});
 	});
 
 	describe("loadTaskplaneMeta", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.20.6",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.20.6",
+      "version": "0.21.1",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",


### PR DESCRIPTION
In workspace mode, agent files live in configRepo/.taskplane/agents/,
not .pi/agents/. The migration was hardcoding .pi/ which placed
supervisor.md in the wrong directory.

- Migration.run() now receives configRoot parameter
- runMigrations() accepts optional configRoot (defaults to .pi/)
- Both call sites in extension.ts pass execCtx.pointer?.configRoot
- New test verifies workspace-mode placement
