### PR TITLE
fix: reviewer killed on step transition + re-review after REVISE enforced

### DIFF
--- a/extensions/task-runner.ts
+++ b/extensions/task-runner.ts
@@ -2854,6 +2854,26 @@ export default function (pi: ExtensionAPI) {
 				}
 			}
 
+			// ── Step transition: kill persistent reviewer for fresh context ──
+			// When a step completes, the reviewer's context from that step is stale.
+			// Kill it so the next step gets a clean reviewer session.
+			if (newlyCompleted.length > 0 && state.persistentReviewerSession) {
+				console.error(`[task-runner] step(s) completed — killing reviewer for fresh context`);
+				logExecution(statusPath, "Reviewer cleanup",
+					`killing persistent reviewer on step transition (${newlyCompleted.map(s => `Step ${s.number}`).join(", ")} completed)`);
+				if (state.persistentReviewerKill) {
+					try { state.persistentReviewerKill(); } catch {}
+				}
+				state.persistentReviewerSession = null;
+				state.persistentReviewerKill = null;
+				state.persistentReviewerSignalNum = 0;
+				state.reviewerRespawnCount = 0;
+				// Reset per-step code review counters for completed steps
+				for (const step of newlyCompleted) {
+					stepCodeReviewCounts.delete(step.number);
+				}
+			}
+
 			// Log iteration summary with progress delta and completed steps
 			const completedNames = newlyCompleted.map(s => `Step ${s.number}`).join(", ");
 			if (newlyCompleted.length > 0) {

--- a/templates/agents/task-worker.md
+++ b/templates/agents/task-worker.md
@@ -205,7 +205,8 @@ value.
 - **APPROVE** → proceed to next step
 - **RETHINK** → reconsider your plan approach, adjust, then implement
 - **REVISE** → read the review file in `.reviews/` for detailed feedback,
-  address the issues, commit fixes, then proceed
+  address the issues, commit fixes, then **call `review_step` again** for re-review.
+  The same reviewer evaluates whether your fixes address its concerns.
 - **UNAVAILABLE** → reviewer failed, proceed with caution
 
 **Example flow for a Review Level 2 task, Step 3:**
@@ -215,8 +216,9 @@ value.
 4. Implement Step 3
 5. Commit changes
 6. Call `review_step(step=3, type="code", baseline="<saved SHA>")` → get code feedback
-7. If REVISE: fix issues, commit again
-8. Move to Step 4
+7. If REVISE: fix issues, commit, call `review_step(step=3, type="code")` again
+8. Repeat 7 until APPROVE (max 2 code review cycles per step)
+9. Move to Step 4
 
 If the `review_step` tool is not available (e.g., non-orchestrated mode), skip
 this protocol entirely — the task-runner handles reviews externally.


### PR DESCRIPTION
Step transition cleanup:
- When a step completes, kill the persistent reviewer if still alive
- Ensures next step always gets a fresh reviewer with clean context
- Reset respawn counter and code review cycle counter for completed steps

Worker template enforcement:
- After REVISE, worker MUST call review_step again for re-review
- Same reviewer evaluates whether fixes address its concerns
- Example flow updated: explicit re-review loop (max 2 cycles per step)

This closes the gap where:
1. Reviewer could linger after step completion (wasting resources)
2. Worker could skip re-review after REVISE (quality gap)
