### PR TITLE
fix: prevent empty task completions — 3-layer defense

### DIFF
--- a/extensions/task-runner.ts
+++ b/extensions/task-runner.ts
@@ -2973,8 +2973,35 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 		} else {
-			// ── Quality Gate Disabled (default) ──────────────────────
-			// Unchanged behavior — create .DONE immediately.
+			// ── Empty completion guard ────────────────────────────────
+			// Detect tasks where the worker checked off STATUS.md without
+			// modifying any source files. This catches "shortcut" completions
+			// where the worker concludes work is "already done" without
+			// implementing anything.
+			if (isOrchestratedMode()) {
+				try {
+					const diffResult = spawnSync("git", ["diff", "--name-only", "HEAD"], {
+						cwd: task.taskFolder, encoding: "utf-8", timeout: 10_000,
+					});
+					const changedFiles = (diffResult.stdout || "").split("\n").filter(Boolean);
+					const sourceChanges = changedFiles.filter(f =>
+						!f.endsWith("STATUS.md") && !f.endsWith(".DONE") &&
+						!f.includes(".reviews/") && !f.endsWith("dependencies.json")
+					);
+					if (sourceChanges.length === 0) {
+						logExecution(statusPath, "⚠️ Empty completion",
+							"Worker marked all steps complete but no source files were modified. " +
+							"Only STATUS.md changes detected. This may indicate the worker shortcut " +
+							"the task without implementing. .DONE will still be created, but this " +
+							"should be investigated.");
+						console.error(`[task-runner] WARNING: Task ${task.taskId} completed with zero source file changes`);
+					}
+				} catch {
+					// Best effort — don't block .DONE creation on git check failure
+				}
+			}
+
+			// Create .DONE
 			const donePath = join(task.taskFolder, ".DONE");
 			writeFileSync(donePath, `Completed: ${new Date().toISOString()}\nTask: ${task.taskId}\n`);
 			updateStatusField(statusPath, "Status", "✅ Complete");

--- a/skills/create-taskplane-task/SKILL.md
+++ b/skills/create-taskplane-task/SKILL.md
@@ -354,6 +354,30 @@ files and make sure their file scopes reflect that.
 
 ---
 
+## Preventing Empty Completions
+
+Workers can shortcut tasks by observing that existing code "already satisfies"
+requirements and checking off items without implementing anything. This is the
+most dangerous failure mode — it produces false completions that waste the entire
+pipeline.
+
+**Defense: Make deliverables concrete and verifiable.**
+
+| ❌ Vague (shortcuttable) | ✅ Concrete (verifiable) |
+|--------------------------|------------------------|
+| "Add taskPacketRepo support" | "Add `taskPacketRepo` field to `WorkspaceRoutingConfig` in types.ts" |
+| "Enforce mode selection" | "Add `validateWorkspaceMode()` function in workspace.ts that throws on invalid state" |
+| "Update config loading" | "Modify `loadWorkspaceConfig()` to parse and validate `taskPacketRepo` from JSON config" |
+| "Add tests" | "Create `tests/packet-home-contract.test.ts` with tests for: valid config, missing field error, invariant violation" |
+
+**Rules for task creators:**
+- Every implementation step MUST name specific files to create or modify
+- "Add X" means "write new code that doesn't exist yet" — if it might already exist, say "verify X exists and add tests, or implement if missing"
+- Include at least one NEW test file per task — workers can't shortcut test creation
+- Each step's artifacts list must include at least one source file (not just STATUS.md)
+
+---
+
 ## Key Principles
 
 - **Documentation in every task.** Without "Must Update" and "Check If Affected"

--- a/templates/agents/task-worker.md
+++ b/templates/agents/task-worker.md
@@ -173,6 +173,15 @@ When a reviewer returns REVISE with specific feedback items:
 - Do NOT expand task scope beyond what the steps require
 - If you discover something out of scope, note it in STATUS.md Discoveries table
 
+## Completion Integrity
+
+**Every checked checkbox MUST correspond to a real code change, test, or document edit.** You must NOT check off items by simply observing that existing code appears to satisfy them. Specifically:
+
+- **If you believe work is already done:** You must still verify by running tests against the specific requirements AND document what you verified. Check off the item only after confirming with evidence (test output, code inspection notes in STATUS.md).
+- **"No source files changed" is a red flag.** If you complete a task without modifying any source files (only STATUS.md), something is wrong. Every implementation task requires code changes. If you genuinely believe no changes are needed, log a detailed explanation in STATUS.md Discoveries and escalate — do NOT mark the task as complete.
+- **A step that requires "Add X to Y" means you write the code.** Reading existing code and deciding it already satisfies the requirement is not implementation. If the existing code truly covers it, write a test that proves it, and document the finding.
+- **Checking boxes without doing work is the most serious failure mode.** It wastes the entire batch pipeline (review, merge, integration) and produces a false completion that blocks dependent tasks.
+
 ## Review Protocol
 
 If you have access to a `review_step` tool, use it at step boundaries to spawn


### PR DESCRIPTION
Root cause: worker checked off all STATUS.md items without modifying
any source files. It concluded the spec requirements were 'already
met' by existing code and treated the task as a checkbox exercise.

Layer 1 — Worker template (task-worker.md):
  Added 'Completion Integrity' section requiring every checkbox to
  correspond to a real code change. Zero-source-file completion is
  explicitly called out as the most serious failure mode.

Layer 2 — Task-runner (task-runner.ts):
  Empty completion guard before .DONE creation: git diff detects if
  only STATUS.md was modified. Logs warning for investigation.

Layer 3 — Task creation skill (SKILL.md):
  Added 'Preventing Empty Completions' section with concrete vs vague
  deliverable examples. Rules: name specific files, require new tests,
  artifacts per step.
