### PR TITLE
feat: infer task repo from file scope paths in workspace mode

### DIFF
--- a/extensions/taskplane/discovery.ts
+++ b/extensions/taskplane/discovery.ts
@@ -928,7 +928,40 @@ export function resolveTaskRouting(
 			}
 		}
 
-		// Precedence 3: workspace default repo
+		// Precedence 3: file scope inference — match file path prefixes against
+		// known workspace repo IDs. If file scope entries like "web-client/src/..."
+		// start with a repo name, route the task to that repo.
+		if (!resolvedId && task.fileScope && task.fileScope.length > 0) {
+			const repoIds = [...validRepoIds.keys()];
+			const repoCounts = new Map<string, number>();
+			for (const filePath of task.fileScope) {
+				const normalized = filePath.replace(/\\/g, "/");
+				for (const repoId of repoIds) {
+					if (normalized.startsWith(repoId + "/") || normalized === repoId) {
+						repoCounts.set(repoId, (repoCounts.get(repoId) || 0) + 1);
+						break; // first matching repo wins for this path
+					}
+				}
+			}
+			// Use the repo with the most file scope matches (majority vote)
+			if (repoCounts.size === 1) {
+				resolvedId = repoCounts.keys().next().value!;
+				source = "file-scope";
+			} else if (repoCounts.size > 1) {
+				// Multiple repos in file scope — pick the one with most entries.
+				// (Future: #51 will handle multi-repo tasks properly)
+				let maxCount = 0;
+				for (const [repoId, count] of repoCounts) {
+					if (count > maxCount) {
+						maxCount = count;
+						resolvedId = repoId;
+					}
+				}
+				source = "file-scope";
+			}
+		}
+
+		// Precedence 4: workspace default repo
 		if (!resolvedId) {
 			resolvedId = workspaceConfig.routing.defaultRepo;
 			source = "default";
@@ -940,7 +973,8 @@ export function resolveTaskRouting(
 				code: "TASK_REPO_UNRESOLVED",
 				message:
 					`Task ${task.taskId} has no resolved repo. ` +
-					`Add a Repo: field to the PROMPT, set repo_id on area "${task.areaName}", ` +
+					`Add file scope paths prefixed with the repo name (e.g., "web-client/src/..."), ` +
+					`set repo_id on area "${task.areaName}", ` +
 					`or set routing.default_repo in the workspace config.`,
 				taskId: task.taskId,
 				taskPath: task.promptPath,

--- a/extensions/tests/discovery-routing.test.ts
+++ b/extensions/tests/discovery-routing.test.ts
@@ -844,6 +844,131 @@ describe("11.x: Default repo fallback when prompt + area have no repo", () => {
 	});
 });
 
+// ── 11.5x: File scope inference ──────────────────────────────────────
+
+describe("11.5x: File scope inference routes task to matching repo", () => {
+	it("11.51: single file scope entry matching a repo routes correctly", () => {
+		const workspaceConfig = makeWorkspaceConfig(
+			{
+				"api-service": { path: "/repos/api-service" },
+				"web-client": { path: "/repos/web-client" },
+				"shared-libs": { path: "/repos/shared-libs" },
+			},
+			"shared-libs",
+		);
+		const taskAreas: Record<string, TaskArea> = {
+			general: { path: "/workspace/tasks", prefix: "TP", context: "" },
+		};
+		const task = makeTask({
+			taskId: "TP-003",
+			areaName: "general",
+			fileScope: ["web-client/src/components/StatusBadge.js"],
+		});
+		const discovery = makeDiscoveryResult([task]);
+
+		const errors = resolveTaskRouting(discovery, taskAreas, workspaceConfig);
+
+		expect(errors).toHaveLength(0);
+		expect(task.resolvedRepoId).toBe("web-client");
+	});
+
+	it("11.52: multiple file scope entries all matching same repo", () => {
+		const workspaceConfig = makeWorkspaceConfig(
+			{
+				"api-service": { path: "/repos/api-service" },
+				"web-client": { path: "/repos/web-client" },
+			},
+			"api-service",
+		);
+		const taskAreas: Record<string, TaskArea> = {
+			general: { path: "/workspace/tasks", prefix: "TP", context: "" },
+		};
+		const task = makeTask({
+			taskId: "TP-005",
+			areaName: "general",
+			fileScope: ["api-service/src/middleware/logger.js", "api-service/src/utils/format.js"],
+		});
+		const discovery = makeDiscoveryResult([task]);
+
+		const errors = resolveTaskRouting(discovery, taskAreas, workspaceConfig);
+
+		expect(errors).toHaveLength(0);
+		expect(task.resolvedRepoId).toBe("api-service");
+	});
+
+	it("11.53: file scope with no matching repo falls through to default", () => {
+		const workspaceConfig = makeWorkspaceConfig(
+			{
+				"api-service": { path: "/repos/api-service" },
+				"web-client": { path: "/repos/web-client" },
+			},
+			"api-service",
+		);
+		const taskAreas: Record<string, TaskArea> = {
+			general: { path: "/workspace/tasks", prefix: "TP", context: "" },
+		};
+		const task = makeTask({
+			taskId: "TP-006",
+			areaName: "general",
+			fileScope: ["docs/README.md"], // no repo prefix match
+		});
+		const discovery = makeDiscoveryResult([task]);
+
+		const errors = resolveTaskRouting(discovery, taskAreas, workspaceConfig);
+
+		expect(errors).toHaveLength(0);
+		expect(task.resolvedRepoId).toBe("api-service"); // falls to default
+	});
+
+	it("11.54: prompt repo still wins over file scope", () => {
+		const workspaceConfig = makeWorkspaceConfig(
+			{
+				"api-service": { path: "/repos/api-service" },
+				"web-client": { path: "/repos/web-client" },
+			},
+			"api-service",
+		);
+		const taskAreas: Record<string, TaskArea> = {
+			general: { path: "/workspace/tasks", prefix: "TP", context: "" },
+		};
+		const task = makeTask({
+			taskId: "TP-007",
+			areaName: "general",
+			promptRepoId: "api-service",
+			fileScope: ["web-client/src/App.js"], // conflicts with prompt
+		});
+		const discovery = makeDiscoveryResult([task]);
+
+		const errors = resolveTaskRouting(discovery, taskAreas, workspaceConfig);
+
+		expect(errors).toHaveLength(0);
+		expect(task.resolvedRepoId).toBe("api-service"); // prompt wins
+	});
+
+	it("11.55: empty file scope falls through to default", () => {
+		const workspaceConfig = makeWorkspaceConfig(
+			{
+				"api-service": { path: "/repos/api-service" },
+			},
+			"api-service",
+		);
+		const taskAreas: Record<string, TaskArea> = {
+			general: { path: "/workspace/tasks", prefix: "TP", context: "" },
+		};
+		const task = makeTask({
+			taskId: "TP-008",
+			areaName: "general",
+			fileScope: [],
+		});
+		const discovery = makeDiscoveryResult([task]);
+
+		const errors = resolveTaskRouting(discovery, taskAreas, workspaceConfig);
+
+		expect(errors).toHaveLength(0);
+		expect(task.resolvedRepoId).toBe("api-service");
+	});
+});
+
 // ── 12.x: TASK_REPO_UNKNOWN ─────────────────────────────────────────
 
 describe("12.x: TASK_REPO_UNKNOWN when resolved ID not in workspace repos", () => {
@@ -1133,7 +1258,7 @@ describe("16.x: Routing errors appear as fatal errors in formatted output", () =
 		expect(output).toContain("❌ Errors:");
 		expect(output).toContain("TASK_REPO_UNRESOLVED");
 		// Error should include actionable guidance
-		expect(output).toContain("Repo:");
+		expect(output).toContain("file scope");
 		expect(output).toContain("repo_id");
 		expect(output).toContain("routing.default_repo");
 	});
@@ -1762,7 +1887,7 @@ describe("17.x: Actionable routing error guidance", () => {
 		expect(errors).toHaveLength(1);
 		expect(errors[0].code).toBe("TASK_REPO_UNRESOLVED");
 		// Verify the message contains actionable guidance
-		expect(errors[0].message).toContain("Add a Repo: field to the PROMPT");
+		expect(errors[0].message).toContain("file scope paths prefixed with the repo name");
 		expect(errors[0].message).toContain("set repo_id on area");
 		expect(errors[0].message).toContain("routing.default_repo");
 	});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.21.1",
+  "version": "0.21.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.21.1",
+      "version": "0.21.6",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",


### PR DESCRIPTION
New routing precedence chain:
1. PROMPT.md explicit Repo:/Workspace: (task override)
2. Task area repoId config
3. File scope inference (NEW) — match path prefixes against workspace repos
4. Workspace default_repo fallback

If a task's file scope lists 'web-client/src/StatusBadge.js', and
'web-client' is a known workspace repo, the task routes there
automatically. No PROMPT.md routing metadata required.

This eliminates the fragile dependency on authors remembering to add
routing directives. File scope is already required for affinity
grouping, so repo routing comes for free.

5 new routing tests for file scope inference.
