### PR TITLE
fix: reviewer lifecycle + file reading discipline for context management

### DIFF
--- a/extensions/task-runner.ts
+++ b/extensions/task-runner.ts
@@ -2555,7 +2555,22 @@ export default function (pi: ExtensionAPI) {
 						reviewContent, statusPath, num, reviewType, stepNum, state.reviewCounter,
 					);
 
-					// Set reviewer to idle (NOT clear — persistent session stays alive)
+					// After code review: kill the persistent reviewer to free context.
+					// The reviewer persists through a plan+code pair for one step,
+					// then gets a fresh session for the next step.
+					if (reviewType === "code") {
+						console.error(`[task-runner] code review complete for step ${stepNum} — killing reviewer for fresh context on next step`);
+						logExecution(statusPath, `Reviewer R${num}`,
+							`code review complete — killing persistent reviewer (step ${stepNum} cycle done)`);
+						if (state.persistentReviewerKill) {
+							try { state.persistentReviewerKill(); } catch {}
+						}
+						state.persistentReviewerSession = null;
+						state.persistentReviewerKill = null;
+						state.persistentReviewerSignalNum = 0;
+						state.reviewerRespawnCount = 0;
+					}
+
 					state.reviewerStatus = "idle";
 					state.reviewerType = "";
 					state.reviewerStep = 0;
@@ -2642,6 +2657,9 @@ export default function (pi: ExtensionAPI) {
 						const { resultText } = processReviewVerdict(
 							fallbackContent, statusPath, num, reviewType, stepNum, state.reviewCounter, "fallback",
 						);
+
+						// Reset respawn counter on successful fallback review
+						state.reviewerRespawnCount = 0;
 
 						clearReviewerState();
 						writeLaneState(state);

--- a/extensions/tests/persistent-reviewer-context.test.ts
+++ b/extensions/tests/persistent-reviewer-context.test.ts
@@ -532,10 +532,11 @@ describe("10.x: Token accumulation — cumulative across persistent reviews", ()
 		expect(taskRunnerSource).toContain("state.reviewerOutputTokens += delta.outputTokens");
 	});
 
-	it("10.3: reviewer status is set to idle (not cleared) after persistent review", () => {
-		// After a persistent review completes, status goes to idle (not fully cleared)
-		const idleRegion = sourceRegion(taskRunnerSource, "Set reviewer to idle (NOT clear", 0, 200);
-		expect(idleRegion).toContain('state.reviewerStatus = "idle"');
+	it("10.3: reviewer status is set to idle after review and killed after code review", () => {
+		// After a review, status goes to idle. After code review, persistent reviewer is killed.
+		expect(taskRunnerSource).toContain('state.reviewerStatus = "idle"');
+		expect(taskRunnerSource).toContain('code review complete for step');
+		expect(taskRunnerSource).toContain('killing persistent reviewer');
 	});
 });
 

--- a/templates/agents/task-worker.md
+++ b/templates/agents/task-worker.md
@@ -289,33 +289,35 @@ checkpoints protect against regressions even when intermediate steps use targete
 2. The merge agent (before merging to the orchestrator branch)
 3. CI (before merging to main)
 
-## File Reading Strategy (Context Budget)
+## File Reading Strategy (Context Budget) — CRITICAL
 
-Your context window is finite. Reading large files whole wastes budget and risks
-triggering the context-pressure safety net (85% → wrap-up, 95% → kill).
-Use targeted reads instead:
+Your context window is finite. **Reading large files without offset/limit is the
+#1 cause of context exhaustion** — one full read of a 3000-line file consumes
+~5% of a 1M context window. Three such reads = 15% gone before you've done
+anything.
+
+### HARD RULES
+
+1. **NEVER read a file > 500 lines without offset/limit.** Always grep first.
+2. **NEVER read the same file twice in full.** Re-read only the changed region.
+3. **ALWAYS check file size before reading:** `wc -l <file>` or `ls -la <file>`
 
 ### Pattern: grep-first, read-with-offset
 
-1. **Locate** the relevant section with `grep` or `find`:
-   ```
-   grep -n "function buildPrompt" extensions/task-runner.ts
-   ```
-2. **Read** just that region with `offset` and `limit`:
-   ```
-   read extensions/task-runner.ts (offset: 1773, limit: 50)
-   ```
-3. **Edit** surgically with exact `oldText → newText`
+1. **Check size:** `wc -l extensions/task-runner.ts` → 4100 lines (DO NOT read fully)
+2. **Locate** the relevant section: `grep -n "function buildPrompt" extensions/task-runner.ts`
+3. **Read** just that region: `read extensions/task-runner.ts (offset: 1773, limit: 50)`
+4. **Edit** surgically with exact `oldText → newText`
 
 ### When to read a full file
 
 - Files under ~500 lines — read the whole thing, it's fine
-- Config files, test files, templates — usually small enough to read fully
+- Config files, small test files, templates — usually small enough
 - New files you're creating — read after writing to verify
 
 ### When NOT to read a full file
 
-- Source files over ~1000 lines — grep first, read the relevant region
+- Source files over ~500 lines — grep first, read with offset/limit
 - Generated files, lock files, large data files — almost never need full reads
 - Files you've already read this session — re-read only the changed region
 


### PR DESCRIPTION
Reviewer lifecycle (per-step, not per-task):
- Fresh reviewer spawned for each step's plan review
- Persists through the paired code review (has relevant plan context)
- Killed after code review completes — next step gets fresh context
- Respawn counter reset after successful reviews and step boundaries
- Eliminates accumulated stale context from prior steps

File reading discipline (worker template):
- HARD RULES: never read >500 lines without offset/limit, never re-read
  in full, always check file size first
- Quantified impact: one 3000-line read = ~5% of 1M context window
- Lowered threshold from 1000 to 500 lines for 'use offset/limit'

Root cause: TP-079 exhausted 18M tokens across 119 tool calls because
the persistent reviewer accumulated context across 6 review cycles and
the worker read multiple 100KB+ files without offset/limit.
