### PR TITLE
fix: parse **Workspace:** as repo routing in PROMPT.md

### DIFF
--- a/extensions/taskplane/discovery.ts
+++ b/extensions/taskplane/discovery.ts
@@ -208,9 +208,9 @@ export function parsePromptForOrchestrator(
 		}
 	}
 	if (execTargetSectionBody !== null) {
-		// Match "Repo: api" or "**Repo:** api" or "Repo: api" with whitespace
+		// Match "Repo: api" or "**Repo:** api" or "Workspace: api" with whitespace
 		const repoLineMatch = execTargetSectionBody.match(
-			/^\s*\*?\*?Repo:?\*?\*?\s+(\S+)/mi,
+			/^\s*\*?\*?(?:Repo|Workspace):?\*?\*?\s+(\S+)/mi,
 		);
 		if (repoLineMatch) {
 			const candidate = repoLineMatch[1].trim().toLowerCase();
@@ -220,10 +220,10 @@ export function parsePromptForOrchestrator(
 		}
 	}
 
-	// Priority 2 (fallback): Inline "**Repo:** <id>" anywhere in content
+	// Priority 2 (fallback): Inline "**Repo:** <id>" or "**Workspace:** <id>" anywhere in content
 	if (!promptRepoId) {
 		const inlineRepoMatch = content.match(
-			/^\*\*Repo:\*\*\s+(\S+)/m,
+			/^\*\*(?:Repo|Workspace):\*\*\s+(\S+)/m,
 		);
 		if (inlineRepoMatch) {
 			const candidate = inlineRepoMatch[1].trim().toLowerCase();


### PR DESCRIPTION
The task routing parser only recognized **Repo:** and ## Execution Target
with 'Repo:' lines. Tasks using **Workspace:** (a common alternative,
used in our own templates) were not routed, falling back to default_repo.

This caused workers to run in the wrong repo's worktree — e.g., a task
targeting web-client would execute in shared-libs, and the worker would
spend its context budget looking at the wrong files.

Now recognizes both **Repo:** and **Workspace:** for inline routing,
and both 'Repo:' and 'Workspace:' in ## Execution Target sections.
