### PR TITLE
fix: strip backticks from file scope paths before repo inference

### DIFF
--- a/extensions/taskplane/discovery.ts
+++ b/extensions/taskplane/discovery.ts
@@ -243,8 +243,12 @@ export function parsePromptForOrchestrator(
 		const scopeBody = fileScopeMatch[1].trim();
 		const scopeLines = scopeBody.split("\n");
 		for (const line of scopeLines) {
-			// "- extensions/task-orchestrator.ts" or "- .pi/task-orchestrator.yaml"
-			const trimmed = line.replace(/^[\s-*]+/, "").trim();
+			// "- extensions/task-orchestrator.ts" or "- `api-service/src/health.js`"
+			let trimmed = line.replace(/^[\s-*]+/, "").trim();
+			// Strip inline backticks: `path/to/file` → path/to/file
+			if (trimmed.startsWith("`") && trimmed.endsWith("`")) {
+				trimmed = trimmed.slice(1, -1);
+			}
 			if (trimmed && !trimmed.startsWith("#") && !trimmed.startsWith("```")) {
 				fileScope.push(trimmed);
 			}


### PR DESCRIPTION
File scope entries in PROMPT.md are commonly wrapped in backticks:
  - `api-service/src/routes/health.js`

The parser wasn't stripping them, so the path started with a backtick
and never matched any repo ID during file scope inference. Tasks
silently fell through to the default repo.
