### PR TITLE
fix: update TP-079..088 prompts — concrete deliverables, correct test command

### DIFF
--- a/taskplane-tasks/TP-079-workspace-packet-home-contract-and-mode-enforcement/PROMPT.md
+++ b/taskplane-tasks/TP-079-workspace-packet-home-contract-and-mode-enforcement/PROMPT.md
@@ -22,6 +22,8 @@ taskplane-tasks/TP-079-workspace-packet-home-contract-and-mode-enforcement/
 
 Implement the foundational workspace routing contract for multi-repo task execution: add deterministic packet-home ownership (`taskPacketRepo`) and enforce startup mode selection without ambiguous fallback. This task establishes the non-negotiable config/runtime invariants required by #51 before segment scheduling work begins.
 
+> ⚠️ **Implementation required:** This task MUST create new source code. If you believe the requirements are already met by existing code, you must write tests that prove it and document what you verified. Checking off items without code changes is not acceptable.
+
 ## Dependencies
 
 - **None**
@@ -96,18 +98,19 @@ Implement the foundational workspace routing contract for multi-repo task execut
 
 ### Step 4: Testing & Verification
 
+- [ ] Create `extensions/tests/packet-home-contract.test.ts` with behavioral tests (not just source-pattern checks)
+
 > ZERO test failures allowed.
 
 - [ ] Add/adjust unit tests for `taskPacketRepo` validation and path invariants
 - [ ] Add/adjust tests for deterministic mode selection and hard-fail cases
-- [ ] Run full suite: `cd extensions && npx vitest run`
+- [ ] Run full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
 - [ ] Fix all failures
 
 ### Step 5: Documentation & Delivery
 
 - [ ] Update spec/status notes if behavior or naming changed during implementation
 - [ ] Log discoveries in STATUS.md
-- [ ] Create `.DONE`
 
 ## Documentation Requirements
 

--- a/taskplane-tasks/TP-080-segment-model-and-explicit-dag-syntax/PROMPT.md
+++ b/taskplane-tasks/TP-080-segment-model-and-explicit-dag-syntax/PROMPT.md
@@ -91,19 +91,20 @@ Introduce the v1 segment planning model for multi-repo task execution. Each task
 
 ### Step 4: Testing & Verification
 
+- [ ] Create `extensions/tests/segment-model.test.ts` with behavioral tests (not just source-pattern checks)
+
 > ZERO test failures allowed.
 
 - [ ] Add/adjust tests for explicit segment metadata parsing
 - [ ] Add/adjust tests for deterministic inference fallback
 - [ ] Add/adjust regression tests for backward compatibility (no metadata)
-- [ ] Run full suite: `cd extensions && npx vitest run`
+- [ ] Run full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
 - [ ] Fix all failures
 
 ### Step 5: Documentation & Delivery
 
 - [ ] Update spec wording if implementation reveals syntax or validation constraints
 - [ ] Log discoveries in STATUS.md
-- [ ] Create `.DONE`
 
 ## Documentation Requirements
 

--- a/taskplane-tasks/TP-081-segment-graph-scheduler-and-state-schema-v4/PROMPT.md
+++ b/taskplane-tasks/TP-081-segment-graph-scheduler-and-state-schema-v4/PROMPT.md
@@ -77,18 +77,19 @@ Implement **schema v4** persisted-state contracts for segment execution and migr
 
 ### Step 3: Testing & Verification
 
+- [ ] Create `extensions/tests/schema-v4-migration.test.ts` with behavioral tests (not just source-pattern checks)
+
 > ZERO test failures allowed.
 
 - [ ] Add/adjust migration fixtures and regression tests
 - [ ] Verify round-trip serialization for v4 fields
-- [ ] Run full suite: `cd extensions && npx vitest run`
+- [ ] Run full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
 - [ ] Fix all failures
 
 ### Step 4: Documentation & Delivery
 
 - [ ] Update spec notes if implementation details differ from planned shape
 - [ ] Log discoveries in STATUS.md
-- [ ] Create `.DONE`
 
 ## Documentation Requirements
 

--- a/taskplane-tasks/TP-082-dual-context-segment-execution-and-packet-path-contract/PROMPT.md
+++ b/taskplane-tasks/TP-082-dual-context-segment-execution-and-packet-path-contract/PROMPT.md
@@ -80,18 +80,19 @@ Implement the packet-path environment contract used by segment execution and mak
 
 ### Step 3: Testing & Verification
 
+- [ ] Create `extensions/tests/packet-path-contract.test.ts` with behavioral tests (not just source-pattern checks)
+
 > ZERO test failures allowed.
 
 - [ ] Add/adjust tests for packet-path env precedence
 - [ ] Add/adjust tests for authoritative `.DONE` path behavior
-- [ ] Run full suite: `cd extensions && npx vitest run`
+- [ ] Run full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
 - [ ] Fix all failures
 
 ### Step 4: Documentation & Delivery
 
 - [ ] Update docs for packet-path env contract if names/fallback changed
 - [ ] Log discoveries in STATUS.md
-- [ ] Create `.DONE`
 
 ## Documentation Requirements
 

--- a/taskplane-tasks/TP-083-supervisor-segment-recovery-and-reordering/PROMPT.md
+++ b/taskplane-tasks/TP-083-supervisor-segment-recovery-and-reordering/PROMPT.md
@@ -98,19 +98,20 @@ Integrate segment-aware autonomous recovery with supervisor-controlled reorderin
 
 ### Step 4: Testing & Verification
 
+- [ ] Create `extensions/tests/supervisor-segment-recovery.test.ts` with behavioral tests (not just source-pattern checks)
+
 > ZERO test failures allowed.
 
 - [ ] Add/adjust tests for segment-level alerts and context payloads
 - [ ] Add/adjust tests for allowed vs rejected reorder scenarios
 - [ ] Add/adjust tests proving reorder audit trail persistence
-- [ ] Run full suite: `cd extensions && npx vitest run`
+- [ ] Run full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
 - [ ] Fix all failures
 
 ### Step 5: Documentation & Delivery
 
 - [ ] Update spec docs if implementation constraints were discovered
 - [ ] Log discoveries in STATUS.md
-- [ ] Create `.DONE`
 
 ## Documentation Requirements
 

--- a/taskplane-tasks/TP-084-segment-observability-docs-and-polyrepo-acceptance/PROMPT.md
+++ b/taskplane-tasks/TP-084-segment-observability-docs-and-polyrepo-acceptance/PROMPT.md
@@ -97,9 +97,11 @@ Complete the first implementation tranche for #51 by shipping segment-aware obse
 
 ### Step 4: Testing & Verification
 
+- [ ] Create `extensions/tests/segment-observability.test.ts` with behavioral tests (not just source-pattern checks)
+
 > ZERO test failures allowed.
 
-- [ ] Run full suite: `cd extensions && npx vitest run`
+- [ ] Run full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
 - [ ] Run CLI smoke checks: `node bin/taskplane.mjs help` and `node bin/taskplane.mjs doctor`
 - [ ] Fix all failures
 
@@ -107,7 +109,6 @@ Complete the first implementation tranche for #51 by shipping segment-aware obse
 
 - [ ] Log discoveries in STATUS.md
 - [ ] Record acceptance outcomes clearly (pass/fail + evidence)
-- [ ] Create `.DONE`
 
 ## Documentation Requirements
 

--- a/taskplane-tasks/TP-085-segment-frontier-scheduler-and-resume/PROMPT.md
+++ b/taskplane-tasks/TP-085-segment-frontier-scheduler-and-resume/PROMPT.md
@@ -84,18 +84,19 @@ Implement segment-level frontier scheduling and resume reconstruction using sche
 
 ### Step 3: Testing & Verification
 
+- [ ] Create `extensions/tests/segment-frontier.test.ts` with behavioral tests (not just source-pattern checks)
+
 > ZERO test failures allowed.
 
 - [ ] Add/adjust direct-implementation tests for segment frontier routing
 - [ ] Add/adjust polyrepo regressions for deterministic ordering and resume parity
-- [ ] Run full suite: `cd extensions && npx vitest run`
+- [ ] Run full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
 - [ ] Fix all failures
 
 ### Step 4: Documentation & Delivery
 
 - [ ] Update docs if runtime behavior wording changed
 - [ ] Log discoveries in STATUS.md
-- [ ] Create `.DONE`
 
 ## Documentation Requirements
 

--- a/taskplane-tasks/TP-086-dynamic-segment-expansion-runtime/PROMPT.md
+++ b/taskplane-tasks/TP-086-dynamic-segment-expansion-runtime/PROMPT.md
@@ -92,18 +92,19 @@ Implement the runtime protocol for dynamic segment expansion requests and superv
 
 ### Step 4: Testing & Verification
 
+- [ ] Create `extensions/tests/segment-expansion-protocol.test.ts` with behavioral tests (not just source-pattern checks)
+
 > ZERO test failures allowed.
 
 - [ ] Add/adjust tests for request payload validation
 - [ ] Add/adjust tests for approve/modify/reject decision plumbing
-- [ ] Run full suite: `cd extensions && npx vitest run`
+- [ ] Run full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
 - [ ] Fix all failures
 
 ### Step 5: Documentation & Delivery
 
 - [ ] Update spec wording if protocol details are finalized/renamed
 - [ ] Log discoveries in STATUS.md
-- [ ] Create `.DONE`
 
 ## Documentation Requirements
 

--- a/taskplane-tasks/TP-087-dynamic-segment-expansion-graph-mutation-and-resume/PROMPT.md
+++ b/taskplane-tasks/TP-087-dynamic-segment-expansion-graph-mutation-and-resume/PROMPT.md
@@ -94,19 +94,20 @@ Implement deterministic application of approved dynamic segment expansion decisi
 
 ### Step 4: Testing & Verification
 
+- [ ] Create `extensions/tests/segment-expansion-graph.test.ts` with behavioral tests (not just source-pattern checks)
+
 > ZERO test failures allowed.
 
 - [ ] Add/adjust tests for approved expansion mutation behavior
 - [ ] Add/adjust tests for cycle rejection and frontier consistency
 - [ ] Add/adjust tests for expanded-graph resume reconstruction
-- [ ] Run full suite: `cd extensions && npx vitest run`
+- [ ] Run full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
 - [ ] Fix all failures
 
 ### Step 5: Documentation & Delivery
 
 - [ ] Update spec/docs if revision schema details differ from planned wording
 - [ ] Log discoveries in STATUS.md
-- [ ] Create `.DONE`
 
 ## Documentation Requirements
 

--- a/taskplane-tasks/TP-088-engine-resume-packet-path-threading/PROMPT.md
+++ b/taskplane-tasks/TP-088-engine-resume-packet-path-threading/PROMPT.md
@@ -81,18 +81,19 @@ Thread packet-path contract through orchestrator runtime and resume flows so com
 
 ### Step 3: Testing & Verification
 
+- [ ] Create `extensions/tests/engine-packet-path.test.ts` with behavioral tests (not just source-pattern checks)
+
 > ZERO test failures allowed.
 
 - [ ] Add/adjust tests for engine/resume packet-path propagation
 - [ ] Add/adjust tests for cross-repo completion/reconciliation correctness
-- [ ] Run full suite: `cd extensions && npx vitest run`
+- [ ] Run full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
 - [ ] Fix all failures
 
 ### Step 4: Documentation & Delivery
 
 - [ ] Update docs if orchestrator runtime behavior wording changed
 - [ ] Log discoveries in STATUS.md
-- [ ] Create `.DONE`
 
 ## Documentation Requirements
 


### PR DESCRIPTION
All 10 multi-repo task prompts updated:
- Replaced 'npx vitest run' with correct node --test command
- Removed 'Create .DONE' checkboxes (task-runner handles this)
- Added specific new test file creation requirement per task
- Added implementation-required warning to TP-079 (first task,
  highest risk of 'already done' shortcutting)
- Test files are behavioral (not source-pattern checks)
