### PR TITLE
chore(release): v0.21.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.21.7",
+  "version": "0.21.8",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Fix: workspace mode uses worktree-relative paths — eliminates split-brain between source dir and worktree