### PR TITLE
fix: force merge hardening — mixed-outcome validation, phase checks, resume sync

### DIFF
--- a/extensions/taskplane/engine.ts
+++ b/extensions/taskplane/engine.ts
@@ -1570,6 +1570,10 @@ export async function executeOrchBatch(
 						`Automatic partial-branch merge is disabled to avoid dropping succeeded commits.`,
 					totalDurationMs: 0,
 				};
+				// Keep mergeResults in sync even when no mergeable lane exists.
+				// Downstream retry/update paths assume the current wave has an entry.
+				allMergeResults.push(mergeResult);
+				batchState.mergeResults.push(mergeResult);
 				onNotify(
 					ORCH_MESSAGES.orchMergeFailed(waveIdx + 1, mergeResult.failedLane, mergeResult.failureReason || "unknown"),
 					"error",

--- a/extensions/taskplane/extension.ts
+++ b/extensions/taskplane/extension.ts
@@ -25,7 +25,6 @@ import { getCurrentBranch, runGit } from "./git.ts";
 import { hasConfigFiles, resolveConfigRoot, loadOrchestratorConfig, loadSupervisorConfig, loadTaskRunnerConfig } from "./config.ts";
 import { resolveOperatorId } from "./naming.ts";
 import { reconstructAllocatedLanes, resumeOrchBatch } from "./resume.ts";
-import { mergeWaveByRepo } from "./merge.ts";
 import { buildExecutionContext } from "./workspace.ts";
 import { openSettingsTui } from "./settings-tui.ts";
 import { loadProjectConfig } from "./config-loader.ts";
@@ -2579,15 +2578,17 @@ export default function (pi: ExtensionAPI) {
 	// ── TP-078: Force Merge Tool ─────────────────────────────────────
 
 	/**
-	 * Core logic for orch_force_merge. Unblocks a paused batch with mixed-outcome lanes
-	 * by skipping failed tasks and updating the merge result to "succeeded".
+	 * Core logic for orch_force_merge. Unblocks mixed-outcome merge failures by
+	 * skipping failed tasks, clearing the failed merge entry, and pausing so
+	 * resume re-attempts the real merge.
 	 *
 	 * This is the supervisor's escape hatch when a wave merge was rejected because
 	 * some lanes had both succeeded and failed tasks (mixed-outcome). The tool:
-	 * 1. Validates the batch is paused/stopped/failed with a "partial" merge result
-	 * 2. If skipFailed=true, marks all failed/stalled tasks in the wave as "skipped"
-	 * 3. Updates the merge result entry to "succeeded"
-	 * 4. Allows orch_resume to continue the batch from the next wave
+	 * 1. Validates the batch is paused/stopped/failed and the wave merge status is "partial"
+	 * 2. Verifies the partial failure is specifically the mixed-outcome rejection
+	 * 3. If skipFailed=true, marks failed/stalled tasks in the wave as "skipped"
+	 * 4. Clears the failed merge entry and sets phase to "paused"
+	 * 5. `orch_resume()` re-runs the merge using real git merge logic
 	 */
 	function doOrchForceMerge(waveIndex: number | undefined, skipFailed: boolean, ctx: ExtensionContext): string {
 		// Reject while engine is actively running
@@ -2608,6 +2609,13 @@ export default function (pi: ExtensionAPI) {
 
 		if (!state) {
 			return "❌ No batch state found. There is no active or recent batch to modify.";
+		}
+
+		// Force-merge is a recovery action for non-running failed/paused batches.
+		const resumablePhases = new Set(["paused", "stopped", "failed"]);
+		if (!resumablePhases.has(state.phase)) {
+			return `❌ Cannot force merge when batch phase is "${state.phase}". ` +
+				`Force merge is only valid for paused/stopped/failed batches.`;
 		}
 
 		// Determine target wave index (0-based). Default to currentWaveIndex.
@@ -2639,10 +2647,22 @@ export default function (pi: ExtensionAPI) {
 		}
 
 		// Only allow force merge for mixed-outcome failures (partial status).
-		// Other failures (conflicts, build failures) need different resolution.
+		// Other failures (conflicts, build failures, repo divergence) need different resolution.
 		if (mergeEntry.status !== "partial") {
 			return `❌ Wave ${targetWave} merge failed with status "${mergeEntry.status}": ${mergeEntry.failureReason || "unknown reason"}.\n` +
 				`Force merge only applies to mixed-outcome lanes (partial). This failure needs manual resolution.`;
+		}
+
+		const failureReason = mergeEntry.failureReason || "";
+		const failureReasonLower = failureReason.toLowerCase();
+		const isMixedOutcomePartial =
+			failureReasonLower.includes("both succeeded and failed tasks") ||
+			failureReasonLower.includes("mixed-outcome") ||
+			failureReasonLower.includes("automatic partial-branch merge is disabled");
+		if (!isMixedOutcomePartial) {
+			return `❌ Wave ${targetWave} has partial merge status, but the failure reason does not match mixed-outcome lanes.\n` +
+				`Reason: ${failureReason || "unknown"}\n` +
+				`Force merge is only valid for the mixed-outcome lane guard. Resolve this merge failure manually.`;
 		}
 
 		// Collect tasks in the target wave

--- a/extensions/taskplane/resume.ts
+++ b/extensions/taskplane/resume.ts
@@ -1377,6 +1377,9 @@ export async function resumeOrchBatch(
 	// For waves where some tasks are already done, we filter them out.
 
 	let preserveWorktreesForResume = false;
+	const persistedStatusByTaskId = new Map(
+		persistedState.tasks.map((task) => [task.taskId, task.status] as const),
+	);
 
 	for (let waveIdx = resumePoint.resumeWaveIndex; waveIdx < persistedState.wavePlan.length; waveIdx++) {
 		// Check pause signal
@@ -1390,10 +1393,12 @@ export async function resumeOrchBatch(
 		batchState.currentWaveIndex = waveIdx;
 		persistRuntimeState("wave-index-change", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discovery, stateRoot);
 
-		// Get wave tasks, filtering out completed/failed/blocked ones.
+		// Get wave tasks, filtering out completed/failed/skipped/blocked ones.
+		// Persisted "skipped" tasks are terminal and must never be re-executed.
 		let waveTasks = persistedState.wavePlan[waveIdx].filter(
 			taskId => !completedTaskSet.has(taskId) &&
 				!failedTaskSet.has(taskId) &&
+				persistedStatusByTaskId.get(taskId) !== "skipped" &&
 				!batchState.blockedTaskIds.has(taskId),
 		);
 
@@ -1425,26 +1430,71 @@ export async function resumeOrchBatch(
 				);
 				const mergeRetryLanes = reconstructAllocatedLanes(waveLaneRecords, persistedState.tasks);
 
-				// Build synthetic WaveExecutionResult with succeeded tasks
+				// Build synthetic WaveExecutionResult from persisted terminal task states.
+				// Crucial for orch_force_merge: tasks intentionally marked "skipped" must
+				// remain skipped here (not failed), otherwise mixed-outcome detection would
+				// trigger again and block the forced merge recovery path.
 				const succeededTaskIds = persistedState.wavePlan[waveIdx].filter(
 					taskId => completedTaskSet.has(taskId),
 				);
-				const syntheticLaneResults: LaneExecutionResult[] = mergeRetryLanes.map(lane => ({
-					laneNumber: lane.laneNumber,
-					laneId: lane.laneId,
-					tasks: lane.tasks.map(t => ({
-						taskId: t.taskId,
-						status: (completedTaskSet.has(t.taskId) ? "succeeded" : "failed") as LaneTaskStatus,
+				const skippedTaskIds = persistedState.wavePlan[waveIdx].filter(
+					taskId => persistedStatusByTaskId.get(taskId) === "skipped",
+				);
+				const failedTaskIds = persistedState.wavePlan[waveIdx].filter(
+					taskId => {
+						const status = persistedStatusByTaskId.get(taskId);
+						return status === "failed" || status === "stalled";
+					},
+				);
+
+				const syntheticLaneResults: LaneExecutionResult[] = mergeRetryLanes.map((lane) => {
+					const laneTasks = lane.tasks.map((t) => {
+						const persistedStatus = persistedStatusByTaskId.get(t.taskId);
+						let status: LaneTaskStatus;
+						if (completedTaskSet.has(t.taskId) || persistedStatus === "succeeded") {
+							status = "succeeded";
+						} else if (persistedStatus === "skipped") {
+							status = "skipped";
+						} else if (persistedStatus === "failed") {
+							status = "failed";
+						} else if (persistedStatus === "stalled") {
+							status = "stalled";
+						} else {
+							status = "failed";
+						}
+
+						return {
+							taskId: t.taskId,
+							status,
+							startTime: Date.now(),
+							endTime: Date.now(),
+							exitReason:
+								status === "succeeded" ? "Task completed (merge retry)"
+									: status === "skipped" ? "Task skipped (merge retry)"
+									: status === "stalled" ? "Task stalled (merge retry)"
+									: "Task failed (merge retry)",
+							sessionName: lane.tmuxSessionName,
+							doneFileFound: status === "succeeded",
+						};
+					});
+
+					const laneHasHardFailure = laneTasks.some(
+						(t) => t.status === "failed" || t.status === "stalled",
+					);
+					const laneHasSucceeded = laneTasks.some((t) => t.status === "succeeded");
+					const overallStatus = laneHasHardFailure
+						? (laneHasSucceeded ? "partial" : "failed")
+						: "succeeded";
+
+					return {
+						laneNumber: lane.laneNumber,
+						laneId: lane.laneId,
+						tasks: laneTasks,
+						overallStatus,
 						startTime: Date.now(),
 						endTime: Date.now(),
-						exitReason: completedTaskSet.has(t.taskId) ? "Task completed (merge retry)" : "Task failed (merge retry)",
-						sessionName: lane.tmuxSessionName,
-						doneFileFound: completedTaskSet.has(t.taskId),
-					})),
-					overallStatus: lane.tasks.every(t => completedTaskSet.has(t.taskId)) ? "succeeded" as const : "partial" as const,
-					startTime: Date.now(),
-					endTime: Date.now(),
-				}));
+					};
+				});
 
 				const syntheticWaveResult: WaveExecutionResult = {
 					waveIndex: waveIdx + 1,
@@ -1453,8 +1503,8 @@ export async function resumeOrchBatch(
 					laneResults: syntheticLaneResults,
 					policyApplied: orchConfig.failure.on_task_failure,
 					stoppedEarly: false,
-					failedTaskIds: [],
-					skippedTaskIds: [],
+					failedTaskIds,
+					skippedTaskIds,
 					succeededTaskIds,
 					blockedTaskIds: [],
 					laneCount: mergeRetryLanes.length,
@@ -1754,6 +1804,9 @@ export async function resumeOrchBatch(
 						`Automatic partial-branch merge is disabled to avoid dropping succeeded commits.`,
 					totalDurationMs: 0,
 				};
+				// Keep mergeResults in sync even when no mergeable lane exists.
+				// Downstream retry/update paths assume the current wave has an entry.
+				batchState.mergeResults.push(mergeResult);
 				onNotify(
 					ORCH_MESSAGES.orchMergeFailed(waveIdx + 1, mergeResult.failedLane, mergeResult.failureReason || "unknown"),
 					"error",

--- a/extensions/tests/supervisor-force-merge.test.ts
+++ b/extensions/tests/supervisor-force-merge.test.ts
@@ -8,13 +8,14 @@
  * - Force merge: rejects when no merge failure exists
  * - Force merge: rejects when batch is actively running
  * - Force merge: rejects invalid wave index
- * - Force merge: succeeds with partial merge result and skipFailed=true
+ * - Force merge: succeeds with mixed-outcome partial merge result and skipFailed=true
  * - Force merge: requires skipFailed when failed tasks exist
- * - Force merge: updates merge result from partial to succeeded
+ * - Force merge: clears failed merge result so resume re-attempts real merge
+ * - Force merge: sets phase to paused for resumable recovery
  * - Force merge: adjusts counters (failed → skipped)
  * - Force merge: handles case where merge already succeeded
  * - Force merge: handles case with no succeeded tasks
- * - Persisted state round-trip: load → force merge → save → reload
+ * - Persisted state round-trip: load → force merge prep → save → reload
  * - Recovery playbooks exist in supervisor-primer.md (source-based)
  */
 import { describe, it } from "node:test";
@@ -119,6 +120,8 @@ function buildTestPersistedState(overrides?: Partial<PersistedBatchState>): Pers
 }
 
 const extensionSource = readSource("extension.ts");
+const engineSource = readSource("engine.ts");
+const resumeSource = readSource("resume.ts");
 const primerSource = readSource("supervisor-primer.md");
 
 // ══════════════════════════════════════════════════════════════════════
@@ -243,7 +246,7 @@ describe("2.x — orch_force_merge validation logic (persisted state)", () => {
 // 3.x — Force merge execution logic
 // ══════════════════════════════════════════════════════════════════════
 
-describe("3.x — orch_force_merge execution logic (persisted state)", () => {
+describe("3.x — orch_force_merge recovery prep logic (persisted state)", () => {
 	it("3.1 — force merge with skipFailed marks failed tasks as skipped", () => {
 		const state = buildTestPersistedState();
 		const waveTasks = state.wavePlan[0];
@@ -269,44 +272,35 @@ describe("3.x — orch_force_merge execution logic (persisted state)", () => {
 		expect(state.skippedTasks).toBe(1);
 	});
 
-	it("3.2 — force merge updates merge result from partial to succeeded", () => {
+	it("3.2 — force merge clears partial merge result so resume re-attempts merge", () => {
 		const state = buildTestPersistedState();
 		const mergeEntry = state.mergeResults[0];
 		expect(mergeEntry.status).toBe("partial");
 
 		// Simulate doOrchForceMerge
-		state.mergeResults[0] = {
-			...mergeEntry,
-			status: "succeeded",
-			failedLane: null,
-			failureReason: null,
-		};
+		state.mergeResults.splice(0, 1);
 
-		expect(state.mergeResults[0].status).toBe("succeeded");
-		expect(state.mergeResults[0].failedLane).toBeNull();
-		expect(state.mergeResults[0].failureReason).toBeNull();
+		expect(state.mergeResults.length).toBe(0);
 	});
 
-	it("3.3 — force merge transitions phase from failed to stopped", () => {
+	it("3.3 — force merge transitions phase from failed to paused", () => {
 		const state = buildTestPersistedState({ phase: "failed" });
 		expect(state.phase).toBe("failed");
 
 		// Simulate doOrchForceMerge phase transition
-		if (state.phase === "failed") {
-			state.phase = "stopped";
-		}
+		state.phase = "paused";
 
-		expect(state.phase).toBe("stopped");
+		expect(state.phase).toBe("paused");
 	});
 
-	it("3.4 — force merge leaves stopped/paused phase as-is", () => {
+	it("3.4 — force merge normalizes stopped/failed to paused for resume", () => {
 		const stoppedState = buildTestPersistedState({ phase: "stopped" });
-		if (stoppedState.phase === "failed") stoppedState.phase = "stopped";
-		expect(stoppedState.phase).toBe("stopped");
+		stoppedState.phase = "paused";
+		expect(stoppedState.phase).toBe("paused");
 
-		const pausedState = buildTestPersistedState({ phase: "paused" });
-		if (pausedState.phase === "failed") pausedState.phase = "stopped";
-		expect(pausedState.phase).toBe("paused");
+		const failedState = buildTestPersistedState({ phase: "failed" });
+		failedState.phase = "paused";
+		expect(failedState.phase).toBe("paused");
 	});
 
 	it("3.5 — force merge adjusts counters correctly with multiple failed tasks", () => {
@@ -415,7 +409,7 @@ describe("3.x — orch_force_merge execution logic (persisted state)", () => {
 // ══════════════════════════════════════════════════════════════════════
 
 describe("4.x — orch_force_merge persisted state round-trip", () => {
-	it("4.1 — force merge persists state round-trip (save → load → modify → save → load)", () => {
+	it("4.1 — force merge prep persists state round-trip (save → load → modify → save → load)", () => {
 		const tempDir = makeTempDir();
 		try {
 			const state = buildTestPersistedState();
@@ -435,13 +429,9 @@ describe("4.x — orch_force_merge persisted state round-trip", () => {
 			loaded.failedTasks = Math.max(0, loaded.failedTasks - 1);
 			loaded.skippedTasks = (loaded.skippedTasks ?? 0) + 1;
 
-			// Update merge result
-			loaded.mergeResults[0] = {
-				...loaded.mergeResults[0],
-				status: "succeeded",
-				failedLane: null,
-				failureReason: null,
-			};
+			// Clear failed merge result and set paused so resume re-runs real merge
+			loaded.mergeResults.splice(0, 1);
+			loaded.phase = "paused";
 
 			loaded.updatedAt = Date.now();
 			saveBatchState(JSON.stringify(loaded, null, 2), tempDir);
@@ -453,9 +443,8 @@ describe("4.x — orch_force_merge persisted state round-trip", () => {
 			expect(skippedTask.exitReason).toBe("Skipped by orch_force_merge");
 			expect(reloaded.failedTasks).toBe(0);
 			expect(reloaded.skippedTasks).toBe(1);
-			expect(reloaded.mergeResults[0].status).toBe("succeeded");
-			expect(reloaded.mergeResults[0].failedLane).toBeNull();
-			expect(reloaded.mergeResults[0].failureReason).toBeNull();
+			expect(reloaded.phase).toBe("paused");
+			expect(reloaded.mergeResults.length).toBe(0);
 		} finally {
 			rmSync(tempDir, { recursive: true, force: true });
 		}
@@ -659,16 +648,59 @@ describe("6.x — doOrchForceMerge implementation verification", () => {
 		expect(fnBlock).toContain('"paused"');
 	});
 
-	it("6.11 — doOrchForceMerge only allows partial (mixed-outcome) merge failures", () => {
+	it("6.10 — doOrchForceMerge only allows partial (mixed-outcome) merge failures", () => {
 		const fnStart = extensionSource.indexOf("function doOrchForceMerge(");
 		const fnBlock = extensionSource.slice(fnStart, fnStart + 7000);
 		expect(fnBlock).toContain('"partial"');
 		expect(fnBlock).toContain("only applies to mixed-outcome");
 	});
 
-	it("6.10 — doOrchForceMerge provides resume hint in output", () => {
+	it("6.11 — doOrchForceMerge provides resume hint in output", () => {
 		const fnStart = extensionSource.indexOf("function doOrchForceMerge(");
 		const fnBlock = extensionSource.slice(fnStart, fnStart + 7000);
 		expect(fnBlock).toContain("orch_resume");
+	});
+
+	it("6.12 — doOrchForceMerge requires a resumable batch phase", () => {
+		const fnStart = extensionSource.indexOf("function doOrchForceMerge(");
+		const fnBlock = extensionSource.slice(fnStart, fnStart + 7000);
+		expect(fnBlock).toContain("resumablePhases");
+		expect(fnBlock).toContain("paused");
+		expect(fnBlock).toContain("stopped");
+		expect(fnBlock).toContain("failed");
+	});
+
+	it("6.13 — doOrchForceMerge validates partial reason matches mixed-outcome guard", () => {
+		const fnStart = extensionSource.indexOf("function doOrchForceMerge(");
+		const fnBlock = extensionSource.slice(fnStart, fnStart + 7000);
+		expect(fnBlock).toContain("both succeeded and failed tasks");
+		expect(fnBlock).toContain("automatic partial-branch merge is disabled");
+		expect(fnBlock).toContain("does not match mixed-outcome lanes");
+	});
+});
+
+// ══════════════════════════════════════════════════════════════════════
+// 7.x — Follow-up regression guards (engine/resume wiring)
+// ══════════════════════════════════════════════════════════════════════
+
+describe("7.x — Follow-up regression guards", () => {
+	it("7.1 — engine persists partial merge result for mixed-outcome/no-mergeable branch", () => {
+		expect(engineSource).toContain("Keep mergeResults in sync even when no mergeable lane exists");
+		expect(engineSource).toContain("allMergeResults.push(mergeResult)");
+		expect(engineSource).toContain("batchState.mergeResults.push(mergeResult)");
+	});
+
+	it("7.2 — resume persists partial merge result for mixed-outcome/no-mergeable branch", () => {
+		expect(resumeSource).toContain("Keep mergeResults in sync even when no mergeable lane exists");
+		expect(resumeSource).toContain("batchState.mergeResults.push(mergeResult)");
+	});
+
+	it("7.3 — resume excludes persisted skipped tasks from wave execution", () => {
+		expect(resumeSource).toContain("persistedStatusByTaskId.get(taskId) !== \"skipped\"");
+	});
+
+	it("7.4 — resume synthetic merge retry preserves skipped task status", () => {
+		expect(resumeSource).toContain("Task skipped (merge retry)");
+		expect(resumeSource).toContain("status === \"skipped\"");
 	});
 });


### PR DESCRIPTION
- engine.ts: push mergeResult for all-mixed-outcome waves (no mergeable lanes)
- extension.ts: remove unused mergeWaveByRepo import, add phase validation
  (only paused/stopped/failed), verify partial failure is specifically
  mixed-outcome (not other partial failures), update doc comments
- resume.ts: align mixed-outcome handling with engine.ts fixes
- Tests updated: 6 new/revised assertions
