### PR TITLE
feat: add Biome linting to CI (non-blocking)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
       - name: Install extension dependencies
         run: npm ci --prefix extensions
 
+      - name: Lint (Biome)
+        continue-on-error: true
+        run: npx @biomejs/biome@2 lint --max-diagnostics=50 --reporter=github .
+
       - name: Run tests
         run: |
           cd extensions

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
+  "files": {
+    "includes": ["extensions/**/*.ts"],
+    "experimentalScannerIgnores": ["extensions/tests/**", "node_modules/**"]
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "off",
+        "noAssignInExpressions": "off"
+      },
+      "complexity": {
+        "noForEach": "off",
+        "noExcessiveCognitiveComplexity": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "off",
+        "useConst": "off",
+        "noParameterAssign": "off",
+        "useDefaultParameterLast": "off",
+        "noUnusedTemplateLiteral": "off"
+      },
+      "correctness": {
+        "noUnusedVariables": "warn",
+        "noUnusedImports": "warn"
+      },
+      "performance": {
+        "noDelete": "off"
+      }
+    }
+  },
+  "formatter": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
Adds Biome v2 linter to CI pipeline as a non-blocking step
(continue-on-error: true). First run baseline:
- 6 errors (untyped lets, intentional regex, duplicate declarations)
- 244 warnings (unused variables/imports)
- 459 infos

Formatter disabled — lint only. Tests excluded.
Blocking enforcement to be enabled after baseline cleanup.
