### PR TITLE
fix: address code review findings for TP-076/077/078

### DIFF
--- a/extensions/taskplane/engine.ts
+++ b/extensions/taskplane/engine.ts
@@ -1510,6 +1510,9 @@ export async function executeOrchBatch(
 						failedLane: mixedOutcomeLanes[0].laneNumber,
 						failureReason,
 					};
+					// Update the already-pushed references so persisted state reflects "partial"
+					allMergeResults[allMergeResults.length - 1] = mergeResult;
+					batchState.mergeResults[batchState.mergeResults.length - 1] = mergeResult;
 				}
 
 				// Emit overall merge result notification

--- a/extensions/taskplane/extension.ts
+++ b/extensions/taskplane/extension.ts
@@ -971,6 +971,7 @@ export function startBatchInWorker(
 				wkData.workspaceRoot,
 				wkData.agentRoot,
 				wkData.force ?? false,
+				onSupervisorAlert ?? null,
 			)
 			: () => executeOrchBatch(
 				wkData.args ?? "",
@@ -983,6 +984,8 @@ export function startBatchInWorker(
 				wsConfig,
 				wkData.workspaceRoot,
 				wkData.agentRoot,
+				null, // onEngineEvent
+				onSupervisorAlert ?? null,
 			);
 		startBatchAsync(fallbackFn, batchState, ctx, updateWidget, onTerminal);
 		return null;
@@ -2389,6 +2392,23 @@ export default function (pi: ExtensionAPI) {
 			state.failedTasks = Math.max(0, state.failedTasks - 1);
 		}
 
+		// Recompute blocked dependents — the retried task is no longer a failure,
+		// so tasks that were blocked solely by it should be unblocked.
+		const remainingFailures = new Set<string>();
+		for (const t of state.tasks) {
+			if (t.status === "failed" || t.status === "stalled") {
+				remainingFailures.add(t.taskId);
+			}
+		}
+		if (orchBatchState.dependencyGraph && orchBatchState.batchId === state.batchId) {
+			const newBlocked = computeTransitiveDependents(remainingFailures, orchBatchState.dependencyGraph);
+			state.blockedTaskIds = [...newBlocked].sort();
+			state.blockedTasks = newBlocked.size;
+		} else if (remainingFailures.size === 0) {
+			state.blockedTaskIds = [];
+			state.blockedTasks = 0;
+		}
+
 		// TP-077 R001-3: Phase transition — terminal "failed" → "stopped" (resumable with force)
 		// "stopped" and "paused" are kept as-is (already resumable).
 		if (state.phase === "failed") {
@@ -2408,7 +2428,8 @@ export default function (pi: ExtensionAPI) {
 		// Sync in-memory state if batch IDs match
 		if (orchBatchState.batchId === state.batchId) {
 			orchBatchState.failedTasks = state.failedTasks;
-			orchBatchState.blockedTaskIds.delete(taskId);
+			orchBatchState.blockedTasks = state.blockedTasks;
+			orchBatchState.blockedTaskIds = new Set(state.blockedTaskIds);
 			if (state.phase === "stopped" && orchBatchState.phase === "failed") {
 				orchBatchState.phase = "stopped";
 			}
@@ -2617,6 +2638,13 @@ export default function (pi: ExtensionAPI) {
 			return `✅ Wave ${targetWave} merge already succeeded. No force merge needed.`;
 		}
 
+		// Only allow force merge for mixed-outcome failures (partial status).
+		// Other failures (conflicts, build failures) need different resolution.
+		if (mergeEntry.status !== "partial") {
+			return `❌ Wave ${targetWave} merge failed with status "${mergeEntry.status}": ${mergeEntry.failureReason || "unknown reason"}.\n` +
+				`Force merge only applies to mixed-outcome lanes (partial). This failure needs manual resolution.`;
+		}
+
 		// Collect tasks in the target wave
 		const waveTasks = state.wavePlan[targetWave] ?? [];
 		const failedInWave: string[] = [];
@@ -2677,18 +2705,13 @@ export default function (pi: ExtensionAPI) {
 				`Use skipFailed=true to skip them, or use orch_skip_task to skip them individually first.`;
 		}
 
-		// Update the merge result to "succeeded"
-		state.mergeResults[mergeResultIdx] = {
-			...mergeEntry,
-			status: "succeeded",
-			failedLane: null,
-			failureReason: null,
-		};
+		// Clear the failed merge result so resume will re-attempt the merge.
+		// With failed tasks now skipped, the merge should succeed (no mixed outcomes).
+		state.mergeResults.splice(mergeResultIdx, 1);
 
-		// Phase transition — terminal "failed" → "stopped" (resumable with force)
-		if (state.phase === "failed") {
-			state.phase = "stopped";
-		}
+		// Phase transition to "paused" so orch_resume will re-run the merge phase.
+		// "paused" is the standard resumable state (not "stopped" which needs force).
+		state.phase = "paused";
 
 		// Clear merge-related errors
 		state.errors = state.errors.filter(e => !e.includes("mixed") && !e.includes("merge") && !e.includes("Merge"));
@@ -2710,28 +2733,24 @@ export default function (pi: ExtensionAPI) {
 			orchBatchState.skippedTasks = state.skippedTasks ?? 0;
 			orchBatchState.blockedTasks = state.blockedTasks;
 			orchBatchState.blockedTaskIds = new Set(state.blockedTaskIds);
-			if (state.phase === "stopped" && orchBatchState.phase === "failed") {
-				orchBatchState.phase = "stopped";
-			}
+			orchBatchState.phase = "paused";
 		}
 
 		updateOrchWidget();
 
 		const lines = [
-			`✅ Force merge applied for wave ${targetWave}.`,
-			`   Merge result updated: partial → succeeded`,
+			`✅ Force merge prepared for wave ${targetWave}.`,
+			`   Failed merge result cleared — resume will re-attempt the merge.`,
 			`   Succeeded tasks: ${succeededInWave.join(", ")}`,
 		];
 
 		if (skippedTasks.length > 0) {
-			lines.push(`   Skipped tasks: ${skippedTasks.join(", ")}`);
+			lines.push(`   Skipped tasks (were failed): ${skippedTasks.join(", ")}`);
 		}
 
-		lines.push(`   Batch phase: ${state.phase} | Failed: ${state.failedTasks}, Skipped: ${state.skippedTasks ?? 0} / ${state.totalTasks} total`);
+		lines.push(`   Batch phase: paused | Failed: ${state.failedTasks}, Skipped: ${state.skippedTasks ?? 0} / ${state.totalTasks} total`);
 
-		const resumeHint = state.phase === "stopped"
-			? "Use orch_resume(force=true) to continue the batch."
-			: "Use orch_resume() to continue the batch.";
+		const resumeHint = "Use orch_resume() to re-run the merge with failed tasks skipped.";
 		lines.push(`   ${resumeHint}`);
 
 		return lines.join("\n");

--- a/extensions/taskplane/resume.ts
+++ b/extensions/taskplane/resume.ts
@@ -1713,6 +1713,8 @@ export async function resumeOrchBatch(
 						`Lane(s) ${mixedIds} contain both succeeded and failed tasks. ` +
 						`Automatic partial-branch merge is disabled to avoid dropping succeeded commits.`;
 					mergeResult = { ...mergeResult, status: "partial", failedLane: mixedOutcomeLanes[0].laneNumber, failureReason };
+					// Update the already-pushed reference so persisted state reflects "partial"
+					batchState.mergeResults[batchState.mergeResults.length - 1] = mergeResult;
 				}
 
 				// TP-032 R006-3: Exclude verification_new_failure lanes from success count

--- a/extensions/tests/supervisor-force-merge.test.ts
+++ b/extensions/tests/supervisor-force-merge.test.ts
@@ -633,10 +633,11 @@ describe("6.x — doOrchForceMerge implementation verification", () => {
 		expect(fnBlock).toContain("Skipped by orch_force_merge");
 	});
 
-	it("6.6 — doOrchForceMerge updates merge result status to succeeded", () => {
+	it("6.6 — doOrchForceMerge clears merge result and sets phase to paused for re-merge", () => {
 		const fnStart = extensionSource.indexOf("function doOrchForceMerge(");
 		const fnBlock = extensionSource.slice(fnStart, fnStart + 7000);
-		expect(fnBlock).toContain('status: "succeeded"');
+		expect(fnBlock).toContain("mergeResults.splice(");
+		expect(fnBlock).toContain('"paused"');
 	});
 
 	it("6.7 — doOrchForceMerge persists state with saveBatchState", () => {
@@ -652,11 +653,17 @@ describe("6.x — doOrchForceMerge implementation verification", () => {
 		expect(fnBlock).toContain("orchBatchState.failedTasks");
 	});
 
-	it("6.9 — doOrchForceMerge handles phase transition from failed to stopped", () => {
+	it("6.9 — doOrchForceMerge sets phase to paused for re-merge", () => {
 		const fnStart = extensionSource.indexOf("function doOrchForceMerge(");
 		const fnBlock = extensionSource.slice(fnStart, fnStart + 7000);
-		expect(fnBlock).toContain('"failed"');
-		expect(fnBlock).toContain('"stopped"');
+		expect(fnBlock).toContain('"paused"');
+	});
+
+	it("6.11 — doOrchForceMerge only allows partial (mixed-outcome) merge failures", () => {
+		const fnStart = extensionSource.indexOf("function doOrchForceMerge(");
+		const fnBlock = extensionSource.slice(fnStart, fnStart + 7000);
+		expect(fnBlock).toContain('"partial"');
+		expect(fnBlock).toContain("only applies to mixed-outcome");
 	});
 
 	it("6.10 — doOrchForceMerge provides resume hint in output", () => {

--- a/extensions/tests/supervisor-recovery-tools.test.ts
+++ b/extensions/tests/supervisor-recovery-tools.test.ts
@@ -634,7 +634,7 @@ describe("5.x — Implementation correctness (source-based)", () => {
 
 	it("5.2 — doOrchRetryTask saves modified state", () => {
 		const idx = extensionSource.indexOf("function doOrchRetryTask(");
-		const block = extensionSource.slice(idx, idx + 2500);
+		const block = extensionSource.slice(idx, idx + 5000);
 		expect(block).toContain("saveBatchState(");
 	});
 
@@ -690,7 +690,7 @@ describe("5.x — Implementation correctness (source-based)", () => {
 	it("5.10 — both tools update in-memory orchBatchState for widget sync", () => {
 		const retryIdx = extensionSource.indexOf("function doOrchRetryTask(");
 		// Search a larger block to ensure we capture updateOrchWidget call
-		const retryBlock = extensionSource.slice(retryIdx, retryIdx + 3500);
+		const retryBlock = extensionSource.slice(retryIdx, retryIdx + 5000);
 		expect(retryBlock).toContain("updateOrchWidget()");
 
 		const skipIdx = extensionSource.indexOf("function doOrchSkipTask(");
@@ -723,7 +723,7 @@ describe("5.x — Implementation correctness (source-based)", () => {
 
 	it("5.14 — doOrchRetryTask transitions failed phase to stopped", () => {
 		const idx = extensionSource.indexOf("function doOrchRetryTask(");
-		const block = extensionSource.slice(idx, idx + 2500);
+		const block = extensionSource.slice(idx, idx + 5000);
 		// Should transition "failed" → "stopped" for resumability
 		expect(block).toContain('"failed"');
 		expect(block).toContain('"stopped"');
@@ -736,9 +736,17 @@ describe("5.x — Implementation correctness (source-based)", () => {
 		expect(block).toContain('"stopped"');
 	});
 
-	it("5.16 — doOrchRetryTask clears exitDiagnostic and partial progress fields", () => {
+	it("5.16 — doOrchRetryTask recomputes blocked dependents", () => {
 		const idx = extensionSource.indexOf("function doOrchRetryTask(");
-		const block = extensionSource.slice(idx, idx + 2500);
+		const block = extensionSource.slice(idx, idx + 5000);
+		expect(block).toContain("computeTransitiveDependents");
+		expect(block).toContain("remainingFailures");
+		expect(block).toContain("blockedTaskIds");
+	});
+
+	it("5.17 — doOrchRetryTask clears exitDiagnostic and partial progress fields", () => {
+		const idx = extensionSource.indexOf("function doOrchRetryTask(");
+		const block = extensionSource.slice(idx, idx + 5000);
 		expect(block).toContain("exitDiagnostic");
 		expect(block).toContain("partialProgressCommits");
 		expect(block).toContain("partialProgressBranch");


### PR DESCRIPTION
Five fixes from external code review:

1. [High] orch_force_merge now clears the failed merge result and sets
   phase to 'paused' so orch_resume re-runs the actual git merge.
   Previously it only mutated state without performing a merge.

2. [High] Merge result push-then-reassign stale reference fixed in both
   engine.ts and resume.ts. After reassigning mergeResult to a new
   object with status 'partial', the array entry is now updated too.

3. [High] orch_force_merge validation tightened — only allows 'partial'
   (mixed-outcome) merge failures. Other failures (conflicts, build)
   are rejected with guidance.

4. [Medium] orch_retry_task now recomputes blocked dependents using
   computeTransitiveDependents, matching the skip path behavior.

5. [Medium] Fallback execution path (main-thread) now passes the
   onSupervisorAlert callback to executeOrchBatch/resumeOrchBatch.
