### PR TITLE
fix(TP-080): workspace-aware segment inference for /orch-plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.10] - 2026-03-28
+
+### Fixed
+- **TP-080 segment inference completeness** — segment planning now accepts workspace repo IDs during wave computation so single-task, cross-repo `File Scope` hints are inferred correctly (e.g., `api/...` + `web/...` now yields two inferred segments instead of collapsing to one when only one repo was present in pending task routing signals).
+- **Planning wiring** — `/orch-plan` now passes workspace repo IDs into `computeWaveAssignments(...)` for deterministic, workspace-aware segment inference.
+- **Regression coverage** — added tests for workspace-hinted cross-repo inference in `segment-model.test.ts` and `waves-repo-scoped.test.ts`.
+
 ## [0.20.0] - 2026-03-26
 
 ### New

--- a/extensions/taskplane/extension.ts
+++ b/extensions/taskplane/extension.ts
@@ -1685,6 +1685,11 @@ export default function (pi: ExtensionAPI) {
 				discovery.pending,
 				discovery.completed,
 				orchConfig,
+				{
+					workspaceRepoIds: execCtx!.workspaceConfig
+						? execCtx!.workspaceConfig.repos.keys()
+						: undefined,
+				},
 			);
 
 			ctx.ui.notify(

--- a/extensions/taskplane/waves.ts
+++ b/extensions/taskplane/waves.ts
@@ -617,8 +617,24 @@ function normalizeRepoIdCandidate(raw: string): string | null {
 	return candidate;
 }
 
-function collectKnownRepoIds(pending: Map<string, ParsedTask>): Set<string> {
+interface SegmentPlanBuildOptions {
+	/** Optional workspace repo IDs used to validate file-scope repo prefixes. */
+	workspaceRepoIds?: Iterable<string>;
+}
+
+function collectKnownRepoIds(
+	pending: Map<string, ParsedTask>,
+	workspaceRepoIds?: Iterable<string>,
+): Set<string> {
 	const known = new Set<string>();
+
+	if (workspaceRepoIds) {
+		for (const repoIdRaw of workspaceRepoIds) {
+			const repoId = normalizeRepoIdCandidate(String(repoIdRaw));
+			if (repoId) known.add(repoId);
+		}
+	}
+
 	for (const task of pending.values()) {
 		if (task.resolvedRepoId) {
 			const repoId = normalizeRepoIdCandidate(task.resolvedRepoId);
@@ -784,8 +800,11 @@ export function buildSegmentPlanForTask(
 }
 
 /** Build a deterministic taskId→segmentPlan map for the whole pending set. */
-export function buildTaskSegmentPlans(pending: Map<string, ParsedTask>): TaskSegmentPlanMap {
-	const knownRepoIds = collectKnownRepoIds(pending);
+export function buildTaskSegmentPlans(
+	pending: Map<string, ParsedTask>,
+	options: SegmentPlanBuildOptions = {},
+): TaskSegmentPlanMap {
+	const knownRepoIds = collectKnownRepoIds(pending, options.workspaceRepoIds);
 	const plans: TaskSegmentPlanMap = new Map();
 	for (const taskId of [...pending.keys()].sort()) {
 		const task = pending.get(taskId);
@@ -1349,10 +1368,16 @@ export function allocateLanes(
  * Returns WaveAssignment[] with wave numbers and lane assignments,
  * plus any errors encountered.
  */
+export interface WaveComputationOptions {
+	/** Optional workspace repo IDs used by segment inference in workspace mode. */
+	workspaceRepoIds?: Iterable<string>;
+}
+
 export function computeWaveAssignments(
 	pending: Map<string, ParsedTask>,
 	completed: Set<string>,
 	config: OrchestratorConfig,
+	options: WaveComputationOptions = {},
 ): WaveComputationResult {
 	const errors: DiscoveryError[] = [];
 
@@ -1372,7 +1397,9 @@ export function computeWaveAssignments(
 	}
 
 	// Step 3.5: Build additive segment planning output (deterministic map)
-	const segmentPlans = buildTaskSegmentPlans(pending);
+	const segmentPlans = buildTaskSegmentPlans(pending, {
+		workspaceRepoIds: options.workspaceRepoIds,
+	});
 
 	// Step 4: Assign tasks to lanes within each wave
 	const waveAssignments: WaveAssignment[] = [];

--- a/extensions/tests/segment-model.test.ts
+++ b/extensions/tests/segment-model.test.ts
@@ -100,6 +100,25 @@ describe("computeWaveAssignments segment plan wiring", () => {
 		expect(result.segmentPlans!.size).toBe(2);
 	});
 
+	it("accepts workspaceRepoIds to infer cross-repo file scope hints", () => {
+		const pending = new Map<string, ParsedTask>([
+			["TP-450", makeTask("TP-450", {
+				resolvedRepoId: "api",
+				fileScope: ["api/src/service.ts", "web/src/client.ts"],
+			})],
+		]);
+
+		const result = computeWaveAssignments(
+			pending,
+			new Set<string>(),
+			DEFAULT_ORCHESTRATOR_CONFIG,
+			{ workspaceRepoIds: ["api", "web"] },
+		);
+		expect(result.errors).toEqual([]);
+		expect(result.segmentPlans).toBeDefined();
+		expect(result.segmentPlans!.get("TP-450")!.segments.map((s) => s.repoId)).toEqual(["api", "web"]);
+	});
+
 	it("omits segmentPlans when graph validation fails", () => {
 		const pending = new Map<string, ParsedTask>([
 			["TP-500", makeTask("TP-500", { dependencies: ["TP-501"] })],

--- a/extensions/tests/waves-repo-scoped.test.ts
+++ b/extensions/tests/waves-repo-scoped.test.ts
@@ -276,6 +276,30 @@ describe("segment planning", () => {
 		expect(plan.edges.every((e) => e.provenance === "inferred")).toBe(true);
 	});
 
+	it("uses workspace repo IDs to infer cross-repo file-scope touches for a single task", () => {
+		const pending = new Map<string, ParsedTask>([
+			[
+				"TP-905",
+				makeParsedTask("TP-905", {
+					resolvedRepoId: "api",
+					fileScope: ["api/src/a.ts", "web/src/b.ts", "src/noise.ts"],
+				}),
+			],
+		]);
+
+		const withoutWorkspaceHints = buildTaskSegmentPlans(pending).get("TP-905")!;
+		expect(withoutWorkspaceHints.segments.map((s) => s.repoId)).toEqual(["api"]);
+
+		const withWorkspaceHints = buildTaskSegmentPlans(pending, {
+			workspaceRepoIds: ["api", "web"],
+		}).get("TP-905")!;
+		expect(withWorkspaceHints.mode).toBe("inferred-sequential");
+		expect(withWorkspaceHints.segments.map((s) => s.repoId)).toEqual(["api", "web"]);
+		expect(withWorkspaceHints.edges.map((e) => `${e.fromSegmentId}->${e.toSegmentId}`)).toEqual([
+			"TP-905::api->TP-905::web",
+		]);
+	});
+
 	it("falls back to singleton repo segment when there are no multi-repo signals", () => {
 		const pending = new Map<string, ParsedTask>([
 			["TP-901", makeParsedTask("TP-901", { resolvedRepoId: "backend", fileScope: [], dependencies: [] })],


### PR DESCRIPTION
## Summary
- pass workspace repo IDs into wave segment planning from /orch-plan
- use workspace repo IDs when building known repo set for inferred segment plans
- add regression tests for single-task cross-repo file-scope inference
- add changelog entry for 0.22.10

## Why
TP-080 under-detected inferred segments when only one repo appeared in pending routing signals, even if file scope touched additional valid workspace repos.

## Validation
- cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts
- node bin/taskplane.mjs help
- node bin/taskplane.mjs doctor