### PR TITLE
feat: lean worker prompt — file paths instead of inline content

### DIFF
--- a/extensions/task-runner.ts
+++ b/extensions/task-runner.ts
@@ -3519,80 +3519,41 @@ export default function (pi: ExtensionAPI) {
 				|| workerDef?.model
 				|| (ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : "anthropic/claude-sonnet-4-20250514"));
 
-		const contextDocsList = task.contextDocs.length > 0
-			? "\n\nContext docs to read if needed:\n" + task.contextDocs.map(d => `- ${d}`).join("\n")
-			: "";
+		// ── Lean worker prompt: pass file paths, not content ──────────
+		// The worker reads PROMPT.md and STATUS.md itself using the read tool.
+		// This keeps the initial prompt small (~500 chars) instead of embedding
+		// 50K+ of compiled content that exceeds Windows command line limits
+		// and wastes initial context window capacity.
+		const promptLines = [
+			`Read your task instructions at: ${task.promptPath}`,
+			`Read your execution state at: ${statusPath}`,
+			``,
+			`Task: ${task.taskId}`,
+			`Task folder: ${task.taskFolder}/`,
+			`Iteration: ${state.totalIterations}`,
+			`Wrap-up signal file: ${wrapUpFile}`,
+		];
 
-		// When running under the parallel orchestrator, workers must NOT
-		// archive or move the task folder — the orchestrator polls for .DONE
-		// at the original path and handles post-merge archival itself.
-		const archiveSuppression = isOrchestratedMode()
-			? "\n\n⚠️ ORCHESTRATED RUN: Do NOT archive or move the task folder. " +
-			  "Do NOT rename, relocate, or reorganize the task folder path. " +
-			  "The orchestrator handles post-merge archival. " +
-			  "Just create the .DONE file in the task folder when complete."
-			: "";
+		if (isOrchestratedMode()) {
+			promptLines.push(``, `⚠️ ORCHESTRATED RUN: Do NOT archive or move the task folder. The orchestrator handles post-merge archival.`);
+		}
 
-		// Build step listing for the worker prompt — show ALL steps with status
-		const remainingSet = new Set(remainingSteps.map(s => s.number));
-		const stepListing = task.steps.map(s =>
-			remainingSet.has(s.number)
-				? `  - Step ${s.number}: ${s.name}`
-				: `  - Step ${s.number}: ${s.name}  [already complete — skip]`
-		).join("\n");
-
-		// TP-073: Build nudge for subsequent iterations (iter > 0)
-		// When the worker exited without completing all steps, the next iteration
-		// gets an explicit nudge listing completed/remaining steps and a warning
-		// not to exit prematurely again.
-		let iterationNudge = "";
 		if (state.totalIterations > 1 && remainingSteps.length > 0) {
+			const remainingSet = new Set(remainingSteps.map(s => s.number));
 			const completedSteps = task.steps.filter(s => !remainingSet.has(s.number));
 			const completedList = completedSteps.length > 0
 				? completedSteps.map(s => `Step ${s.number}: ${s.name}`).join(", ")
 				: "(none)";
 			const remainingList = remainingSteps.map(s => `Step ${s.number}: ${s.name}`).join(", ");
-			iterationNudge = [
+			promptLines.push(
 				``,
-				`IMPORTANT: You exited on your previous iteration without completing all steps.`,
-				`Do NOT repeat this — you must complete all remaining steps before stopping.`,
-				``,
-				`Completed steps (do not redo): ${completedList}`,
-				`Remaining steps (focus here): ${remainingList}`,
-				``,
-				`Your final action MUST be a tool call (update STATUS.md). Do NOT produce a`,
-				`text-only response — that will terminate your session prematurely.`,
-				``,
-			].join("\n");
+				`IMPORTANT: You exited previously without completing all steps.`,
+				`Completed (do not redo): ${completedList}`,
+				`Remaining (focus here): ${remainingList}`,
+			);
 		}
 
-		const prompt = [
-			`Execute all remaining steps for task ${task.taskId}.`,
-			``,
-			`Task: ${task.taskId} — ${task.taskName}`,
-			`Task folder: ${task.taskFolder}/`,
-			`PROMPT: ${task.promptPath}`,
-			`STATUS: ${statusPath}`,
-			``,
-			`This is iteration ${state.totalIterations}.`,
-			`Read STATUS.md FIRST to find where you left off.`,
-			iterationNudge,
-			`Steps:`,
-			stepListing,
-			``,
-			`Work through these steps in order. For each step:`,
-			`1. Read STATUS.md to find unchecked items for that step`,
-			`2. Complete all items for the step`,
-			`3. Update STATUS.md step status to "complete"`,
-			`4. Commit your changes: feat(${task.taskId}): complete Step N — description`,
-			`5. Check for wrap-up signal files before starting the next step`,
-			`6. Proceed to the next incomplete step`,
-			``,
-			`Wrap-up signal file: ${wrapUpFile}`,
-			`Check for this file after each checkpoint. If it exists, stop.`,
-			archiveSuppression,
-			contextDocsList,
-		].join("\n");
+		const prompt = promptLines.join("\n");
 
 		state.workerStatus = "running";
 		state.workerElapsed = 0;

--- a/extensions/tests/persistent-worker-context.test.ts
+++ b/extensions/tests/persistent-worker-context.test.ts
@@ -91,20 +91,16 @@ describe("1.x: Single spawn per task — worker handles all remaining steps", ()
 		expect(runWorkerSig![1]).toContain("StepInfo[]");
 	});
 
-	it("1.3: worker prompt includes all remaining steps, not just one", () => {
+	it("1.3: worker prompt passes file paths, not inline content", () => {
 		const runWorkerBody = extractFunction(source, "runWorker");
 
-		// Should build a step listing showing all steps with their status
-		expect(runWorkerBody).toContain("stepListing");
-		expect(runWorkerBody).toContain("already complete — skip");
+		// Lean prompt: worker reads PROMPT.md and STATUS.md via file paths
+		expect(runWorkerBody).toContain("task.promptPath");
+		expect(runWorkerBody).toContain("statusPath");
 
-		// Should instruct worker to work through steps in order
-		expect(runWorkerBody).toContain("Execute all remaining steps");
-		expect(runWorkerBody).toContain("Work through these steps in order");
-
-		// Should NOT contain "Execute Step ${step.number}" (old single-step pattern)
+		// Should NOT embed step listings inline (worker reads STATUS.md instead)
+		expect(runWorkerBody).not.toContain("Work through these steps in order");
 		expect(runWorkerBody).not.toContain("Execute Step ${step.number}");
-		// Should NOT contain "Work ONLY on Step" (old constraint)
 		expect(runWorkerBody).not.toContain("Work ONLY on Step");
 	});
 
@@ -127,15 +123,15 @@ describe("1.x: Single spawn per task — worker handles all remaining steps", ()
 		expect(source).not.toMatch(/function executeStep\s*\(/);
 	});
 
-	it("1.7: worker prompt includes per-step commit instructions", () => {
+	it("1.7: worker prompt includes wrap-up signal file path", () => {
 		const runWorkerBody = extractFunction(source, "runWorker");
-		// Worker should be told to commit at each step boundary
-		expect(runWorkerBody).toContain("feat(${task.taskId}): complete Step N");
+		expect(runWorkerBody).toContain("Wrap-up signal file");
+		expect(runWorkerBody).toContain("wrapUpFile");
 	});
 
-	it("1.8: worker prompt includes wrap-up signal check between steps", () => {
+	it("1.8: worker prompt includes iteration number", () => {
 		const runWorkerBody = extractFunction(source, "runWorker");
-		expect(runWorkerBody).toContain("Check for wrap-up signal files before starting the next step");
+		expect(runWorkerBody).toContain("state.totalIterations");
 	});
 });
 
@@ -400,8 +396,9 @@ describe("6.x: Context limit mid-task → next iteration picks up from incomplet
 
 	it("6.7: worker prompt includes iteration number for context on recovery", () => {
 		const runWorkerBody = extractFunction(source, "runWorker");
-		expect(runWorkerBody).toContain("This is iteration ${state.totalIterations}");
-		expect(runWorkerBody).toContain("Read STATUS.md FIRST to find where you left off");
+		expect(runWorkerBody).toContain("state.totalIterations");
+		// Iteration nudge for subsequent iterations
+		expect(runWorkerBody).toContain("exited previously without completing");
 	});
 
 	it("6.8: paused state is checked at start of each iteration", () => {
@@ -602,56 +599,38 @@ describe("7.x: parseStatusMd correctness — supports new execution model", () =
 // 8.x — Worker prompt construction: multi-step format
 // ══════════════════════════════════════════════════════════════════════
 
-describe("8.x: Worker prompt construction — multi-step format", () => {
-	it("8.1: step listing shows completed steps as [already complete — skip]", () => {
+describe("8.x: Worker prompt construction — lean filepath-based format", () => {
+	it("8.1: prompt passes PROMPT.md and STATUS.md file paths (not content)", () => {
 		const runWorkerBody = extractFunction(source, "runWorker");
-
-		// The step listing distinguishes remaining vs completed
-		expect(runWorkerBody).toContain("remainingSet.has(s.number)");
-		expect(runWorkerBody).toContain("`  - Step ${s.number}: ${s.name}`");
-		expect(runWorkerBody).toContain("`  - Step ${s.number}: ${s.name}  [already complete — skip]`");
+		// Worker reads task files itself via the read tool
+		expect(runWorkerBody).toContain("task.promptPath");
+		expect(runWorkerBody).toContain("statusPath");
+		// Should NOT embed inline step listings or numbered instructions
+		expect(runWorkerBody).not.toContain("1. Read STATUS.md to find unchecked items");
 	});
 
-	it("8.2: prompt includes all six worker instructions", () => {
+	it("8.2: prompt includes task ID and task folder", () => {
 		const runWorkerBody = extractFunction(source, "runWorker");
-
-		// The 6 numbered instructions for the worker
-		expect(runWorkerBody).toContain("1. Read STATUS.md to find unchecked items");
-		expect(runWorkerBody).toContain("2. Complete all items for the step");
-		expect(runWorkerBody).toContain("3. Update STATUS.md step status");
-		expect(runWorkerBody).toContain("4. Commit your changes");
-		expect(runWorkerBody).toContain("5. Check for wrap-up signal files");
-		expect(runWorkerBody).toContain("6. Proceed to the next incomplete step");
+		expect(runWorkerBody).toContain("task.taskId");
+		expect(runWorkerBody).toContain("task.taskFolder");
 	});
 
-	it("8.3: prompt includes task ID and task folder", () => {
+	it("8.3: prompt includes wrap-up signal file path", () => {
 		const runWorkerBody = extractFunction(source, "runWorker");
-		expect(runWorkerBody).toContain("Task: ${task.taskId}");
-		expect(runWorkerBody).toContain("Task folder: ${task.taskFolder}");
+		expect(runWorkerBody).toContain("Wrap-up signal file");
+		expect(runWorkerBody).toContain("wrapUpFile");
 	});
 
-	it("8.4: prompt includes wrap-up signal file path", () => {
-		const runWorkerBody = extractFunction(source, "runWorker");
-		expect(runWorkerBody).toContain("Wrap-up signal file: ${wrapUpFile}");
-	});
-
-	it("8.5: archive suppression text is included for orchestrated mode", () => {
+	it("8.4: archive suppression included for orchestrated mode", () => {
 		const runWorkerBody = extractFunction(source, "runWorker");
 		expect(runWorkerBody).toContain("isOrchestratedMode()");
-		expect(runWorkerBody).toContain("ORCHESTRATED RUN: Do NOT archive");
-		expect(runWorkerBody).toContain("archiveSuppression");
+		expect(runWorkerBody).toContain("ORCHESTRATED RUN");
 	});
 
-	it("8.6: context docs are appended to prompt when present", () => {
+	it("8.5: iteration nudge included for subsequent iterations", () => {
 		const runWorkerBody = extractFunction(source, "runWorker");
-		expect(runWorkerBody).toContain("contextDocsList");
-		expect(runWorkerBody).toContain("task.contextDocs");
-	});
-
-	it("8.7: prompt references PROMPT and STATUS paths", () => {
-		const runWorkerBody = extractFunction(source, "runWorker");
-		expect(runWorkerBody).toContain("PROMPT: ${task.promptPath}");
-		expect(runWorkerBody).toContain("STATUS: ${statusPath}");
+		expect(runWorkerBody).toContain("state.totalIterations > 1");
+		expect(runWorkerBody).toContain("exited previously without completing");
 	});
 });
 

--- a/extensions/tests/task-runner-orchestration.test.ts
+++ b/extensions/tests/task-runner-orchestration.test.ts
@@ -214,63 +214,25 @@ function runAllTests(): void {
 	// ───────────────────────────────────────────────────────────────
 	// 5.2: Archive suppression prompt assembly
 	// ───────────────────────────────────────────────────────────────
-	console.log("── 5.2: archiveSuppression prompt assembly ──");
+	console.log("── 5.2: archive suppression in lean prompt ──");
 
-	// Verify the archive suppression text exists in source and is gated
-	// by isOrchestratedMode(). We extract the relevant code block.
-
-	// Check that archiveSuppression variable exists and is conditional
-	const archiveSuppressionPattern = /const\s+archiveSuppression\s*=\s*isOrchestratedMode\(\)/;
+	// Verify archive suppression is gated by isOrchestratedMode() in runWorker
+	const runWorkerBody = extractFunction(source, "runWorker");
 	assert(
-		archiveSuppressionPattern.test(source),
-		"archiveSuppression is gated by isOrchestratedMode()",
-	);
-
-	// Check the suppression message contains critical keywords
-	const suppressionTextMatch = source.match(
-		/archiveSuppression\s*=\s*isOrchestratedMode\(\)\s*\n\s*\?\s*"([^"]*(?:"[^"]*)*)/s,
+		runWorkerBody.includes("isOrchestratedMode()"),
+		"archive suppression is gated by isOrchestratedMode()",
 	);
 	assert(
-		suppressionTextMatch !== null,
-		"archiveSuppression has truthy branch (orchestrated mode text)",
-	);
-
-	// Verify the message includes key directives
-	const archiveBlock = source.slice(
-		source.indexOf("const archiveSuppression"),
-		source.indexOf("const archiveSuppression") + 500,
+		runWorkerBody.includes("ORCHESTRATED RUN"),
+		"suppression text includes ORCHESTRATED RUN directive",
 	);
 	assert(
-		archiveBlock.includes("Do NOT archive"),
+		runWorkerBody.includes("Do NOT archive"),
 		"suppression text includes 'Do NOT archive'",
 	);
 	assert(
-		archiveBlock.includes("Do NOT rename"),
-		"suppression text includes 'Do NOT rename'",
-	);
-	assert(
-		archiveBlock.includes(".DONE"),
-		"suppression text references .DONE file",
-	);
-	assert(
-		archiveBlock.includes("orchestrator handles"),
+		runWorkerBody.includes("orchestrator handles"),
 		"suppression text mentions orchestrator handles archival",
-	);
-
-	// Verify the falsy branch is empty string (no suppression for non-orchestrated)
-	assert(
-		archiveBlock.includes(': ""'),
-		"non-orchestrated mode produces empty string",
-	);
-
-	// Verify archiveSuppression is used in prompt assembly
-	const promptAssemblyBlock = source.slice(
-		source.indexOf("const prompt = ["),
-		source.indexOf("const prompt = [") + 1500,
-	);
-	assert(
-		promptAssemblyBlock.includes("archiveSuppression"),
-		"archiveSuppression is included in prompt array",
 	);
 
 	// Verify executeTask archival is gated in orchestrated mode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.22.17",
+  "version": "0.22.18",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Worker prompt reduced from ~50K to ~500 chars. The worker reads PROMPT.md and STATUS.md itself instead of receiving them pre-compiled in the system prompt.

Eliminates the command line length issue at its source and reduces initial context consumption.