### PR TITLE
fix: check lane branch for .DONE after grace period expires

### DIFF
--- a/extensions/taskplane/execution.ts
+++ b/extensions/taskplane/execution.ts
@@ -1069,9 +1069,37 @@ export async function pollUntilTaskComplete(
 				}
 			}
 
-			// Grace period expired without .DONE → task failed (TP-070: async)
+			// Grace period expired — last resort: check the lane BRANCH for .DONE.
+			// The worker may have committed .DONE before the session exited, but
+			// the worktree filesystem doesn't reflect it (stale checkout, race).
+			// This handles the common case where the worker completes all work,
+			// commits .DONE, and then the session exits before the poll detects it.
+			{
+				const relDonePath = donePath.startsWith(lane.worktreePath)
+					? donePath.slice(lane.worktreePath.length).replace(/^[\\/]+/, "").replace(/\\/g, "/")
+					: null;
+				if (relDonePath) {
+					const gitResult = runGit(
+						["show", `${lane.branch}:${relDonePath}`],
+						lane.worktreePath,
+					);
+					if (gitResult.ok) {
+						execLog(laneId, task.taskId, ".DONE found on lane branch (not in worktree) — task succeeded", {
+							session: sessionName,
+							branch: lane.branch,
+						});
+						return {
+							status: "succeeded",
+							exitReason: ".DONE committed to lane branch (found via git show after grace period)",
+							doneFileFound: true,
+						};
+					}
+				}
+			}
+
+			// Truly failed — no .DONE on filesystem or branch
 			const logTail = await readLaneLogTailAsync(laneLogPath);
-			execLog(laneId, task.taskId, "grace period expired without .DONE — task failed", {
+			execLog(laneId, task.taskId, "grace period expired, no .DONE on filesystem or branch — task failed", {
 				session: sessionName,
 				logPath: laneLogPath,
 			});


### PR DESCRIPTION
When a tmux session exits without the poll detecting .DONE on the
filesystem, the engine now checks the lane git branch via
'git show <branch>:<path>/.DONE' before declaring failure.

This handles the race condition where the worker completes all work,
commits .DONE to the lane branch, and exits — but the worktree
filesystem is stale or the poll timing barely misses the file.

Previously this was the #1 cause of false task failures in production
batches (seen in TP-065, TP-067, TP-072, TP-075, and user reports).
