### PR TITLE
fix: restore dashboard telemetry — tmux spawn mode + batch-aware lane state (#293)

### DIFF
--- a/dashboard/server.cjs
+++ b/dashboard/server.cjs
@@ -792,7 +792,17 @@ function computeBatchTotalCost(laneStates, telemetry) {
 function buildDashboardState() {
   const state = loadBatchState();
   const tmuxSessions = getTmuxSessions();
-  const laneStates = loadLaneStates();
+  const rawLaneStates = loadLaneStates();
+  // Filter stale lane states from previous batches.
+  // Lane state files persist across batches (same filename), so without
+  // filtering the dashboard shows telemetry from old runs.
+  const currentBatchId = state?.batchId || null;
+  const laneStates = {};
+  for (const [key, ls] of Object.entries(rawLaneStates)) {
+    if (!currentBatchId || !ls.batchId || ls.batchId === currentBatchId) {
+      laneStates[key] = ls;
+    }
+  }
   const telemetry = loadTelemetryData(state);
   const batchTotalCost = computeBatchTotalCost(laneStates, telemetry);
   const supervisor = loadSupervisorData(state);

--- a/extensions/task-runner.ts
+++ b/extensions/task-runner.ts
@@ -447,6 +447,7 @@ function writeLaneState(state: TaskState): void {
 			reviewerOutputTokens: state.reviewerOutputTokens || 0,
 			reviewerCacheReadTokens: state.reviewerCacheReadTokens || 0,
 			reviewerCacheWriteTokens: state.reviewerCacheWriteTokens || 0,
+			batchId: process.env.ORCH_BATCH_ID || null,
 			timestamp: Date.now(),
 		};
 		writeFileSync(filePath, JSON.stringify(data) + "\n");

--- a/extensions/taskplane/execution.ts
+++ b/extensions/taskplane/execution.ts
@@ -475,7 +475,7 @@ export function buildLaneEnvVars(
 
 	const vars: Record<string, string> = {
 		TASK_AUTOSTART: relativePath,
-		TASK_RUNNER_SPAWN_MODE: "subprocess",
+		TASK_RUNNER_SPAWN_MODE: "tmux",
 		TASK_RUNNER_TMUX_PREFIX: lane.tmuxSessionName,
 		ORCH_SIDECAR_DIR: join(workspaceRoot || repoRoot, ".pi"),
 		NODE_PATH: nodePath,
@@ -915,6 +915,10 @@ export function spawnLaneSession(
 
 	// Build env vars
 	const envVars = buildLaneEnvVars(lane, task.task.promptPath, repoRoot, workspaceRoot);
+	// Pass batch ID so task-runner can include it in lane state for dashboard filtering
+	if (config.orchestrator?.batchId) {
+		envVars.ORCH_BATCH_ID = config.orchestrator.batchId;
+	}
 	if (extraEnvVars) {
 		Object.assign(envVars, extraEnvVars);
 	}


### PR DESCRIPTION
Three fixes for dashboard showing no telemetry during batch execution:

1. Spawn mode: 'subprocess' → 'tmux' in execution.ts
   Workers now run in named tmux sessions with their own rpc-wrapper
   sidecar, giving the task-runner per-agent telemetry to poll.
   Subprocess mode gave zero visibility — worker was a black box.

2. Batch ID in lane state: ORCH_BATCH_ID env var passed to task-runner,
   included in lane-state JSON. Enables dashboard to distinguish
   current vs stale lane state entries.

3. Dashboard batch filtering: buildDashboardState() compares lane state
   batchId against current batch, ignores stale entries from prior runs.

Closes #293.
