### PR TITLE
chore: restore TP-094 and TP-095 STATUS.md from checkpoint commits

### DIFF
--- a/taskplane-tasks/TP-094-context-pressure-telemetry-fix/STATUS.md
+++ b/taskplane-tasks/TP-094-context-pressure-telemetry-fix/STATUS.md
@@ -1,59 +1,74 @@
 # TP-094: Context Pressure and Telemetry Accuracy Fix — Status
 
-**Current Step:** Not Started
-**Status:** 🔵 Ready for Execution
+**Current Step:** Complete
+**Status:** ✅ Complete
 **Last Updated:** 2026-03-29
 **Review Level:** 2
-**Review Counter:** 0
-**Iteration:** 0
+**Review Counter:** 5
+**Iteration:** 4
 **Size:** M
 
 ---
 
 ### Step 0: Preflight
-**Status:** ⬜ Not Started
+**Status:** ✅ Complete
 
-- [ ] Verify field name mismatch in real sidecar data
-- [ ] Trace all percentUsed code paths
-- [ ] Identify manual fallback removal points
+- [x] Verify field name mismatch in real sidecar data
+- [x] Trace all percentUsed code paths
+- [x] Identify manual fallback removal points
 
 ---
 
 ### Step 1: Fix field name mismatch in sidecar tailing
-**Status:** ⬜ Not Started
+**Status:** ✅ Complete
 
-- [ ] Fix percent vs percentUsed in tailSidecarJsonl
-- [ ] Verify rpc-wrapper field extraction
-- [ ] Remove manual token fallback from threshold decisions
+- [x] 1a. Type: renamed `percentUsed` → `percent` in `SidecarTelemetryDelta.contextUsage`
+- [x] 1b. Parser: reads `cu.percent ?? cu.percentUsed` for backward compat
+- [x] 1c. Worker consumer: updated to `.percent`
+- [x] 1d. Reviewer consumers (both paths): updated to `.percent`
+- [x] 1e. Manual token fallback removed from worker + both reviewer paths
+- [x] 1f. One-shot warning: gated on `sawStatsResponseWithoutContextUsage` flag (not hadEvents)
+- [x] 1g. rpc-wrapper verified: passes through correctly, no changes needed
 
 ---
 
 ### Step 2: Context % snapshots at iteration boundaries
-**Status:** ⬜ Not Started
+**Status:** ✅ Complete
 
-- [ ] Write JSONL snapshot at worker iteration end
-- [ ] Add to batch artifact cleanup
+- [x] Write JSONL snapshot at worker iteration end (`writeContextSnapshot()` after `runWorker()`)
+- [x] Add to batch artifact cleanup (post-integrate + preflight age sweep)
 
 ---
 
 ### Step 3: Testing & Verification
-**Status:** ⬜ Not Started
+**Status:** ✅ Complete
 
-- [ ] Tests for correct field extraction
-- [ ] Full test suite passing
+- [x] Tests updated: `percent` field extracted correctly from real pi response format
+- [x] Tests added: backward-compatible `percentUsed` fallback works
+- [x] Tests added: `percent` takes precedence over `percentUsed`
+- [x] Tests added: `sawStatsResponseWithoutContextUsage` flag behavior
+- [x] 240 targeted tests pass (sidecar, rpc-wrapper, cleanup, reviewer context)
+- [x] 37 state persistence tests pass
 
 ---
 
 ### Step 4: Documentation & Delivery
-**Status:** ⬜ Not Started
+**Status:** ✅ Complete
 
-- [ ] Log discoveries
+- [x] Log discoveries in STATUS.md
+- [x] Inline comments updated (TP-094 references in all changed locations)
+- [x] No external doc updates needed (resilience-architecture.md doesn't reference field names)
 
 ---
 
 ## Reviews
 
 | # | Type | Step | Verdict | File |
+| R001 | plan | Step 1 | REVISE | .reviews/R001-plan-step1.md |
+| R002 | plan | Step 1 | APPROVE | .reviews/R002-plan-step1.md |
+| R003 | code | Step 1 | REVISE | .reviews/R003-code-step1.md |
+| R004 | code | Step 1 | APPROVE | .reviews/R004-code-step1.md |
+| R005 | plan | Step 3 | UNKNOWN | .reviews/R005-plan-step3.md |
 |---|------|------|---------|------|
 
 ---
@@ -62,6 +77,11 @@
 
 | Discovery | Disposition | Location |
 |-----------|-------------|----------|
+| Pi sends `contextUsage.percent` but code checks `cu.percentUsed` — always undefined | Fix in Step 1 | `extensions/task-runner.ts:1509` |
+| 6 locations reference `.percentUsed` in task-runner.ts: L1374 (type), L1509-1511 (sidecar parse), L2466, L2673 (reviewer), L3302 (worker onTelemetry) | Fix all in Step 1 | `extensions/task-runner.ts` |
+| Manual fallback `(delta.latestTotalTokens / contextWindow) * 100` at L3303-3305 and L2468-2469, L2675-2676 (reviewer) | Remove in Step 1 | `extensions/task-runner.ts` |
+| rpc-wrapper passes through `event.data.contextUsage` unmodified — field name is `percent` from pi, correct passthrough | No change needed | `bin/rpc-wrapper.mjs:426` |
+| Tests in sidecar-tailing.test.ts use `percentUsed` in test data (wrong field) | Fix in Step 3 | `extensions/tests/sidecar-tailing.test.ts` |
 
 ---
 
@@ -70,6 +90,35 @@
 | Timestamp | Action | Outcome |
 |-----------|--------|---------|
 | 2026-03-29 | Task staged | PROMPT.md and STATUS.md created |
+| 2026-03-29 14:58 | Task started | Extension-driven execution |
+| 2026-03-29 14:58 | Step 0 started | Preflight |
+| 2026-03-29 14:58 | Task started | Extension-driven execution |
+| 2026-03-29 14:58 | Step 0 started | Preflight |
+| 2026-03-29 14:58 | Worker iter 1 | done in 3s, ctx: 0%, tools: 0 |
+| 2026-03-29 14:58 | No progress | Iteration 1: 0 new checkboxes (1/3 stall limit) |
+| 2026-03-29 14:58 | Worker iter 2 | done in 3s, ctx: 0%, tools: 0 |
+| 2026-03-29 14:58 | No progress | Iteration 1: 0 new checkboxes (1/3 stall limit) |
+| 2026-03-29 14:58 | Worker iter 2 | done in 3s, ctx: 0%, tools: 0 |
+| 2026-03-29 14:58 | No progress | Iteration 2: 0 new checkboxes (2/3 stall limit) |
+| 2026-03-29 14:58 | Worker iter 3 | done in 3s, ctx: 0%, tools: 0 |
+| 2026-03-29 14:58 | No progress | Iteration 2: 0 new checkboxes (2/3 stall limit) |
+| 2026-03-29 14:58 | Worker iter 3 | done in 3s, ctx: 0%, tools: 0 |
+| 2026-03-29 14:58 | No progress | Iteration 3: 0 new checkboxes (3/3 stall limit) |
+| 2026-03-29 14:58 | Task blocked | No progress after 3 iterations |
+| 2026-03-29 14:58 | Worker iter 4 | done in 2s, ctx: 0%, tools: 0 |
+| 2026-03-29 14:58 | No progress | Iteration 3: 0 new checkboxes (3/3 stall limit) |
+| 2026-03-29 14:58 | Task blocked | No progress after 3 iterations |
+| 2026-03-29 | Step 0 complete | Confirmed: pi sends `percent`, code checks `percentUsed` — 6 locations to fix, manual fallback in 3 locations |
+| 2026-03-29 15:00 | Reviewer R001 | persistent reviewer failed — falling back to fresh spawn: Persistent reviewer exited within 30s of spawn without producing a verdict — wait_for_review tool may not be supported by this model (e.g., called via bash instead of as a registered tool) |
+| 2026-03-29 15:03 | Review R001 | plan Step 1: REVISE (fallback) |
+| 2026-03-29 15:05 | Reviewer R002 | persistent reviewer failed — falling back to fresh spawn: Persistent reviewer session died while waiting for verdict |
+| 2026-03-29 15:08 | Review R002 | plan Step 1: APPROVE (fallback) |
+| 2026-03-29 15:09 | Reviewer R003 | persistent reviewer failed — falling back to fresh spawn: Persistent reviewer exited within 30s of spawn without producing a verdict — wait_for_review tool may not be supported by this model (e.g., called via bash instead of as a registered tool) |
+| 2026-03-29 15:12 | Review R003 | code Step 1: REVISE (fallback) |
+| 2026-03-29 15:13 | Reviewer R004 | persistent reviewer failed — falling back to fresh spawn: Persistent reviewer exited within 30s of spawn without producing a verdict — wait_for_review tool may not be supported by this model (e.g., called via bash instead of as a registered tool) |
+| 2026-03-29 15:16 | Review R004 | code Step 1: APPROVE (fallback) |
+| 2026-03-29 15:18 | Reviewer R005 | persistent reviewer failed — falling back to fresh spawn: Persistent reviewer exited within 30s of spawn without producing a verdict — wait_for_review tool may not be supported by this model (e.g., called via bash instead of as a registered tool) |
+| 2026-03-29 15:26 | Review R005 | plan Step 3: UNKNOWN (fallback) |
 
 ---
 

--- a/taskplane-tasks/TP-095-crash-recovery-and-spawn-reliability/STATUS.md
+++ b/taskplane-tasks/TP-095-crash-recovery-and-spawn-reliability/STATUS.md
@@ -1,71 +1,73 @@
 # TP-095: Crash Recovery and Spawn Reliability — Status
 
-**Current Step:** Not Started
-**Status:** 🔵 Ready for Execution
+**Current Step:** Complete
+**Status:** ✅ Complete
 **Last Updated:** 2026-03-29
 **Review Level:** 2
-**Review Counter:** 0
-**Iteration:** 0
+**Review Counter:** 2
+**Iteration:** 4
 **Size:** L
 
 ---
 
 ### Step 0: Preflight
-**Status:** ⬜ Not Started
+**Status:** ✅ Complete
 
-- [ ] Read spawn, lane-state, and execution paths
-- [ ] Read GitHub issues #333, #334, #335, #339
+- [x] Read spawn, lane-state, and execution paths
+- [x] Read GitHub issues #333, #334, #335, #339
 
 ---
 
 ### Step 1: Worker spawn reliability (#335)
-**Status:** ⬜ Not Started
+**Status:** ✅ Complete
 
-- [ ] Add post-spawn verification with retry
-- [ ] Log failures for diagnosis
+- [x] Add post-spawn verification with retry
+- [x] Log failures for diagnosis
 
 ---
 
 ### Step 2: Lane-state reset on worker restart (#333)
-**Status:** ⬜ Not Started
+**Status:** ✅ Complete
 
-- [ ] Reset stale fields before new worker spawn
-- [ ] Write lane-state immediately
+- [x] Reset stale fields before new worker spawn
+- [x] Write lane-state immediately
 
 ---
 
 ### Step 3: Telemetry accumulation across restarts (#334)
-**Status:** ⬜ Not Started
+**Status:** ✅ Complete
 
-- [ ] Preserve and accumulate telemetry across iterations
+- [x] Preserve and accumulate telemetry across iterations
 
 ---
 
 ### Step 4: Lane session stderr capture (#339)
-**Status:** ⬜ Not Started
+**Status:** ✅ Complete
 
-- [ ] Redirect lane stderr to log file
+- [x] Redirect lane stderr to log file
 
 ---
 
 ### Step 5: Testing & Verification
-**Status:** ⬜ Not Started
+**Status:** ✅ Complete
 
-- [ ] Behavioral tests for all four fixes
-- [ ] Full test suite passing
+- [x] Behavioral tests for all four fixes
+- [x] Full test suite passing (3009/3009)
 
 ---
 
 ### Step 6: Documentation & Delivery
-**Status:** ⬜ Not Started
+**Status:** ✅ Complete
 
-- [ ] Log discoveries
+- [x] Log discoveries
 
 ---
 
 ## Reviews
 
 | # | Type | Step | Verdict | File |
+| R001 | plan | Step 1 | REVISE | .reviews/R001-plan-step1.md |
+| R002 | code | Step 1 | UNKNOWN | .reviews/R002-code-step1.md |
 |---|------|------|---------|------|
 
 ---
@@ -74,6 +76,9 @@
 
 | Discovery | Disposition | Location |
 |-----------|-------------|----------|
+| Quality gate fix agent has its own workerToolCount=0 reset (separate lifecycle) | Preserved — fix agents are not worker iterations | extensions/task-runner.ts:3963 |
+| Subprocess mode already accumulates tokens via += (no fix needed) | Confirmed by source extraction test | extensions/task-runner.ts:3505+ |
+| extractFunctionRegion captures too much when functions aren't separated by section markers | Test used narrower region extraction | extensions/tests/crash-recovery-spawn-reliability.test.ts |
 
 ---
 
@@ -82,6 +87,32 @@
 | Timestamp | Action | Outcome |
 |-----------|--------|---------|
 | 2026-03-29 | Task staged | PROMPT.md and STATUS.md created |
+| 2026-03-29 15:30 | Task started | Extension-driven execution |
+| 2026-03-29 15:30 | Step 0 started | Preflight |
+| 2026-03-29 15:30 | Task started | Extension-driven execution |
+| 2026-03-29 15:30 | Step 0 started | Preflight |
+| 2026-03-29 15:30 | Worker iter 1 | done in 3s, ctx: 0%, tools: 0 |
+| 2026-03-29 15:30 | No progress | Iteration 1: 0 new checkboxes (1/3 stall limit) |
+| 2026-03-29 15:30 | Worker iter 2 | done in 3s, ctx: 0%, tools: 0 |
+| 2026-03-29 15:30 | No progress | Iteration 1: 0 new checkboxes (1/3 stall limit) |
+| 2026-03-29 15:30 | Worker iter 2 | done in 2s, ctx: 0%, tools: 0 |
+| 2026-03-29 15:30 | No progress | Iteration 2: 0 new checkboxes (2/3 stall limit) |
+| 2026-03-29 15:30 | Worker iter 3 | done in 3s, ctx: 0%, tools: 0 |
+| 2026-03-29 15:30 | No progress | Iteration 3: 0 new checkboxes (3/3 stall limit) |
+| 2026-03-29 15:30 | Task blocked | No progress after 3 iterations |
+| 2026-03-29 15:30 | Worker iter 3 | done in 5s, ctx: 0%, tools: 0 |
+| 2026-03-29 15:30 | No progress | Iteration 2: 0 new checkboxes (2/3 stall limit) |
+| 2026-03-29 15:30 | Worker iter 4 | done in 3s, ctx: 0%, tools: 0 |
+| 2026-03-29 15:30 | No progress | Iteration 3: 0 new checkboxes (3/3 stall limit) |
+| 2026-03-29 15:30 | Task blocked | No progress after 3 iterations |
+| 2026-03-29 15:36 | Reviewer R001 | persistent reviewer failed — falling back to fresh spawn: Persistent reviewer session died while waiting for verdict |
+| 2026-03-29 15:39 | Review R001 | plan Step 1: REVISE (fallback) |
+| 2026-03-29 15:44 | Reviewer R002 | persistent reviewer failed — falling back to fresh spawn: Persistent reviewer exited within 30s of spawn without producing a verdict — wait_for_review tool may not be supported by this model (e.g., called via bash instead of as a registered tool) |
+| 2026-03-29 15:47 | Review R002 | code Step 1: UNKNOWN (fallback) |
+| 2026-03-29 15:48 | Step 0 completed | Preflight — read all source files and GitHub issues |
+| 2026-03-29 15:52 | Steps 1-4 completed | Implemented spawn verification, lane-state reset, telemetry accumulation, stderr capture |
+| 2026-03-29 15:55 | Step 5 completed | 34 new tests, 3009 total pass |
+| 2026-03-29 15:58 | Step 6 completed | Documentation and delivery |
 
 ---
 


### PR DESCRIPTION
Recovered checked-off final state from lane checkpoint commits. TP-096 not recoverable (worker never committed updated STATUS.md before lane death).