### PR TITLE
chore(release): v0.21.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.21.8",
+  "version": "0.21.9",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Fix: strip backticks from file scope paths — routing inference now works with markdown-formatted paths