### PR TITLE
docs(runtime-v2): architecture planning suite, TP-100..TP-110 backlog, and assumption lab

### DIFF
--- a/docs/specifications/README.md
+++ b/docs/specifications/README.md
@@ -51,4 +51,5 @@ Specs that have been fully or substantially implemented. Moved to
 | [cli/commands-cheat-sheet.md](cli/commands-cheat-sheet.md) | Quick reference for CLI commands |
 | [cli/NPM-PUBLISHING.md](cli/NPM-PUBLISHING.md) | npm publish workflow |
 | [framework/33-parallel-task-orchestrator.md](framework/33-parallel-task-orchestrator.md) | Original orchestrator design (early framework era) |
+| [framework/taskplane-runtime-v2/README.md](framework/taskplane-runtime-v2/README.md) | Foundational no-TMUX runtime redesign: mailbox-first control plane, headless lane runners, dashboard-first visibility |
 | [open-source-documentation-plan.md](open-source-documentation-plan.md) | Documentation structure plan |

--- a/docs/specifications/framework/taskplane-runtime-v2/01-architecture.md
+++ b/docs/specifications/framework/taskplane-runtime-v2/01-architecture.md
@@ -1,0 +1,294 @@
+# Runtime V2 Architecture
+
+**Status:** Proposed  
+**Related:** [README](README.md), `docs/specifications/taskplane/spawn-telemetry-stability.md`
+
+## 1. Executive summary
+
+Taskplane should keep its **durable data plane** and replace its fragile
+**runtime control plane**.
+
+### Keep
+
+- `PROMPT.md`, `STATUS.md`, `.DONE`
+- `.pi/batch-state.json`
+- dependency DAG, waves, lanes, worktrees, orch branches
+- supervisor and dashboard concepts
+- packet-home / workspace mode contracts
+
+### Replace
+
+- TMUX as correctness infrastructure
+- lane Pi sessions as orchestration hosts
+- `/orch` bootstrapping `/task` through `TASK_AUTOSTART`
+- sidecar-file tailing as the primary live telemetry transport
+- session identity coupled to terminal sessions
+
+## 2. Core diagnosis
+
+The current failures are not isolated implementation bugs; they come from a
+control plane with too many overlapping layers:
+
+```text
+operator pi session
+  -> orch extension
+    -> engine child
+      -> tmux lane session
+        -> rpc-wrapper
+          -> pi task-runner session
+            -> tmux worker session
+              -> rpc-wrapper
+                -> pi worker
+```
+
+This creates recurring instability:
+
+1. **ambiguous ownership** — when a child dies, the system cannot reliably say
+   which layer failed first or who should clean it up
+2. **transport inversion** — directly related processes communicate live state
+   through files rather than direct IPC
+3. **extension-host coupling** — orchestrated execution depends on extension
+   lifecycle behavior that was originally built for `/task`
+4. **terminal dependency** — agent liveness and visibility depend on TMUX/MSYS
+   behavior instead of deterministic Node process ownership
+
+## 3. Target architecture
+
+```text
+operator pi session / supervisor
+  -> taskplane extension (command surface only)
+    -> engine process (deterministic Node)
+      -> lane-runner process per active lane (deterministic Node)
+        -> agent-host process: worker
+          -> pi --mode rpc
+        -> agent-host process: reviewer
+          -> pi --mode rpc
+      -> agent-host process: merger
+        -> pi --mode rpc
+```
+
+### Key rule
+
+**Every spawned process has exactly one deterministic owner.**
+
+- extension owns engine process
+- engine owns lane-runners and merge hosts
+- lane-runner owns worker/reviewer hosts
+- agent-host owns its Pi child
+
+No process should need to infer liveness from TMUX server state.
+
+## 4. Component responsibilities
+
+## 4.1 Extension (`extensions/taskplane/extension.ts`)
+
+Owns:
+
+- command registration (`/orch*`, settings, supervisor tools)
+- supervisor activation and routing UX
+- batch start/resume/abort requests into the engine
+- process-registry-backed operator tools (`list_active_agents`, `read_agent_status`, mailbox tools)
+
+Does **not** own:
+
+- lane execution loops
+- worker/reviewer lifecycle
+- live telemetry parsing from sidecar files
+
+## 4.2 Engine process
+
+Owns:
+
+- discovery, DAG, wave planning, lane allocation
+- persisted batch state and resume orchestration
+- worktree/orch-branch lifecycle
+- launching lane-runners and merge hosts
+- aggregate policy decisions (pause, resume, abort, retry, skip, merge)
+- high-level events to supervisor/dashboard
+
+Does **not** own:
+
+- per-task worker loops
+- direct agent-tool protocol details
+
+## 4.3 Lane-runner process
+
+New deterministic runtime component.
+
+Owns:
+
+- exactly one lane worktree at a time
+- serial task/segment execution inside that lane
+- task execution state machine
+- STATUS parsing, step progression, checkpoint discipline, .DONE handling
+- reviewer orchestration for that lane
+- lane snapshot emission
+- packet-path authority enforcement
+
+This replaces the current pattern where a lane is a Pi session loading the
+`task-runner.ts` extension.
+
+## 4.4 Agent-host process
+
+New transport adapter around `pi --mode rpc`.
+
+Owns:
+
+- Pi subprocess lifecycle
+- live RPC event parsing
+- telemetry normalization
+- mailbox inbox polling + `steer` injection
+- conversation/event persistence
+- exit summary generation
+- process manifest updates
+
+This is the right place for transport concerns currently split between TMUX,
+`rpc-wrapper.mjs`, and lane-hosted extension code.
+
+## 4.5 Dashboard server
+
+Owns:
+
+- reading normalized runtime artifacts
+- SSE updates to browser clients
+- conversation views from structured event logs
+- mailbox/message panel
+- process/agent status panels
+
+It should never need TMUX pane capture for primary visibility.
+
+## 5. Required invariants
+
+1. **File-backed memory stays authoritative**
+   - `STATUS.md` remains the execution memory.
+   - `.DONE` remains the completion marker.
+
+2. **Batch state remains resumable**
+   - `.pi/batch-state.json` continues as canonical orchestration state.
+
+3. **Live control uses direct ownership, not file polling between siblings**
+   - parents receive child telemetry directly
+   - files persist durable history and snapshots
+
+4. **Mailbox is the only supported steering path**
+   - operator talks to supervisor
+   - supervisor talks to agents
+   - agents reply/escalate through mailbox/outbox
+
+5. **No correctness dependency on terminal infrastructure**
+   - no task outcome should depend on `tmux has-session`, pane capture, or attachability
+
+6. **Packet-home authority is explicit**
+   - segment repo and packet repo may differ
+   - packet file paths are passed explicitly, never inferred from `cwd`
+
+## 6. Canonical runtime storage layout
+
+Runtime V2 introduces a batch-scoped runtime directory:
+
+```text
+.pi/runtime/{batchId}/
+├── agents/
+│   └── {agentId}/
+│       ├── manifest.json
+│       ├── events.jsonl
+│       ├── stderr.log
+│       ├── exit.json
+│       └── bridge/
+├── lanes/
+│   └── lane-{N}.json
+├── merge/
+│   └── merge-{N}.json
+└── registry.json
+```
+
+Existing top-level durable files remain:
+
+```text
+.pi/batch-state.json
+.pi/mailbox/{batchId}/...
+.pi/supervisor/events.jsonl
+.pi/supervisor/actions.jsonl
+```
+
+### Compatibility note
+
+During migration, Runtime V2 may mirror selected legacy artifacts
+(`lane-state-*.json`, legacy conversation JSONL names) so the dashboard and
+supervisor tools can be migrated incrementally.
+
+## 7. Agent identity
+
+Runtime V2 keeps the familiar current identifiers but redefines them as
+**agent IDs**, not TMUX session names.
+
+Examples:
+
+- `orch-henrylach-lane-1-worker`
+- `orch-henrylach-lane-1-reviewer`
+- `orch-henrylach-merge-1`
+
+This preserves operator familiarity and minimizes command/tool churn while
+removing any implication that an agent is backed by a terminal session.
+
+## 8. Steering and visibility without TMUX
+
+### Steering
+
+- supervisor writes mailbox messages to agent inboxes
+- agent-host checks mailbox at `message_end`
+- agent-host injects messages via Pi RPC `steer`
+- agent replies go to outbox and appear in supervisor/dashboard surfaces
+
+### Visibility
+
+- agent-host persists normalized event streams
+- lane-runner emits lane snapshots directly
+- dashboard renders full conversation from structured logs
+- no pane capture fallback is required for the steady state
+
+## 9. `/task` end state
+
+`/task` is already deprecated in user-facing docs. Runtime V2 finishes the job:
+
+- the **authoritative** execution path is `/orch`, even for one task
+- legacy `/task` becomes a compatibility wrapper around the same headless
+  execution core, or is removed in a future major version
+- no mission-critical runtime logic should live only inside the deprecated path
+
+## 10. Feature posture after redesign
+
+### Must survive the redesign
+
+- persistent worker context
+- checkpoint discipline
+- worker-driven review entrypoint (`review_step`) or a compatible replacement
+- quality gate semantics
+- model fallback
+- supervisor alert flow
+- polyrepo packet-home correctness
+
+### May be reintroduced as optional optimizations after baseline stability
+
+- persistent reviewer context
+- advanced reviewer parking/wait loops
+- optional detached runtime service beyond the operator session
+
+## 11. Non-goals for Runtime V2 baseline
+
+These are intentionally deferred until the headless runtime is stable:
+
+- detached always-on background daemon/service
+- remote multi-operator control plane
+- cross-machine execution
+- terminal attach/debug UX parity with TMUX
+
+## 12. Success criteria
+
+Runtime V2 is architecturally complete when:
+
+- worker/reviewer/merge lifecycle no longer depends on TMUX
+- the dashboard can show agent conversations and telemetry without pane capture
+- `send_agent_message` and future mailbox features operate on agent IDs backed by a process registry
+- the lane execution path no longer depends on `task-runner.ts` session lifecycle
+- workspace/segment execution uses explicit packet-path authority end-to-end

--- a/docs/specifications/framework/taskplane-runtime-v2/02-runtime-process-model.md
+++ b/docs/specifications/framework/taskplane-runtime-v2/02-runtime-process-model.md
@@ -1,0 +1,360 @@
+# Runtime Process Model
+
+**Status:** Proposed  
+**Related:** [01-architecture.md](01-architecture.md)
+
+## 1. Purpose
+
+This document defines the concrete process model for Runtime V2:
+
+- who spawns what
+- who owns cleanup
+- how liveness is tracked
+- how `/task` is removed from the critical path
+- how existing execution semantics move into headless runtime code
+
+## 2. Process tree
+
+```text
+operator pi session
+  -> taskplane extension host
+    -> engine process
+      -> lane-runner process (lane 1)
+        -> agent-host (worker)
+          -> pi --mode rpc
+        -> agent-host (reviewer)
+          -> pi --mode rpc
+      -> lane-runner process (lane 2)
+      -> agent-host (merge-1)
+        -> pi --mode rpc
+```
+
+## 3. Ownership rules
+
+## 3.1 Extension owns the engine
+
+The extension may start, stop, or reconnect to the engine, but it does not own
+per-agent subprocesses directly.
+
+## 3.2 Engine owns lane-runners and merge hosts
+
+The engine is the single authority for:
+
+- launching lane-runners for active lanes
+- launching merge hosts for active merges
+- sending pause/resume/abort signals downward
+- updating batch state based on child results
+
+## 3.3 Lane-runner owns worker and reviewer hosts
+
+The lane-runner is the only authority for:
+
+- worker iteration loops
+- reviewer launches for the current lane/task
+- status progression within that lane
+- deciding when to respawn a worker due to context limit, timer, or crash
+
+## 3.4 Agent-host owns exactly one Pi child
+
+The agent-host owns:
+
+- the child process handle
+- stdin/stdout/stderr
+- exit classification input
+- mailbox injection timing
+- runtime manifest updates
+
+No other process should attempt to kill or infer state for the Pi child except
+through the host’s parent.
+
+## 4. New runtime modules
+
+## 4.1 `task-executor-core.ts`
+
+A shared, headless library extracted from `task-runner.ts`.
+
+Owns:
+
+- task packet parsing
+- STATUS parsing and mutation helpers
+- step progression rules
+- checkpoint and completion logic
+- quality gate orchestration contracts
+- worker/reviewer prompt assembly
+
+Does not own:
+
+- extension UI
+- command registration
+- parent/child process management
+
+## 4.2 `lane-runner.ts`
+
+Headless per-lane runtime process.
+
+Suggested inputs:
+
+- batch metadata
+- lane metadata (lane number, branch, worktree, repoId)
+- assigned execution units (task or segment)
+- config snapshot
+- packet-path authority data
+- runtime root path
+
+Suggested outputs:
+
+- lane snapshots
+- task outcomes
+- structured lane events
+- child agent launch requests (internal to process)
+
+## 4.3 `agent-host.mjs`
+
+Replacement for the current TMUX-backed `rpc-wrapper.mjs` role.
+
+Minimum responsibilities:
+
+- spawn `pi --mode rpc --no-session` with `shell: false`
+- parse RPC JSONL
+- normalize telemetry and conversation events
+- inject mailbox messages with RPC `steer`
+- write manifest/events/exit files
+- stream normalized events to parent over IPC or stdout
+
+## 4.4 `agent-bridge-extension.ts`
+
+Minimal extension loaded into Pi agents only when a runtime callback is needed.
+
+Candidate tools:
+
+- `review_step`
+- `wait_for_review` (optional baseline; may be deferred if persistent reviewer is temporarily removed)
+- `notify_supervisor`
+- `reply_supervisor`
+- `request_segment_expansion`
+
+This extension should stay intentionally tiny and protocol-focused.
+
+## 5. Stable agent IDs
+
+Runtime V2 keeps current human-readable IDs but treats them as runtime IDs,
+not terminal names.
+
+| Role | Canonical ID example |
+|---|---|
+| worker | `orch-henrylach-lane-1-worker` |
+| reviewer | `orch-henrylach-lane-1-reviewer` |
+| merger | `orch-henrylach-merge-1` |
+| lane-runner | `orch-henrylach-lane-1` |
+
+### Rule
+
+These identifiers are **opaque stable runtime IDs**. Tools and dashboard code
+must stop assuming they correspond to a TMUX session.
+
+## 6. Process registry
+
+Runtime V2 replaces TMUX discovery with a file-backed process registry.
+
+### Canonical registry
+
+```text
+.pi/runtime/{batchId}/registry.json
+```
+
+### Per-agent manifest
+
+```text
+.pi/runtime/{batchId}/agents/{agentId}/manifest.json
+```
+
+Suggested manifest shape:
+
+```json
+{
+  "batchId": "20260330T120000",
+  "agentId": "orch-henrylach-lane-1-worker",
+  "role": "worker",
+  "laneNumber": 1,
+  "taskId": "TP-091",
+  "repoId": "default",
+  "pid": 12345,
+  "parentPid": 12000,
+  "startedAt": 1774850000000,
+  "status": "running",
+  "cwd": "C:/dev/taskplane/.worktrees/.../lane-1",
+  "packet": {
+    "promptPath": "...",
+    "statusPath": "...",
+    "donePath": "...",
+    "reviewsDir": "..."
+  }
+}
+```
+
+## 6.1 Registry invariants
+
+1. Parent writes the manifest before the child is considered visible.
+2. Parent updates status on normal exit, kill, timeout, crash, and orphan recovery.
+3. Operator tools read the registry, not TMUX.
+4. Resume/orphan cleanup validates `pid` + process liveness + `startedAt`.
+
+## 7. Liveness and cleanup semantics
+
+## 7.1 Live control
+
+Use actual child handles and parent-owned timers/signals.
+
+Do **not** use:
+
+- `tmux has-session`
+- shell polling to infer child existence
+- delayed session stabilization loops as the primary liveness mechanism
+
+## 7.2 Graceful stop sequence
+
+For worker/reviewer/merge hosts:
+
+1. send mailbox `abort` or runtime stop request
+2. allow wrap-up grace period
+3. send process termination
+4. escalate to force kill after timeout
+5. mark manifest/exit summary accordingly
+
+## 7.3 Orphan recovery on restart
+
+At engine startup or resume:
+
+1. load runtime registry for the batch
+2. inspect recorded PIDs
+3. determine which processes are still alive
+4. either reconnect (if supported in the phase) or terminate and rehydrate from file-backed state
+5. never leave a live unknown child burning credits silently
+
+### Baseline recommendation
+
+For first Runtime V2 implementation, prioritize:
+
+- **detect + terminate + rehydrate**
+
+before attempting:
+
+- **full live reattachment to pre-existing agent-host processes**
+
+This gives deterministic recovery faster.
+
+## 8. Execution lifecycle
+
+## 8.1 Batch start
+
+1. extension requests batch start
+2. engine writes batch state and runtime root
+3. engine provisions worktrees/branches
+4. engine spawns lane-runners
+5. lane-runners begin execution units
+6. dashboard and supervisor read registry/events immediately
+
+## 8.2 Single lane execution
+
+1. lane-runner receives next execution unit
+2. lane-runner resolves packet paths and worktree paths
+3. lane-runner spawns worker host
+4. worker host streams normalized events directly back to lane-runner
+5. lane-runner updates lane snapshot and STATUS-driven state
+6. when reviews are required, lane-runner spawns reviewer host(s)
+7. lane-runner writes `.DONE` if completion criteria are met
+8. lane-runner returns outcome to engine
+
+## 8.3 Merge execution
+
+1. engine provisions merge worktree
+2. engine spawns merge host directly
+3. merge host emits normalized merge telemetry/events
+4. engine applies merge result and proceeds or pauses
+
+## 9. `/task` deprecation strategy
+
+Runtime V2 should stop treating `/task` as a privileged implementation host.
+
+### Public product position
+
+- `/orch <PROMPT.md>` is the only recommended single-task execution path
+- `/task` remains deprecated and should not receive new architecture-critical features
+
+### Implementation position
+
+Two acceptable end states:
+
+#### Option A — compatibility shim
+
+`/task` becomes a thin wrapper that invokes the same headless execution core used
+by `/orch` single-task mode.
+
+#### Option B — removal in next major
+
+- remove `/task`, `/task-status`, `/task-pause`, `/task-resume`
+- provide migration messaging and aliases during transition period
+
+### Mandatory rule
+
+No new critical runtime behavior may be implemented only inside `task-runner.ts`
+as a Pi extension.
+
+## 10. Worker/reviewer feature posture
+
+## 10.1 Baseline required for first Runtime V2
+
+- persistent worker context
+- review support at step boundaries
+- mailbox steering
+- quality gate support
+- model fallback
+- deterministic crash/timeout handling
+
+## 10.2 Allowed simplification for first stable cut
+
+If needed for stability, Runtime V2 may temporarily ship with:
+
+- **ephemeral reviewers as the baseline**
+
+while keeping the protocol open for later reintroduction of persistent reviewer
+parking (`wait_for_review`) as an optimization.
+
+That trade is acceptable because resilience is the higher-order requirement.
+
+## 11. Packet-path authority in the process model
+
+Every lane-runner and agent-host launch contract must carry explicit packet paths
+when the packet home differs from the active segment repo.
+
+Required fields:
+
+- `promptPath`
+- `statusPath`
+- `donePath`
+- `reviewsDir`
+
+This is the runtime equivalent of the planned TP-082 / TP-088 contract.
+
+## 12. Windows-specific requirements
+
+Runtime V2 must eliminate the classes of Windows failures currently amplified by
+TMUX/MSYS shells.
+
+Required rules:
+
+1. prefer `spawn(..., { shell: false })`
+2. pass argument arrays, not shell-composed strings
+3. avoid terminal/session semantics for liveness
+4. avoid shell quoting as a primary correctness mechanism
+5. use process-registry-based cleanup instead of server/session cleanup
+
+## 13. Acceptance criteria
+
+This process model is accepted when:
+
+- `list_active_agents` can be implemented entirely from the process registry
+- `send_agent_message` no longer checks `tmuxHasSession()`
+- lane progress does not require a lane Pi session to host task execution
+- worker/reviewer crashes are reported from actual process ownership and exit summaries
+- the system can run without TMUX installed

--- a/docs/specifications/framework/taskplane-runtime-v2/03-bridge-and-mailbox.md
+++ b/docs/specifications/framework/taskplane-runtime-v2/03-bridge-and-mailbox.md
@@ -1,0 +1,337 @@
+# Bridge and Mailbox Protocols
+
+**Status:** Proposed  
+**Related:** [02-runtime-process-model.md](02-runtime-process-model.md), `docs/specifications/taskplane/agent-mailbox-steering.md`
+
+## 1. Purpose
+
+Runtime V2 needs two distinct communication layers:
+
+1. **Mailbox** — cross-agent / supervisor messaging, durable, asynchronous, auditable
+2. **Runtime bridge** — deterministic request/response protocol between lane-runner and Pi agents for execution-time callbacks such as reviews and segment-expansion requests
+
+The current mailbox work (TP-089, TP-090) remains strategically correct and
+should be preserved. What changes is the runtime substrate around it.
+
+## 2. Mailbox remains the canonical steering channel
+
+### Rule
+
+Operators do not type into agents directly.
+
+Communication path is always:
+
+```text
+operator -> supervisor -> mailbox -> agent-host -> Pi RPC steer -> agent
+```
+
+This is a feature, not a limitation:
+
+- one conversation surface for the user
+- auditable steering history
+- no terminal-state hazards
+- no accidental agent bypass of supervisor policy
+
+## 3. Mailbox identity model
+
+Mailbox addressing continues to use the familiar current strings, but they are
+**agent IDs**, not TMUX session names.
+
+### Examples
+
+- `orch-henrylach-lane-1-worker`
+- `orch-henrylach-lane-1-reviewer`
+- `orch-henrylach-merge-1`
+- `_broadcast`
+
+Existing TP-089/090 file layout can be preserved:
+
+```text
+.pi/mailbox/{batchId}/
+├── {agentId}/
+│   ├── inbox/
+│   ├── ack/
+│   ├── outbox/
+│   └── processed/
+└── _broadcast/
+    └── inbox/
+```
+
+## 4. Supervisor -> agent flow
+
+```text
+supervisor tool
+  -> write mailbox message
+    -> agent-host checks inbox at message_end
+      -> inject via Pi RPC steer
+        -> move inbox file to ack/
+          -> emit message-delivered event
+```
+
+### Required properties
+
+- delivery occurs at turn boundaries
+- delivery is durable across host crashes until acked
+- dashboard shows pending vs delivered status
+- no TMUX liveness check is involved
+
+### `send_agent_message` validation source
+
+`send_agent_message()` should validate against the **process registry**, not TMUX:
+
+- batch exists and is non-terminal
+- target agent ID exists in registry for the batch
+- target is in a live/steerable state
+
+## 5. Agent -> supervisor flow
+
+TP-091 becomes a first-class Runtime V2 feature, not an afterthought.
+
+```text
+agent tool / bridge
+  -> write outbox message
+    -> engine or lane-runner polls/receives it
+      -> emit supervisor alert + dashboard event
+        -> supervisor may reply through mailbox
+```
+
+### Required message types
+
+- `reply`
+- `escalate`
+
+### Typical use cases
+
+- worker asks for guidance under ambiguity
+- worker acknowledges a steering message with a status update
+- reviewer escalates malformed request or blocked state
+- merge agent escalates impossible/manual conflict
+- future segment expansion request references supervisor decision flow
+
+## 6. Mailbox follow-ons under Runtime V2
+
+## 6.1 TP-091 — replies
+
+Keep the task, but re-scope implementation assumptions:
+
+- outbox reader should be engine/lane-runner/process-registry aware
+- reply display should target supervisor + dashboard surfaces
+- session-name assumptions must become agent-ID assumptions
+
+## 6.2 TP-092 — broadcast and rate limiting
+
+Keep the task almost unchanged.
+
+Runtime V2 still needs:
+
+- `_broadcast` support
+- per-agent rate limiting
+- compatibility with mailbox delivery at `message_end`
+
+## 6.3 TP-093 — dashboard mailbox panel
+
+Keep the task, but build the panel on top of:
+
+- mailbox directories
+- registry-backed agent metadata
+- normalized message delivery events
+
+not TMUX-derived lane/session assumptions.
+
+## 7. Runtime bridge purpose
+
+The mailbox is not sufficient for synchronous execution callbacks like:
+
+- `review_step`
+- `wait_for_review`
+- `request_segment_expansion`
+- structured runtime acknowledgments that must return data to the current turn
+
+These need a **bridge protocol** between Pi agents and their deterministic owner.
+
+## 8. Bridge design goals
+
+1. deterministic and file-backed
+2. works in worker/reviewer/merge agents without TMUX
+3. supports request/response semantics
+4. survives parent/child crashes cleanly
+5. is minimal and role-focused
+
+## 9. Bridge topology
+
+Per-agent bridge directories live under the runtime root:
+
+```text
+.pi/runtime/{batchId}/agents/{agentId}/bridge/
+├── requests/
+├── responses/
+└── signals/
+```
+
+### Protocol shape
+
+- agent-side bridge tool writes a request file
+- deterministic owner writes a response file
+- tool polls/waits for matching response with timeout
+
+This mirrors the existing file-first coordination style already used in Taskplane.
+
+## 10. Minimal bridge tools
+
+## 10.1 `review_step`
+
+Available to worker agents.
+
+Request shape:
+
+```json
+{
+  "id": "req-001",
+  "type": "review_step",
+  "taskId": "TP-091",
+  "step": 2,
+  "reviewType": "plan",
+  "requestPath": "...",
+  "responsePath": "..."
+}
+```
+
+Response shape:
+
+```json
+{
+  "id": "req-001",
+  "ok": true,
+  "verdict": "APPROVE",
+  "reviewPath": "...",
+  "summary": "No blocking issues"
+}
+```
+
+### Baseline requirement
+
+The worker must be able to request and receive a deterministic review verdict
+without the lane itself being a Pi extension host.
+
+## 10.2 `notify_supervisor`
+
+Available to all agent roles.
+
+Purpose:
+
+- durable agent -> supervisor escalation
+- convenience wrapper for outbox writing
+- avoids requiring agents to hand-roll JSON with `write`/`bash`
+
+## 10.3 `reply_supervisor`
+
+Available to all agent roles.
+
+Purpose:
+
+- structured response to a `query`
+- explicit threading through `replyTo`
+
+## 10.4 `request_segment_expansion`
+
+Available to worker agents in segment-aware runtime.
+
+Purpose:
+
+- structured handoff into the future TP-086 / TP-087 expansion flow
+
+## 10.5 `wait_for_review` (optional optimization)
+
+This remains optional for the first stable Runtime V2 cut.
+
+If persistent reviewers are retained or reintroduced, `wait_for_review` can be
+implemented as a bridge-based parked reviewer flow. If not, Runtime V2 may use
+fresh reviewer processes first and add persistent reviewer parking later.
+
+## 11. Why bridge + mailbox instead of one protocol
+
+They solve different problems:
+
+| Need | Mailbox | Bridge |
+|---|---|---|
+| Supervisor steering | ✅ | ❌ |
+| Agent replies/escalations | ✅ | ⚠️ could, but not ideal |
+| Audit trail | ✅ | ✅ |
+| Synchronous tool result | ❌ | ✅ |
+| Cross-role messaging | ✅ | ❌ owner-local only |
+| Review callback | ❌ | ✅ |
+
+## 12. Conversation visibility contract
+
+Mailbox events and bridge events both need to be visible downstream.
+
+### Mailbox event types
+
+- `message_sent`
+- `message_delivered`
+- `message_replied`
+- `message_escalated`
+- `message_rate_limited`
+
+### Bridge event types
+
+- `review_requested`
+- `review_completed`
+- `review_failed`
+- `segment_expansion_requested`
+- `segment_expansion_decided`
+
+The dashboard should render these without needing to inspect raw implementation files.
+
+## 13. Supervisor-facing tool set after redesign
+
+Required tools:
+
+- `send_agent_message(to, content, type?)`
+- `read_agent_replies(from?)`
+- `broadcast_message(content, type?)`
+- existing recovery tools (`orch_retry_task`, `orch_skip_task`, `orch_force_merge`, etc.)
+
+### Recommended additions
+
+- `read_agent_messages(agentId?)` — unified sent + delivered + reply history
+- `read_agent_events(agentId?)` — normalized event tail for diagnosis
+
+## 14. Rate limiting
+
+Rate limiting from TP-092 remains valid.
+
+### Required policy
+
+- max 1 supervisor-originated message per agent per 30 seconds by default
+- broadcast counts against each recipient’s budget
+- `abort` may bypass or use a stricter dedicated policy if required
+- rate-limit decisions are surfaced to supervisor and dashboard
+
+## 15. Failure semantics
+
+### Mailbox failure
+
+If mailbox delivery fails:
+
+- message remains in inbox until delivered or explicitly invalidated
+- invalid target/state is rejected before write
+- ack state remains authoritative for delivery confirmation
+
+### Bridge failure
+
+If a bridge request times out:
+
+- the tool call returns a structured failure to the agent
+- deterministic owner records the timeout in runtime events
+- supervisor may be alerted if policy requires
+
+## 16. Acceptance criteria
+
+This protocol layer is accepted when:
+
+- steering works without TMUX installed
+- agents can escalate/reply without hand-rolling JSON via generic tools
+- worker review callbacks no longer depend on the lane being a Pi extension host
+- dashboard can show mailbox activity and bridge-driven review activity
+- TP-091, TP-092, TP-093, and future TP-086 all fit the same protocol family

--- a/docs/specifications/framework/taskplane-runtime-v2/04-observability-and-dashboard.md
+++ b/docs/specifications/framework/taskplane-runtime-v2/04-observability-and-dashboard.md
@@ -1,0 +1,327 @@
+# Observability and Dashboard Model
+
+**Status:** Proposed  
+**Related:** [01-architecture.md](01-architecture.md), [03-bridge-and-mailbox.md](03-bridge-and-mailbox.md)
+
+## 1. Goal
+
+Runtime V2 must provide **better** visibility than TMUX, not merely visibility
+without TMUX.
+
+The dashboard becomes the canonical operator surface for:
+
+- live agent conversations
+- lane/task/segment progress
+- message steering and replies
+- context/cost/tool telemetry
+- process health
+- supervisor actions and engine events
+
+## 2. Design rule
+
+**All primary visibility must come from normalized runtime artifacts, not
+terminal capture.**
+
+That means no dependence on:
+
+- TMUX pane capture
+- attachable terminals
+- stderr-only diagnostics for routine monitoring
+
+## 3. Event model
+
+Agent-hosts should emit normalized events directly to their parent and persist
+those same normalized events durably.
+
+### Canonical per-agent log
+
+```text
+.pi/runtime/{batchId}/agents/{agentId}/events.jsonl
+```
+
+### Canonical aggregate snapshots
+
+```text
+.pi/runtime/{batchId}/lanes/lane-{N}.json
+.pi/runtime/{batchId}/registry.json
+```
+
+## 4. Normalized event schema
+
+Suggested common fields:
+
+```json
+{
+  "batchId": "20260330T120000",
+  "agentId": "orch-henrylach-lane-1-worker",
+  "role": "worker",
+  "laneNumber": 1,
+  "taskId": "TP-091",
+  "repoId": "default",
+  "ts": 1774850000000,
+  "type": "tool_call",
+  "payload": { "tool": "read", "path": "STATUS.md" }
+}
+```
+
+### Required event families
+
+#### Lifecycle
+
+- `agent_started`
+- `agent_exited`
+- `agent_killed`
+- `agent_crashed`
+- `agent_timeout`
+
+#### Conversation
+
+- `prompt_sent`
+- `assistant_message`
+- `tool_call`
+- `tool_result`
+- `message_delivered` (mailbox steer)
+- `reply_sent`
+- `escalation_sent`
+
+#### Telemetry
+
+- `usage_delta`
+- `context_usage`
+- `retry_started`
+- `retry_finished`
+- `compaction_started`
+- `compaction_finished`
+
+#### Review / bridge
+
+- `review_requested`
+- `review_completed`
+- `review_failed`
+- `segment_expansion_requested`
+- `segment_expansion_decided`
+
+#### Engine / supervisor
+
+These continue to live in the existing supervisor event streams:
+
+- `.pi/supervisor/events.jsonl`
+- `.pi/supervisor/actions.jsonl`
+
+## 5. Snapshot model
+
+Snapshots are for current state; event logs are for history.
+
+### Lane snapshot
+
+Suggested shape:
+
+```json
+{
+  "batchId": "20260330T120000",
+  "laneNumber": 1,
+  "laneId": "lane-1",
+  "repoId": "default",
+  "taskId": "TP-091",
+  "segmentId": null,
+  "status": "running",
+  "worker": {
+    "agentId": "orch-henrylach-lane-1-worker",
+    "status": "running",
+    "elapsedMs": 42000,
+    "toolCalls": 18,
+    "contextPct": 37.2,
+    "costUsd": 0.41,
+    "lastTool": "edit extensions/taskplane/engine.ts"
+  },
+  "reviewer": null,
+  "progress": {
+    "currentStep": "Step 2: Engine outbox polling",
+    "checked": 5,
+    "total": 14,
+    "iteration": 2,
+    "reviews": 1
+  }
+}
+```
+
+### Registry snapshot
+
+Contains:
+
+- live agents and lane-runners
+- pids and statuses
+- task/repo attribution
+- start times and ownership metadata
+
+This replaces TMUX discovery for active-agent surfaces.
+
+## 6. Conversation viewer
+
+The conversation viewer should read normalized event streams, not raw pane text.
+
+### Required display abilities
+
+- assistant messages in order
+- tool call/result pairs
+- injected steering messages at the correct point in the conversation
+- review requests/verdict summaries
+- agent replies/escalations
+- token/context/cost summaries per turn
+
+### Why this is better than terminal capture
+
+- deterministic structure
+- no ANSI noise
+- no missing history due to scrollback limits
+- works identically on Windows/macOS/Linux
+- can be filtered and summarized intelligently
+
+## 7. Dashboard sections after Runtime V2
+
+## 7.1 Batch overview
+
+Keep existing overview, but source it from batch state + runtime registry.
+
+## 7.2 Lanes / tasks / segments
+
+Show:
+
+- lane health
+- current task and segment
+- packet-home repo where relevant
+- progress from STATUS-derived snapshots
+- worker/reviewer status and telemetry
+
+## 7.3 Agents
+
+A dedicated process-registry-backed panel replacing TMUX-centric views.
+
+Show:
+
+- agent ID
+- role
+- lane
+- task / segment
+- pid
+- state (`running`, `wrapping_up`, `exited`, `crashed`)
+- elapsed time
+- context percent
+- cost
+
+## 7.4 Messages
+
+TP-093 should land here in the Runtime V2 world.
+
+Show:
+
+- supervisor -> agent messages
+- delivered status
+- replies/escalations back to supervisor
+- broadcast events
+- rate-limit rejections
+
+## 7.5 Supervisor
+
+Keep and strengthen current supervisor visibility:
+
+- lock state
+- actions
+- engine events
+- conversation history
+- recovery actions taken
+
+## 7.6 Diagnostics
+
+A first-class panel for:
+
+- agent crashes / exit classifications
+- retry histories
+- timeout events
+- bridge failures
+- merge failures
+
+## 8. Legacy compatibility shims
+
+During migration, the dashboard server may temporarily support both:
+
+### Legacy
+
+- `.pi/lane-state-*.json`
+- `.pi/telemetry/*.jsonl`
+- `.pi/worker-conversation-*.jsonl`
+
+### Runtime V2
+
+- `.pi/runtime/{batchId}/lanes/*.json`
+- `.pi/runtime/{batchId}/agents/*/events.jsonl`
+- `.pi/runtime/{batchId}/registry.json`
+
+The server should prefer Runtime V2 artifacts when both exist.
+
+## 9. Cost and context accounting
+
+The dashboard should stop reconstructing truth indirectly from mismatched files.
+
+### Rule
+
+- live telemetry comes directly from agent-host normalized events
+- snapshots store already-aggregated current values
+- event logs store full history
+
+### Context pressure logic
+
+- warning thresholds are driven by authoritative `contextUsage`
+- kill/wrap-up decisions are visible in both lane snapshot and event stream
+- context snapshots remain durable artifacts for later analysis
+
+## 10. Operator tools backed by the same model
+
+These tools should read the same registry/snapshots the dashboard reads:
+
+- `read_agent_status`
+- `list_active_agents`
+- `read_agent_replies`
+- future `read_agent_events`
+
+This avoids tool/dashboard drift.
+
+## 11. Acceptance tests for observability
+
+Runtime V2 observability is not complete until the following are demonstrably true:
+
+1. **No-TMUX visibility**
+   - a running batch with TMUX absent still shows live worker conversations and telemetry
+
+2. **Mailbox visibility**
+   - steering messages appear as pending then delivered
+   - replies and escalations appear in supervisor + dashboard
+
+3. **Crash visibility**
+   - agent crash produces exit classification, stderr path, and recovery context without manual log scraping
+
+4. **Polyrepo visibility**
+   - repo ID, packet-home repo, and active segment are visible where applicable
+
+5. **Resume visibility**
+   - after an interruption, registry/snapshot/event surfaces clearly distinguish resumed agents from historical ones
+
+## 12. Soak-test observability requirements
+
+For multi-hour and multi-day batches, the dashboard must remain useful without unbounded growth.
+
+Required controls:
+
+- incremental JSONL tailing
+- bounded in-memory retention in the server
+- per-panel truncation and pagination where needed
+- log rotation/archival policies for runtime event files
+
+## 13. Success criteria
+
+This observability model is accepted when:
+
+- the dashboard no longer needs TMUX pane capture for primary worker visibility
+- the operator can inspect any active agent from structured logs alone
+- mailbox activity and bridge-driven reviews are visible in one place
+- lane snapshots and operator tools are derived from the same runtime truth

--- a/docs/specifications/framework/taskplane-runtime-v2/05-polyrepo-and-segment-compatibility.md
+++ b/docs/specifications/framework/taskplane-runtime-v2/05-polyrepo-and-segment-compatibility.md
@@ -1,0 +1,235 @@
+# Polyrepo and Segment Compatibility
+
+**Status:** Proposed  
+**Related:** [01-architecture.md](01-architecture.md), `docs/specifications/taskplane/multi-repo-task-execution.md`
+
+## 1. Purpose
+
+Runtime V2 must not be a single-repo-only stabilization project.
+
+The redesign has to strengthen, not weaken, Taskplane’s path toward:
+
+- packet-home authority
+- workspace mode correctness
+- segment-aware execution
+- cross-repo resume parity
+- dynamic segment expansion
+
+This document explains how the headless runtime aligns with TP-082 through TP-088.
+
+## 2. Core compatibility claim
+
+The no-TMUX redesign is **compatible with** and in several places **better for**
+packet-home and segment execution, because it removes hidden `cwd` and session
+assumptions from the runtime.
+
+## 3. Packet-home authority becomes mandatory runtime data
+
+Runtime V2 requires every execution unit to carry explicit packet-path metadata.
+
+### Required fields
+
+- `promptPath`
+- `statusPath`
+- `donePath`
+- `reviewsDir`
+- `packetHomeRepoId`
+- `executionRepoId`
+
+### Rule
+
+The lane-runner and any spawned agent-host must treat these packet paths as
+**authoritative**. They may not derive packet file locations from `cwd`.
+
+This is the architectural version of what TP-082 and TP-088 are trying to land.
+
+## 4. Execution unit model
+
+Runtime V2 should use a unified `ExecutionUnit` abstraction that supports both
+current task-level execution and future segment-level execution.
+
+Suggested shape:
+
+```ts
+interface ExecutionUnit {
+  id: string;                 // taskId or taskId::segmentId
+  taskId: string;
+  segmentId?: string | null;
+  executionRepoId: string;
+  packetHomeRepoId: string;
+  worktreePath: string;
+  packet: {
+    promptPath: string;
+    statusPath: string;
+    donePath: string;
+    reviewsDir: string;
+  };
+}
+```
+
+### Benefit
+
+This lets the engine and lane-runner support:
+
+- current single-task behavior
+- packet-home correctness
+- future segment frontier scheduling
+
+with one runtime contract.
+
+## 5. Lane-runner behavior in workspace mode
+
+A lane-runner executes in the active segment repo worktree, but packet files may
+live elsewhere.
+
+### Therefore
+
+The lane-runner must separate:
+
+- **execution filesystem authority** — active worktree/repo
+- **packet filesystem authority** — packet home paths
+
+This directly avoids the split-brain behavior described in the current multi-repo
+spec and seen in smoke-test failures.
+
+## 6. `.DONE` semantics in Runtime V2
+
+`.DONE` remains the completion marker, but Runtime V2 tightens the rule:
+
+- the only authoritative `.DONE` path is the execution unit’s explicit `donePath`
+- no lane-runner, engine, or resume flow may guess `.DONE` from worktree-relative paths when explicit packet paths exist
+
+This should be enforced everywhere:
+
+- execution completion checks
+- resume reconciliation
+- artifact staging
+- merge follow-up
+
+## 7. STATUS.md semantics in Runtime V2
+
+`STATUS.md` stays authoritative task memory.
+
+### Required invariants
+
+- worker reads/writes authoritative packet `statusPath`
+- lane-runner snapshots derive progress from authoritative packet state
+- dashboard shows packet-home-aware status in workspace mode
+- artifact staging never overwrites a newer packet-home STATUS update with stale execution-local copies
+
+## 8. Segment scheduling compatibility
+
+Runtime V2 does not block the segment roadmap; it gives it a cleaner substrate.
+
+## 8.1 TP-085 — segment frontier scheduler
+
+A headless lane-runner is a better host for segment frontier execution than a
+Pi extension session because:
+
+- it can own explicit `ExecutionUnit` metadata
+- it can update deterministic frontier state without extension/UI coupling
+- it can persist exact segment outcomes and packet paths cleanly
+
+## 8.2 TP-086 / TP-087 — dynamic segment expansion
+
+The bridge + mailbox architecture gives a natural path:
+
+- worker emits `request_segment_expansion`
+- lane-runner forwards structured request to engine
+- engine notifies supervisor
+- supervisor decides
+- engine mutates graph/frontier deterministically
+
+This is cleaner than trying to wedge the protocol through lane TMUX sessions.
+
+## 8.3 TP-083 — supervisor segment recovery and reordering
+
+Supervisor recovery should target execution-unit and frontier state, not TMUX sessions.
+
+That becomes easier when:
+
+- lane state is explicit
+- execution units are explicit
+- active agent IDs are registry-backed
+
+## 8.4 TP-084 — observability
+
+Segment observability should attach naturally to the Runtime V2 event and snapshot model:
+
+- active segment ID in lane snapshots
+- packet-home repo badge in task/segment UI
+- supervisor intervention history from normalized events
+
+## 9. Resume and reconciliation compatibility
+
+Resume logic should reconstruct from persisted execution-unit state, not from
+terminal or transport artifacts.
+
+### Required persisted fields for segment-aware Runtime V2
+
+- execution unit ID (`taskId` or `taskId::segmentId`)
+- packet paths
+- execution repo ID
+- packet home repo ID
+- latest lane snapshot state
+- last worker/reviewer outcome
+- graph revision / frontier metadata when segment expansion is enabled
+
+## 10. Artifact staging contract
+
+Runtime V2 should preserve the current important rule:
+
+- worker-generated packet artifacts are staged into the orch branch after successful execution/merge
+
+But with a stronger constraint:
+
+- staging always sources packet-home-authoritative files
+- staging logic must be aware that packet files and source changes may originate in different repos
+
+## 11. Multi-repo worktree model stays intact
+
+Runtime V2 does **not** replace the worktree/orch-branch model.
+
+It preserves:
+
+- repo-scoped worktrees
+- repo-scoped lane assignment
+- repo-aware merge orchestration
+- orch-managed branch lifecycle
+
+The redesign only changes **how the runtime inside those worktrees is hosted and observed**.
+
+## 12. Acceptance criteria for workspace mode
+
+Runtime V2 should not be considered complete until it passes these workspace-mode
+acceptance conditions:
+
+1. single-repo behavior remains unchanged when packet paths are local
+2. packet-home repo differs from execution repo and STATUS/.DONE still resolve correctly
+3. resume uses authoritative packet paths in all reconciliation branches
+4. dashboard shows repo ID + packet-home-aware status for active execution units
+5. dynamic segment expansion protocol can be layered in without changing runtime identity or mailbox assumptions
+
+## 13. Implementation guidance by task horizon
+
+| Existing task | Runtime V2 interpretation |
+|---|---|
+| TP-082 | becomes a required base contract for lane-runner + agent-host launches |
+| TP-083 | should target execution units/frontier, not TMUX/session recovery |
+| TP-084 | should build on runtime registry + normalized events |
+| TP-085 | fits naturally into engine + lane-runner headless scheduling |
+| TP-086 | should use bridge request + supervisor decision flow |
+| TP-087 | should persist graph revisions alongside runtime execution-unit state |
+| TP-088 | becomes mandatory for all engine/resume paths in Runtime V2 |
+
+## 14. Recommendation
+
+Do **not** postpone packet-path authority until after the no-TMUX runtime lands.
+
+Instead, treat these as coupled foundations:
+
+- headless runtime ownership
+- explicit packet-path authority
+
+They solve the same class of bug: execution state being inferred from the wrong
+hosting context.

--- a/docs/specifications/framework/taskplane-runtime-v2/06-migration-and-rollout.md
+++ b/docs/specifications/framework/taskplane-runtime-v2/06-migration-and-rollout.md
@@ -1,0 +1,252 @@
+# Migration and Rollout Plan
+
+**Status:** Proposed  
+**Related:** [07-task-crosswalk-and-roadmap.md](07-task-crosswalk-and-roadmap.md)
+
+## 1. Goal
+
+Land Runtime V2 without losing Taskplane’s strongest current properties:
+
+- resumability
+- operator clarity
+- branch/worktree safety
+- polyrepo correctness
+
+This plan assumes the redesign is worth doing **properly**, not as a quick fix.
+
+## 2. Migration principles
+
+1. **Keep durable contracts stable**
+   - `STATUS.md`, `.DONE`, `.pi/batch-state.json` remain authoritative.
+
+2. **Migrate transport first, semantics second**
+   - replace TMUX/process hosting before broad feature expansion.
+
+3. **Preserve feature semantics where practical**
+   - workers still execute tasks, reviews still happen, supervisor still steers.
+
+4. **Allow temporary compatibility shims**
+   - dashboard and tools may read both legacy and v2 artifacts during migration.
+
+5. **Feature-flag the runtime backend during transition**
+   - avoid big-bang replacement until soak-tested.
+
+## 3. Suggested rollout phases
+
+## Phase 0 — Assumption lab (TP-110)
+
+### Deliverables
+
+- standalone no-TMUX validation harness under `scripts/runtime-v2-lab/`
+- durable report in `docs/specifications/framework/taskplane-runtime-v2/assumption-lab-report.md`
+- explicit go/no-go notes for direct host, mailbox steering, telemetry, packet-path proof, and bridge proof
+
+### Exit gate
+
+Proceed into foundation extraction only after the lab confirms that direct-child
+hosting and mailbox steering are viable enough to justify the refactor.
+
+## Phase A — Foundation extraction
+
+### Deliverables
+
+- extract `task-executor-core` from `task-runner.ts`
+- define `ExecutionUnit` and packet-path launch contracts
+- define runtime registry + event schemas
+- keep existing runtime path operational during extraction
+
+### Why first
+
+This is the minimum needed to stop future work from deepening the `/task` /
+extension-host coupling.
+
+## Phase B — Direct-child agent host
+
+### Deliverables
+
+- implement `agent-host.mjs`
+- spawn Pi agents directly with `shell: false`
+- stream normalized events directly to parent
+- persist per-agent manifests/events/exit summaries
+- support mailbox inbox delivery in the new host
+
+### Exit gate
+
+Worker and merge hosts can run without TMUX installed.
+
+## Phase C — Lane-runner headless execution
+
+### Deliverables
+
+- implement `lane-runner.ts`
+- move orchestrated task execution out of lane Pi extension sessions
+- use `task-executor-core` inside lane-runner
+- emit lane snapshots directly
+
+### Exit gate
+
+`/orch <PROMPT.md>` can execute a single task entirely without the legacy `/task`
+critical path.
+
+## Phase D — Mailbox and bridge completion
+
+### Deliverables
+
+- re-scope TP-091 replies onto registry-backed agent IDs
+- land TP-092 broadcast + rate limiting on the new host
+- implement bridge tools for `review_step`, supervisor replies, expansion requests
+- keep TP-089/090 semantics intact
+
+### Exit gate
+
+Supervisor steering and agent replies work end-to-end on Runtime V2 without TMUX.
+
+## Phase E — Dashboard migration
+
+### Deliverables
+
+- dashboard prefers runtime-v2 registry/snapshots/events
+- land TP-093 mailbox panel on the new artifacts
+- replace TMUX-centric active-agent visibility
+- conversation viewer reads normalized event streams
+
+### Exit gate
+
+Dashboard provides full live visibility with no TMUX pane capture dependency.
+
+## Phase F — Workspace/segment parity
+
+### Deliverables
+
+- thread packet-path authority through engine/resume/lane-runner
+- re-scope and land TP-082/088 on the new runtime
+- continue TP-085/086/087 on execution-unit contracts
+- complete polyrepo acceptance coverage
+
+### Exit gate
+
+Workspace-mode smoke tests and segment-roadmap prerequisites pass on Runtime V2.
+
+## Phase G — Default switch and cleanup
+
+### Deliverables
+
+- make Runtime V2 the default backend
+- deprecate and then remove TMUX runtime dependency
+- convert `/task` into shim or remove in next major
+- retire legacy telemetry/session discovery code paths
+
+### Exit gate
+
+No production path requires TMUX. Legacy code is no longer authoritative.
+
+## 4. Feature flag strategy
+
+Introduce a project/runtime config gate such as:
+
+```json
+{
+  "orchestrator": {
+    "runtimeBackend": "legacy-tmux" | "process-v2"
+  }
+}
+```
+
+### Rules
+
+- new projects may eventually default to `process-v2`
+- migration period supports both
+- dashboard server can detect both artifact families
+- legacy backend is removable only after soak and workspace parity
+
+## 5. Validation strategy
+
+## 5.1 Unit and integration tests
+
+Required new coverage areas:
+
+- process registry lifecycle
+- direct-child agent hosting
+- mailbox delivery without TMUX
+- bridge request/response contracts
+- packet-path authority in lane-runner and resume
+- dashboard reading normalized runtime artifacts
+
+## 5.2 End-to-end batch tests
+
+Required scenarios:
+
+1. single-task `/orch <PROMPT.md>` run, repo mode
+2. multi-task batch with worker review cycles
+3. merge failure and recovery path
+4. supervisor steering while worker is live
+5. worker crash + restart + telemetry continuity
+6. mailbox reply/escalation round trip
+7. workspace-mode packet-home != execution repo
+8. forced interruption + resume
+
+## 5.3 Soak tests
+
+Because the product target is multi-day unattended operation, Runtime V2 needs
+intentional soak criteria.
+
+### Minimum soak suite
+
+- 6-hour continuous batch on Windows
+- 6-hour continuous batch on macOS/Linux
+- repeated worker spawn/kill/retry loops
+- repeated steering messages under load
+- repeated dashboard polling + SSE subscribers
+
+### Stretch soak suite
+
+- 24-hour unattended batch with mixed review, retries, and supervisor interventions
+
+## 6. Operational migration
+
+## 6.1 CLI/docs changes
+
+When Runtime V2 becomes default:
+
+- `taskplane doctor` stops treating TMUX as a required runtime dependency
+- `taskplane install-tmux` becomes optional/deprecated, then removable
+- README and install docs should describe dashboard + supervisor as the operator path
+- `/orch-sessions` may be aliased to process-registry-backed agent listings or renamed later
+
+## 6.2 Supervisor/tool changes
+
+Update tools to use registry-backed agent IDs:
+
+- `send_agent_message`
+- `read_agent_status`
+- `list_active_agents`
+- future `read_agent_replies`
+
+## 6.3 Dashboard changes
+
+The dashboard server should tolerate both artifact layouts during migration.
+
+## 7. Kill-switch posture
+
+Even during Runtime V2 rollout, retain a clean rollback path:
+
+- runtime backend feature flag
+- clear operator messaging on which backend is active
+- separate artifact roots where necessary to avoid ambiguity
+
+## 8. What not to do
+
+1. **Do not** keep layering fixes onto nested TMUX worker hosting while the redesign is underway.
+2. **Do not** implement new mailbox/dashboard features against TMUX-only liveness assumptions.
+3. **Do not** ship packet-path/segment features that still infer authority from `cwd`.
+4. **Do not** switch defaults before Windows soak stability is demonstrated.
+
+## 9. Definition of success
+
+Runtime V2 rollout is complete when:
+
+- TMUX is not required for correctness
+- single-task and batch execution both use the same headless runtime core
+- dashboard visibility and steering are fully mailbox/event based
+- workspace/packet-home correctness holds under resume
+- soak tests demonstrate reliable unattended execution on Windows

--- a/docs/specifications/framework/taskplane-runtime-v2/07-task-crosswalk-and-roadmap.md
+++ b/docs/specifications/framework/taskplane-runtime-v2/07-task-crosswalk-and-roadmap.md
@@ -1,0 +1,230 @@
+# Task Crosswalk and Recommended Roadmap
+
+**Status:** Proposed  
+**Related:** [06-migration-and-rollout.md](06-migration-and-rollout.md)
+
+## 1. Purpose
+
+This document maps the current open Taskplane task horizon onto Runtime V2 so
+future implementation work stays aligned with the new architecture instead of
+reinforcing the legacy TMUX-centered path.
+
+## 2. Current open task horizon reviewed
+
+### Mailbox / messaging
+
+- TP-091 — agent-to-supervisor replies
+- TP-092 — broadcast and rate limiting
+- TP-093 — dashboard mailbox panel
+
+### Packet-home / segment / polyrepo
+
+- TP-082 — packet-path env contract and task-runner authority
+- TP-083 — supervisor segment recovery and reordering
+- TP-084 — segment observability, docs, and polyrepo acceptance
+- TP-085 — segment frontier scheduler and resume reconstruction
+- TP-086 — dynamic segment expansion protocol and supervisor decisions
+- TP-087 — dynamic segment expansion graph mutation and resume
+- TP-088 — engine/resume packet-path threading
+
+## 3. Crosswalk summary
+
+| Existing task | Keep / Re-scope / Supersede | Runtime V2 interpretation |
+|---|---|---|
+| TP-091 | **Re-scope** | replies/outbox should target registry-backed agent IDs and Runtime V2 events |
+| TP-092 | **Keep** | broadcast + rate limiting still needed; just remove TMUX assumptions |
+| TP-093 | **Re-scope** | mailbox panel should read runtime-v2 registry + mailbox + normalized message events |
+| TP-082 | **Keep, but lift earlier** | packet-path authority becomes a foundation, not a late feature |
+| TP-083 | **Re-scope** | supervisor recovery/reordering should target execution units, not TMUX session state |
+| TP-084 | **Re-scope** | observability should land on normalized runtime artifacts |
+| TP-085 | **Keep** | segment frontier belongs naturally in engine + lane-runner |
+| TP-086 | **Keep** | use bridge + supervisor decision plumbing |
+| TP-087 | **Keep** | apply graph mutation on execution-unit-aware runtime state |
+| TP-088 | **Keep, but lift earlier** | engine/resume packet threading is a base invariant |
+
+## 4. Existing completed work to preserve
+
+| Completed task | Runtime V2 disposition |
+|---|---|
+| TP-089 | preserve mailbox core and rpc injection semantics |
+| TP-090 | preserve steering annotation concept; adapt to new runtime event/snapshot flow |
+| TP-094 | preserve authoritative contextUsage handling |
+| TP-095 | treat as incident history; most TMUX-specific retry machinery should disappear |
+| TP-096 | preserve supervisor recovery tools, but retarget them to registry/runtime artifacts |
+| TP-097 | stable sidecar identity concept becomes stable agent/event identity |
+| TP-098 | preserve log de-duplication intent in the new event model |
+
+## 5. Recommended implementation order
+
+## Workstream 0 — Assumption lab gate
+
+### Recommended deliverables
+
+1. stage and execute `TP-110`
+2. validate direct-child host viability without TMUX
+3. validate mailbox steering on the direct host
+4. document any still-open packet-path and bridge risks before refactor tasks proceed
+
+### Why first
+
+This prevents the Runtime V2 refactor from being driven entirely by architecture
+intuition without a platform-level proof pass.
+
+## Workstream 1 — Runtime foundations
+
+### Recommended deliverables
+
+1. extract `task-executor-core`
+2. define runtime registry and normalized event schema
+3. define packet-path authority contract (`ExecutionUnit` + packet fields)
+4. implement `agent-host.mjs`
+
+### Why first
+
+Without this, new tasks will keep accumulating inside the old `/task` + TMUX substrate.
+
+## Workstream 2 — Single-task `/orch` on Runtime V2
+
+### Recommended deliverables
+
+1. implement headless `lane-runner.ts`
+2. make `/orch <PROMPT.md>` use lane-runner + agent-host + packet-path contract
+3. keep legacy backend behind feature flag for batch mode initially
+
+### Why second
+
+This gives a narrow end-to-end proving ground before full batch migration.
+
+## Workstream 3 — Mailbox completion on Runtime V2
+
+### Recommended deliverables
+
+1. re-scope TP-091 replies/outbox
+2. land TP-092 broadcast/rate limiting
+3. implement runtime bridge for `review_step` and supervisor messaging tools
+4. land TP-093 dashboard mailbox panel on new artifacts
+
+## Workstream 4 — Batch mode migration
+
+### Recommended deliverables
+
+1. engine launches lane-runners instead of lane Pi/TMUX sessions
+2. merge agent moves to agent-host direct child path
+3. list/read tools switch to registry-backed liveness
+
+## Workstream 5 — Packet-home / segment parity
+
+### Recommended deliverables
+
+1. land TP-082 and TP-088 on the new runtime contracts
+2. continue TP-085 segment frontier
+3. continue TP-086 / TP-087 expansion flow
+4. re-scope TP-083 / TP-084 to new event model
+
+## 6. Suggested epic structure
+
+If you want to re-task this work cleanly, these are the epics I would stage.
+
+## Epic A — Headless Runtime Foundation
+
+Scope:
+
+- `task-executor-core`
+- `agent-host`
+- registry/events/snapshots
+- single-task `/orch` path
+
+Acceptance:
+
+- one task can run end-to-end without TMUX
+- dashboard can show live conversation and telemetry
+
+## Epic B — Mailbox-First Supervisor Control
+
+Scope:
+
+- TP-091, TP-092, TP-093 re-scoped
+- bridge tools for review/reply/escalation
+- registry-backed operator tools
+
+Acceptance:
+
+- supervisor can steer, query, receive replies, and broadcast without TMUX
+
+## Epic C — Batch and Merge Runtime Migration
+
+Scope:
+
+- lane-runner batch integration
+- merge host migration
+- tool and dashboard parity
+- legacy backend feature flag
+
+Acceptance:
+
+- full batch executes on Runtime V2 backend with worktrees and orch branches preserved
+
+## Epic D — Polyrepo and Segment Runtime Parity
+
+Scope:
+
+- TP-082 through TP-088 on Runtime V2
+- packet-home correctness
+- segment frontier + expansion + resume
+- polyrepo acceptance suite
+
+Acceptance:
+
+- workspace/segment roadmap is unblocked on the new runtime
+
+## 7. Tasks that become legacy-only
+
+These areas should stop receiving major design investment except as migration shims:
+
+- TMUX worker spawn retries
+- TMUX session discovery as the primary operator surface
+- pane capture as the conversation viewer source
+- `/task` as a privileged implementation host
+
+## 8. Hard recommendation
+
+If you stage new implementation tasks from this plan, do **not** continue the
+old pattern of tasking mailbox/dashboard work separately from runtime extraction.
+
+The correct dependency order is:
+
+```text
+runtime ownership -> mailbox/bridge completion -> dashboard on new artifacts -> segment expansion on new runtime
+```
+
+not:
+
+```text
+more TMUX/runtime patching -> more mailbox features on TMUX assumptions -> later redesign
+```
+
+## 9. Ready-to-build order
+
+If I were sequencing the actual coding effort, I would do it in this order:
+
+1. `TP-110` assumption lab gate
+2. Runtime foundation spec acceptance
+3. `task-executor-core` extraction
+4. `agent-host.mjs`
+5. single-task `/orch <PROMPT.md>` on new backend
+6. registry-backed `send_agent_message` + `list_active_agents`
+7. TP-091 + TP-092 on new backend
+8. dashboard conversation/message migration (TP-093)
+9. full lane-runner batch integration
+10. TP-082 + TP-088 packet-path authority end-to-end
+11. TP-085..TP-087 segment roadmap continuation
+
+## 10. What success looks like
+
+After this roadmap, Taskplane should have:
+
+- one execution architecture instead of a legacy `/task` architecture plus an `/orch` wrapper architecture
+- one steering model (supervisor + mailbox)
+- one visibility model (dashboard + normalized events)
+- one identity model (agent IDs backed by a process registry)
+- one polyrepo execution story (explicit packet-home authority)

--- a/docs/specifications/framework/taskplane-runtime-v2/08-implementation-workpackages.md
+++ b/docs/specifications/framework/taskplane-runtime-v2/08-implementation-workpackages.md
@@ -1,0 +1,214 @@
+# Implementation Work Packages
+
+**Status:** Proposed build plan  
+**Related:** [07-task-crosswalk-and-roadmap.md](07-task-crosswalk-and-roadmap.md)
+
+## 1. Purpose
+
+This document turns the Runtime V2 architecture into concrete build packages
+with code touchpoints and acceptance criteria.
+
+## 2. WP-1 — Extract headless execution core
+
+### Goal
+
+Separate execution semantics from the deprecated `/task` extension host.
+
+### Likely code touchpoints
+
+- `extensions/task-runner.ts`
+- new `extensions/taskplane/task-executor-core.ts`
+- status parsing/mutation helpers already in `task-runner.ts`
+- tests currently targeting task-runner behavior
+
+### Deliverables
+
+- headless execution library with no Pi UI/session assumptions
+- compatibility wrapper retained temporarily in `task-runner.ts`
+- no behavior drift in STATUS/.DONE semantics
+
+### Acceptance
+
+- existing execution semantics still pass regression tests
+- `/orch` can call the shared execution core without `TASK_AUTOSTART`
+
+## 3. WP-2 — Agent host
+
+### Goal
+
+Replace TMUX-backed child hosting with direct child-process ownership.
+
+### Likely code touchpoints
+
+- `bin/rpc-wrapper.mjs` -> evolve or split into `agent-host.mjs`
+- new `extensions/taskplane/process-registry.ts`
+- `extensions/taskplane/types.ts`
+- telemetry-related tests (`rpc-wrapper.test.ts`, telemetry tests)
+
+### Deliverables
+
+- direct `pi --mode rpc` host
+- registry/manifest updates
+- normalized events
+- mailbox inbox delivery preserved
+
+### Acceptance
+
+- worker host runs without TMUX installed
+- exit summary + telemetry + mailbox delivery all work on direct-child backend
+
+## 4. WP-3 — Lane runner
+
+### Goal
+
+Introduce a deterministic headless lane runtime.
+
+### Likely code touchpoints
+
+- new `extensions/taskplane/lane-runner.ts`
+- `extensions/taskplane/engine.ts`
+- `extensions/taskplane/execution.ts`
+- `extensions/taskplane/resume.ts`
+
+### Deliverables
+
+- lane-runner launch contract
+- direct worker/reviewer ownership
+- lane snapshot emission
+- no lane Pi session requirement
+
+### Acceptance
+
+- single-task `/orch <PROMPT.md>` runs end-to-end through lane-runner
+- engine receives task outcomes without TMUX session polling
+
+## 5. WP-4 — Registry-backed operator tools
+
+### Goal
+
+Remove TMUX assumptions from operator/supervisor tools.
+
+### Likely code touchpoints
+
+- `extensions/taskplane/extension.ts`
+- `extensions/taskplane/sessions.ts` (likely replaced or heavily rewritten)
+- dashboard server agent-status loading paths
+
+### Deliverables
+
+- `send_agent_message` validates against registry
+- `list_active_agents` reads registry
+- `read_agent_status` reads lane snapshots + packet paths
+
+### Acceptance
+
+- tools work when TMUX is absent
+- no tool calls `tmuxHasSession()` for agent liveness
+
+## 6. WP-5 — Mailbox completion and bridge tools
+
+### Goal
+
+Finish the messaging stack on Runtime V2.
+
+### Likely code touchpoints
+
+- `extensions/taskplane/mailbox.ts`
+- new `extensions/taskplane/agent-bridge-extension.ts`
+- `extensions/taskplane/engine.ts`
+- `extensions/taskplane/extension.ts`
+- mailbox tests
+
+### Deliverables
+
+- TP-091 replies/outbox
+- TP-092 broadcast/rate limiting
+- bridge tools for review and supervisor contact
+
+### Acceptance
+
+- supervisor can query and receive replies from live agents
+- worker can request review without lane extension hosting
+
+## 7. WP-6 — Dashboard migration
+
+### Goal
+
+Make dashboard the complete primary visibility surface.
+
+### Likely code touchpoints
+
+- `dashboard/server.cjs`
+- `dashboard/public/app.js`
+- `dashboard/public/style.css`
+- `dashboard/public/index.html`
+
+### Deliverables
+
+- registry-backed agent panel
+- normalized conversation viewer
+- TP-093 messages panel
+- diagnostics panel updates
+
+### Acceptance
+
+- pane capture no longer required for primary worker visibility
+- mailbox activity and agent conversation visible on Runtime V2 backend
+
+## 8. WP-7 — Packet-path authority
+
+### Goal
+
+Thread packet-home authority end-to-end in the new runtime.
+
+### Likely code touchpoints
+
+- `extensions/taskplane/engine.ts`
+- `extensions/taskplane/execution.ts`
+- `extensions/taskplane/resume.ts`
+- lane-runner inputs
+- multi-repo tests
+
+### Deliverables
+
+- TP-082/TP-088 semantics on Runtime V2 launch contracts
+- authoritative `.DONE`/`STATUS.md` checks in execution and resume
+
+### Acceptance
+
+- packet-home repo != execution repo works correctly in workspace mode
+- resume never guesses packet paths from `cwd`
+
+## 9. WP-8 — Segment runtime continuation
+
+### Goal
+
+Continue TP-085..TP-087 on the new execution-unit-based runtime.
+
+### Likely code touchpoints
+
+- `extensions/taskplane/engine.ts`
+- `extensions/taskplane/resume.ts`
+- `extensions/taskplane/persistence.ts`
+- `extensions/taskplane/types.ts`
+- supervisor alert + dashboard integration
+
+### Deliverables
+
+- segment frontier
+- expansion request protocol
+- graph mutation + persisted revisioning
+
+### Acceptance
+
+- segment roadmap proceeds without reintroducing TMUX/runtime coupling
+
+## 10. Definition of done for the full program
+
+The Runtime V2 program is done when:
+
+- TMUX is not required for correctness
+- `/orch` is the sole authoritative execution path
+- mailbox and dashboard provide all required steering and visibility
+- worker/reviewer/merge lifecycle is registry-backed and directly owned
+- polyrepo packet-home correctness and segment roadmap both sit on the same runtime foundation

--- a/docs/specifications/framework/taskplane-runtime-v2/README.md
+++ b/docs/specifications/framework/taskplane-runtime-v2/README.md
@@ -1,0 +1,108 @@
+# Taskplane Runtime V2 Planning Suite
+
+**Status:** Proposed foundational redesign  
+**Created:** 2026-03-30  
+**Primary driver:** `docs/specifications/taskplane/spawn-telemetry-stability.md`
+
+This folder defines the long-term runtime architecture for making Taskplane a
+**resilient, mailbox-first, dashboard-first agent orchestrator** without TMUX as
+part of the correctness path.
+
+## Why this suite exists
+
+Taskplane's durable core is already strong:
+
+- file-backed task memory (`PROMPT.md`, `STATUS.md`, `.DONE`)
+- resumable batch state (`.pi/batch-state.json`)
+- worktree isolation and orch-managed branches
+- operator-first visibility and recovery intent
+
+The instability is concentrated in the **runtime transport/control plane**:
+
+- nested TMUX session spawning
+- file-based live telemetry between directly related processes
+- `/orch` bootstrapping `/task` through extension/session lifecycle hooks
+- ambiguous process ownership and orphan cleanup
+- worker visibility tied to terminal infrastructure instead of normalized events
+
+## Top-level decisions
+
+1. **Remove TMUX from the critical execution path**
+   - No worker, reviewer, merger, or lane correctness may depend on TMUX.
+   - TMUX becomes optional debug UX at most, and can ultimately disappear.
+
+2. **Make the mailbox the canonical steering mechanism**
+   - Operators steer only through the supervisor.
+   - Supervisor steers agents through mailbox + RPC injection.
+   - No direct operator typing into agent terminals.
+
+3. **Remove `/task` from the critical path**
+   - `/orch` becomes the single authoritative execution path, including single-task runs.
+   - Legacy `/task` becomes a compatibility shim or is removed in a future major version.
+
+4. **Split deterministic orchestration from agent hosting**
+   - Deterministic Node processes own lifecycle, retries, cleanup, and state.
+   - Pi agents become leaf processes, not orchestration hosts.
+
+5. **Use direct process ownership for live control**
+   - Parent/child telemetry should flow directly over IPC/stdio.
+   - Files remain the durable audit/recovery layer, not the primary live transport.
+
+6. **Keep existing durable contracts**
+   - `STATUS.md`, `.DONE`, batch-state, worktrees, orch branches, and packet-home authority remain foundational.
+
+## Document map
+
+| Document | Purpose |
+|---|---|
+| [01-architecture.md](01-architecture.md) | Target system architecture and core invariants |
+| [02-runtime-process-model.md](02-runtime-process-model.md) | Process ownership, lifecycle, IDs, and `/task` deprecation path |
+| [03-bridge-and-mailbox.md](03-bridge-and-mailbox.md) | Mailbox-first steering, agent replies, and runtime bridge contracts |
+| [04-observability-and-dashboard.md](04-observability-and-dashboard.md) | Visibility model without TMUX, normalized events, dashboard contracts |
+| [05-polyrepo-and-segment-compatibility.md](05-polyrepo-and-segment-compatibility.md) | How the redesign fits packet-home, workspace mode, and segment execution |
+| [06-migration-and-rollout.md](06-migration-and-rollout.md) | Phased migration, feature flags, validation, and soak strategy |
+| [07-task-crosswalk-and-roadmap.md](07-task-crosswalk-and-roadmap.md) | Mapping to existing TP-082..TP-093 work and recommended implementation order |
+| [assumption-lab-report.md](assumption-lab-report.md) | TP-110 validation results for direct host, telemetry, mailbox, and open packet-path/bridge risks |
+
+## Scope of the redesign
+
+### Preserved
+
+- task packet model
+- file-backed batch state
+- wave/lane/worktree/orch-branch model
+- supervisor concept
+- mailbox concept
+- dashboard as primary operator surface
+- workspace/polyrepo support
+
+### Replaced or extracted
+
+- TMUX-backed worker/reviewer/merge spawning
+- lane session as a Pi extension host
+- `/orch` → `TASK_AUTOSTART` → `/task` bootstrapping as the critical path
+- live telemetry by tailing sidecar files written by a sibling process
+- session identity being defined by terminal infrastructure
+
+## Relationship to current open task horizon
+
+This suite explicitly accounts for the currently unimplemented roadmap items:
+
+- **Mailbox follow-ons:** TP-091, TP-092, TP-093
+- **Packet-home / segment / polyrepo execution:** TP-082 through TP-088
+
+Those tasks are still strategically correct, but several need to be
+**re-scoped onto the new runtime architecture** so we do not keep investing in
+TMUX-bound execution assumptions.
+
+## Success criteria for Runtime V2
+
+Taskplane should be able to run unattended batches for days with these properties:
+
+- worker/reviewer/merge startup is not TMUX-dependent
+- steering works through supervisor + mailbox only
+- dashboard shows real conversation/telemetry without pane capture
+- every live process has one deterministic owner
+- orphans are detectable and killable from a process registry, not guessed from TMUX state
+- packet-home and segment execution remain correct in workspace mode
+- resume works from persisted state, not from terminal/session assumptions

--- a/docs/specifications/framework/taskplane-runtime-v2/assumption-lab-report.md
+++ b/docs/specifications/framework/taskplane-runtime-v2/assumption-lab-report.md
@@ -1,0 +1,339 @@
+# Runtime V2 Assumption Lab Report
+
+**Status:** Completed exploratory validation  
+**Date:** 2026-03-30  
+**Task:** `TP-110`  
+**Harness:** `scripts/runtime-v2-lab/`  
+**Raw summary:** `scripts/runtime-v2-lab/out/latest-summary.json`
+
+## 1. Goal
+
+Validate the highest-risk Runtime V2 architectural assumptions **outside the
+current TMUX- and `/task`-based production path** before the main refactor
+proceeds.
+
+## 2. Baseline and scope
+
+### Runtime baseline selected
+
+- **Session-attached but resumable**
+
+This lab does **not** attempt detached/background execution.
+
+### Out of scope for this lab
+
+- full wave/batch orchestration
+- dashboard SSE integration
+- merge orchestration parity
+- dynamic segment expansion
+- full bridge callback semantics
+
+## 3. Environment
+
+- **Repo:** `C:/dev/taskplane`
+- **Node:** `v25.8.0`
+- **Pi:** `0.64.0` (`pi --version`)
+- **Platform:** Windows host environment (current Taskplane development environment)
+
+## 4. Harness design
+
+The lab uses a standalone direct-child host that:
+
+- resolves Pi's underlying CLI entrypoint directly
+- spawns `node <pi-cli> --mode rpc --no-session` with **no TMUX**
+- parses RPC JSONL directly from stdout
+- optionally queries `get_session_stats`
+- optionally injects mailbox messages through RPC `steer`
+- records raw outcomes to `scripts/runtime-v2-lab/out/latest-summary.json`
+
+### Important preflight observation
+
+On this Windows environment, `pi` resolves to an npm shim (`pi.cmd`).
+For Runtime V2, the host should **not** depend on spawning the shim as though it
+were a native binary. It should resolve the underlying CLI entrypoint and invoke
+Node directly (or an equivalent non-TMUX/non-pane-dependent path).
+
+## 5. Experiments run
+
+## E1 — Direct-child close strategy
+
+### Question
+
+Can a direct child host run Pi RPC sessions and exit cleanly without TMUX?
+
+### Result
+
+- direct-host sessions exited cleanly in the final harness configuration
+- direct `contextUsage` capture also succeeded in the delayed-close path
+
+### Interpretation
+
+The transport is viable.
+
+### Exploratory caution
+
+During early ad hoc probing outside the final harness, I observed a Windows-side
+assertion failure when the host closed stdin too aggressively after `agent_end`
+while extra RPC interaction was still happening. I did **not** reproduce this in
+the final harness summary run, but it is enough evidence to keep one design
+rule:
+
+> Runtime V2 host shutdown should be centralized and conservative. Do not assume
+> that closing stdin immediately after `agent_end` is always safe under all
+> argument mixes and in-flight RPC conditions.
+
+## E2 — Sequential and limited-parallel direct spawn reliability
+
+### Question
+
+Can a no-TMUX direct host reliably run simple Pi RPC sessions in sequence and in
+small parallel sets?
+
+### Result
+
+From `latest-summary.json`:
+
+- **Sequential:** 5/5 successful
+- **Parallel:** 3/3 successful
+- all successful runs captured `contextUsage`
+- no stderr crash signatures were recorded in the successful runs
+
+### Interpretation
+
+This is strong evidence that the **core no-TMUX direct-child hosting model is
+viable** for Runtime V2 on this machine, at least for simple prompts.
+
+### Constraint
+
+This does **not** prove that long, tool-heavy, multi-turn execution is fully
+stable yet. It proves the transport layer is promising enough to justify the
+refactor.
+
+## E3 — Direct RPC telemetry / authoritative context usage
+
+### Question
+
+Can a direct host capture useful runtime telemetry without sidecar tailing
+between sibling processes?
+
+### Result
+
+Yes.
+
+The host was able to:
+
+- parse RPC JSONL directly from stdout
+- identify message boundaries and tool events
+- call `get_session_stats`
+- receive `contextUsage`
+
+### Interpretation
+
+This validates a key Runtime V2 assumption:
+
+> live control/telemetry can flow directly between parent and child rather than
+> being reconstructed by file polling between siblings.
+
+That does **not** remove the value of persisted event logs; it only means disk
+should be the **durable audit layer**, not the primary live transport for
+parent/child state.
+
+## E4 — Mailbox steering without TMUX
+
+### Question
+
+Does the mailbox + `steer` RPC model still work when the agent is direct-hosted
+instead of living inside TMUX?
+
+### Result
+
+Yes.
+
+Observed outcome:
+
+- prewritten mailbox message delivered successfully
+- inbox message moved to `ack/`
+- assistant responded first with `READY`
+- after steering injection, assistant responded with `STEER-ACK`
+
+### Interpretation
+
+This validates a major Runtime V2 architectural bet:
+
+> Supervisor → mailbox → agent-host → Pi RPC `steer` works without TMUX.
+
+This is the strongest evidence that the user-facing operator model can become:
+
+- operator talks only to supervisor
+- supervisor steers agents
+- dashboard shows message lifecycle
+
+with **no direct terminal interaction requirement**.
+
+## E5 — Explicit packet-path / `cwd != packet home`
+
+### Question
+
+Can a direct-hosted agent reliably operate when the execution cwd differs from
+the packet home location?
+
+### Result
+
+**Not yet validated in a reproducible way.**
+
+In the final summary run:
+
+- packet-path experiment attempts: **2**
+- successes: **0**
+- both attempts timed out without completing tool work
+
+### Important nuance
+
+Before the final repeatable harness run, I did obtain an **ad hoc successful
+probe** where a direct-hosted agent:
+
+- ran with `cwd` in an execution repo directory
+- read packet files from a separate packet-home directory
+- wrote `.DONE` into the packet-home directory
+- finished successfully
+
+However, because the repeatable harness did **not** reproduce that success, I am
+not counting this assumption as validated yet.
+
+### Interpretation
+
+The result is best classified as:
+
+- **conceptually promising**
+- **operationally still open**
+
+This does **not** mean explicit packet paths are a bad design. It means we do
+not yet have enough reliable evidence from the lab harness to treat the prompt-
+level tool sequence as proven.
+
+### Implication for the roadmap
+
+Packet-path authority should still be implemented as a **contract-level
+foundation** (TP-102), but Runtime V2 should not treat packet-home execution
+behavior as fully de-risked until a dedicated proof lands during the execution
+slice work.
+
+## E6 — Minimal bridge-style callback
+
+### Question
+
+Can we already claim that bridge-style request/response callbacks are proven for
+Runtime V2?
+
+### Result
+
+**Open. Not validated in this first lab run.**
+
+The lab recorded this explicitly as still open.
+
+### Interpretation
+
+Bridge semantics should remain a planned area of work for:
+
+- `TP-105` (lane-runner slice)
+- `TP-106` (mailbox/bridge control work)
+
+It would be premature to declare bridge callbacks solved from the current lab.
+
+## 6. Additional exploratory finding: thinking-mode compatibility is model-specific
+
+During ad hoc probing, I observed a provider/model-side error when passing a
+blanket `--thinking off` style override under one default model path:
+
+- the model rejected an unsupported "none"-style thinking value
+
+This matters because current Taskplane runtime code often assumes worker/reviewer
+thinking overrides can be pushed mechanically.
+
+### Interpretation
+
+Runtime V2 should avoid a naive assumption that one universal thinking override
+is valid across all models/providers. The new host/runtime should either:
+
+- rely on compatible configured values only, or
+- validate/normalize thinking settings per model path
+
+## 7. Summary table
+
+| Assumption | Result | Confidence |
+|---|---|---|
+| Direct child spawning without TMUX is viable | **Validated** | Medium-high |
+| Direct RPC telemetry + `contextUsage` capture is viable | **Validated** | High |
+| Mailbox steering without TMUX is viable | **Validated** | High |
+| Explicit packet-home paths work reliably in repeatable harness runs | **Open / partial** | Low |
+| Minimal bridge callback semantics are proven | **Open** | Low |
+| Session-attached but resumable baseline is reasonable | **Validated for current scope** | High |
+
+## 8. Recommendations before TP-102+ proceeds
+
+## Proceed now
+
+I recommend proceeding with:
+
+- **TP-102** — Runtime V2 contracts
+- **TP-103** — executor-core extraction
+- **TP-104** — direct host + registry
+
+These are justified by the validated transport, telemetry, and mailbox results.
+
+## Proceed, but with explicit caution
+
+For **TP-105** and later execution-slice work:
+
+1. keep direct-host transport as the foundation
+2. keep mailbox-first steering as the control model
+3. add a **dedicated packet-path proof checkpoint** before treating workspace
+   packet-home behavior as solved
+4. treat bridge semantics as an explicit design/proof item, not an assumed freebie
+
+## Host implementation rules now justified by the lab
+
+1. **No TMUX in the correctness path**
+2. **Direct stdout RPC parsing is sufficient for live control**
+3. **Use mailbox + `steer` for supervisor control**
+4. **Do not rely on the Windows npm shim as the host abstraction**
+5. **Centralize shutdown and avoid over-eager stdin close assumptions**
+6. **Do not assume one universal thinking override is safe across providers/models**
+
+## 9. Suggested roadmap adjustments
+
+### Add a Phase 0 gate to Runtime V2 rollout
+
+Treat TP-110 as the pre-refactor gate before core implementation tasks.
+
+### Keep packet-path authority early, but treat runtime proof separately
+
+- keep TP-102 packet-path contracts early
+- keep TP-109 as the real workspace/runtime proof point
+- do not declare packet-home execution behavior validated from architecture alone
+
+### Keep bridge work explicit
+
+Do not fold bridge assumptions into vague “runtime glue.”
+Make them concrete in TP-105 / TP-106.
+
+## 10. Final judgment
+
+The lab result is a **qualified green light**.
+
+### Green-lighted foundations
+
+- no-TMUX direct-child hosting
+- direct RPC telemetry capture
+- mailbox steering as the canonical supervisor control path
+- session-attached but resumable Runtime V2 baseline
+
+### Still-open risks
+
+- repeatable packet-home execution proof in the harness
+- bridge callback proof
+- behavior of tool-heavy multi-step prompts under the current default model path
+
+That is enough confidence to continue Runtime V2 foundation work — but not
+enough to skip explicit packet-path and bridge validation in the early
+implementation tasks.

--- a/docs/specifications/taskplane/spawn-telemetry-stability.md
+++ b/docs/specifications/taskplane/spawn-telemetry-stability.md
@@ -6,6 +6,9 @@
 >
 > **Status:** Active investigation — last updated 2026-03-30
 > **Versions covered:** v0.22.11 through v0.22.18
+>
+> **Follow-on architecture suite:** See `docs/specifications/framework/taskplane-runtime-v2/`
+> for the long-term no-TMUX runtime redesign created from this investigation.
 
 ---
 

--- a/scripts/runtime-v2-lab/README.md
+++ b/scripts/runtime-v2-lab/README.md
@@ -1,0 +1,30 @@
+# Runtime V2 Assumption Lab
+
+Standalone validation harness for the highest-risk Runtime V2 architectural assumptions.
+
+## Purpose
+
+Validate, outside the current TMUX- and `/task`-based production path, that:
+
+- direct child spawning of Pi agents is viable on Windows
+- a direct host can capture RPC events and authoritative `contextUsage`
+- mailbox steering works without TMUX
+- explicit packet paths work when `cwd != packet home`
+- remaining open assumptions are clearly documented before the refactor proceeds
+
+## Run
+
+```bash
+node scripts/runtime-v2-lab/run-lab.mjs
+```
+
+## Output
+
+- Summary JSON: `scripts/runtime-v2-lab/out/latest-summary.json`
+- Human report: `docs/specifications/framework/taskplane-runtime-v2/assumption-lab-report.md`
+
+## Notes
+
+- The lab assumes **session-attached but resumable** as the Runtime V2 baseline.
+- The harness intentionally avoids TMUX and the current `/task` production path.
+- Results are designed to inform the Runtime V2 build order (`TP-102+`).

--- a/scripts/runtime-v2-lab/out/latest-summary.json
+++ b/scripts/runtime-v2-lab/out/latest-summary.json
@@ -1,0 +1,129 @@
+{
+  "runAt": "2026-03-30T21:57:12.765Z",
+  "environment": {
+    "node": "v25.8.0",
+    "piVersion": null,
+    "sessionModeBaseline": "session-attached but resumable"
+  },
+  "experiments": [
+    {
+      "name": "close-strategy",
+      "immediate": {
+        "exitCode": 0,
+        "stderrTail": "",
+        "hasAssertion": false
+      },
+      "delayed": {
+        "exitCode": 0,
+        "contextUsagePresent": true,
+        "assistantTexts": [
+          "OK"
+        ]
+      }
+    },
+    {
+      "name": "reliability",
+      "sequential": {
+        "runs": 5,
+        "successes": 5,
+        "results": [
+          {
+            "exitCode": 0,
+            "contextUsagePresent": true,
+            "stderrTail": ""
+          },
+          {
+            "exitCode": 0,
+            "contextUsagePresent": true,
+            "stderrTail": ""
+          },
+          {
+            "exitCode": 0,
+            "contextUsagePresent": true,
+            "stderrTail": ""
+          },
+          {
+            "exitCode": 0,
+            "contextUsagePresent": true,
+            "stderrTail": ""
+          },
+          {
+            "exitCode": 0,
+            "contextUsagePresent": true,
+            "stderrTail": ""
+          }
+        ]
+      },
+      "parallel": {
+        "runs": 3,
+        "successes": 3,
+        "results": [
+          {
+            "exitCode": 0,
+            "contextUsagePresent": true,
+            "stderrTail": ""
+          },
+          {
+            "exitCode": 0,
+            "contextUsagePresent": true,
+            "stderrTail": ""
+          },
+          {
+            "exitCode": 0,
+            "contextUsagePresent": true,
+            "stderrTail": ""
+          }
+        ]
+      }
+    },
+    {
+      "name": "mailbox-steering",
+      "exitCode": 0,
+      "deliveredMessages": [
+        "1774907917019-ffe03"
+      ],
+      "ackFiles": [
+        "1774907917019-ffe03.msg.json"
+      ],
+      "assistantTexts": [
+        "READY",
+        "STEER-ACK"
+      ],
+      "prewrittenMessageId": "1774907917019-ffe03"
+    },
+    {
+      "name": "packet-paths",
+      "attempts": [
+        {
+          "exitCode": null,
+          "signal": "SIGTERM",
+          "doneExists": false,
+          "doneContent": null,
+          "toolCalls": [],
+          "assistantTexts": [],
+          "stderrTail": ""
+        },
+        {
+          "exitCode": null,
+          "signal": "SIGTERM",
+          "doneExists": false,
+          "doneContent": null,
+          "toolCalls": [],
+          "assistantTexts": [],
+          "stderrTail": ""
+        }
+      ],
+      "successes": 0,
+      "note": "A passing attempt demonstrates explicit packet paths are viable outside cwd assumptions; a failing/hanging attempt indicates tool-heavy multi-step prompts still need robust retry/timeout handling in Runtime V2."
+    },
+    {
+      "name": "bridge-feasibility",
+      "status": "open",
+      "note": "A true synchronous file-bridge callback was not validated in this first lab run. The mailbox and packet-path experiments reduce risk, but bridge semantics still need a dedicated proof task during TP-106/TP-105 work.",
+      "smokeExitCode": 0,
+      "smokeAssistantTexts": [
+        "BRIDGE-DEFERRED"
+      ]
+    }
+  ]
+}

--- a/scripts/runtime-v2-lab/run-lab.mjs
+++ b/scripts/runtime-v2-lab/run-lab.mjs
@@ -1,0 +1,396 @@
+import { spawn, spawnSync } from "child_process";
+import {
+	mkdtempSync,
+	mkdirSync,
+	writeFileSync,
+	readFileSync,
+	readdirSync,
+	renameSync,
+	existsSync,
+	rmSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join, dirname, resolve } from "path";
+
+function wait(ms) {
+	return new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+}
+
+function ensureDir(dir) {
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+function resolvePiCliPath() {
+	const appData = process.env.APPDATA;
+	if (!appData) throw new Error("APPDATA is not set; cannot resolve pi CLI path.");
+	return join(appData, "npm", "node_modules", "@mariozechner", "pi-coding-agent", "dist", "cli.js");
+}
+
+function resolvePiVersion() {
+	try {
+		const result = spawnSync(process.execPath, [resolvePiCliPath(), "--version"], {
+			encoding: "utf8",
+			shell: false,
+			timeout: 10_000,
+		});
+		return result.stdout?.trim() || null;
+	} catch {
+		return null;
+	}
+}
+
+function contentToText(message) {
+	if (!message || !Array.isArray(message.content)) return "";
+	return message.content
+		.map((part) => {
+			if (part && typeof part === "object" && typeof part.text === "string") return part.text;
+			return "";
+		})
+		.join(" ")
+		.trim();
+}
+
+function writeMailboxMessage(mailboxDir, batchId, to, content) {
+	const inboxDir = ensureDir(join(mailboxDir, "inbox"));
+	const id = `${Date.now()}-${Math.random().toString(16).slice(2, 7)}`;
+	const message = {
+		id,
+		batchId,
+		from: "supervisor",
+		to,
+		timestamp: Date.now(),
+		type: "steer",
+		content,
+	};
+	const tempPath = join(inboxDir, `${id}.msg.json.tmp`);
+	const finalPath = join(inboxDir, `${id}.msg.json`);
+	writeFileSync(tempPath, JSON.stringify(message) + "\n", "utf8");
+	renameSync(tempPath, finalPath);
+	return { id, finalPath };
+}
+
+function readJsonFile(filePath) {
+	return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+async function runPiAgent(options) {
+	const {
+		prompt,
+		systemPrompt,
+		tools,
+		cwd,
+		closeDelayMs = 100,
+		requestSessionStats = true,
+		timeoutMs = 45_000,
+		mailboxDir = null,
+	} = options;
+
+	const cliPath = resolvePiCliPath();
+	const args = [cliPath, "--mode", "rpc", "--no-session", "--no-extensions", "--no-skills"];
+	if (tools && tools.length > 0) {
+		args.push("--tools", tools.join(","));
+	}
+	if (systemPrompt) {
+		args.push("--system-prompt", systemPrompt);
+	}
+
+	return await new Promise((resolvePromise) => {
+		const proc = spawn(process.execPath, args, {
+			shell: false,
+			cwd,
+			stdio: ["pipe", "pipe", "pipe"],
+			env: { ...process.env },
+		});
+
+		let stdoutBuffer = "";
+		let stderrBuffer = "";
+		let statsRequested = false;
+		let agentEnded = false;
+		let finished = false;
+		const startedAt = Date.now();
+		const eventTypes = [];
+		const messages = [];
+		const toolCalls = [];
+		const deliveredMessages = [];
+		let contextUsage = null;
+		let statsResponse = null;
+
+		const timeoutHandle = setTimeout(() => {
+			try {
+				proc.kill("SIGTERM");
+			} catch {
+				// Ignore kill failures on timeout path.
+			}
+		}, timeoutMs);
+
+		function finish(result) {
+			if (finished) return;
+			finished = true;
+			clearTimeout(timeoutHandle);
+			resolvePromise({
+				...result,
+				durationMs: Date.now() - startedAt,
+				stderr: stderrBuffer,
+				eventTypes,
+				messages,
+				toolCalls,
+				deliveredMessages,
+				contextUsage,
+				statsResponse,
+			});
+		}
+
+		function maybeDeliverMailbox() {
+			if (!mailboxDir) return;
+			const inboxDir = join(mailboxDir, "inbox");
+			if (!existsSync(inboxDir)) return;
+			const ackDir = ensureDir(join(mailboxDir, "ack"));
+			const files = readdirSync(inboxDir)
+				.filter((name) => name.endsWith(".msg.json"))
+				.sort();
+			for (const name of files) {
+				const sourcePath = join(inboxDir, name);
+				const message = readJsonFile(sourcePath);
+				proc.stdin.write(JSON.stringify({ type: "steer", message: message.content }) + "\n");
+				renameSync(sourcePath, join(ackDir, name));
+				deliveredMessages.push(message.id);
+			}
+		}
+
+		proc.stdout.setEncoding("utf8");
+		proc.stderr.setEncoding("utf8");
+
+		proc.stdout.on("data", (chunk) => {
+			stdoutBuffer += chunk;
+			let newlineIndex = stdoutBuffer.indexOf("\n");
+			while (newlineIndex >= 0) {
+				const line = stdoutBuffer.slice(0, newlineIndex);
+				stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1);
+				newlineIndex = stdoutBuffer.indexOf("\n");
+				if (!line.trim()) continue;
+				let event;
+				try {
+					event = JSON.parse(line);
+				} catch {
+					continue;
+				}
+				eventTypes.push(event.type || "unknown");
+				if (event.type === "tool_execution_start") {
+					toolCalls.push(event.toolName || event.tool?.name || "tool");
+				}
+				if (event.type === "message_end") {
+					messages.push({
+						role: event.message?.role || "unknown",
+						text: contentToText(event.message),
+						stopReason: event.message?.stopReason || null,
+						error: event.message?.errorMessage || null,
+					});
+					maybeDeliverMailbox();
+					if (
+						requestSessionStats &&
+						!statsRequested &&
+						event.message?.role === "assistant"
+					) {
+						statsRequested = true;
+						proc.stdin.write(JSON.stringify({ type: "get_session_stats" }) + "\n");
+					}
+				}
+				if (event.type === "response" && event.command === "get_session_stats") {
+					statsResponse = event.data || null;
+					contextUsage = event.data?.contextUsage || null;
+				}
+				if (event.type === "agent_end" && !agentEnded) {
+					agentEnded = true;
+					if (closeDelayMs <= 0) {
+						try {
+							proc.stdin.end();
+						} catch {
+							// Ignore stdin close failures.
+						}
+					} else {
+						setTimeout(() => {
+							try {
+								proc.stdin.end();
+							} catch {
+								// Ignore stdin close failures.
+							}
+						}, closeDelayMs);
+					}
+				}
+			}
+		});
+
+		proc.stderr.on("data", (chunk) => {
+			stderrBuffer += chunk;
+		});
+
+		proc.on("error", (error) => {
+			finish({ exitCode: null, signal: null, error: `spawn error: ${error.message}` });
+		});
+
+		proc.on("close", (code, signal) => {
+			finish({ exitCode: code, signal, error: null });
+		});
+
+		if (mailboxDir) {
+			proc.stdin.write(JSON.stringify({ type: "set_steering_mode", mode: "all" }) + "\n");
+		}
+		proc.stdin.write(JSON.stringify({ type: "prompt", message: prompt }) + "\n");
+	});
+}
+
+async function experimentCloseStrategies() {
+	const prompt = "Reply with exactly OK and then stop.";
+	const immediate = await runPiAgent({ prompt, closeDelayMs: 0, requestSessionStats: false, timeoutMs: 20_000 });
+	const delayed = await runPiAgent({ prompt, closeDelayMs: 100, requestSessionStats: true, timeoutMs: 20_000 });
+	return {
+		name: "close-strategy",
+		immediate: {
+			exitCode: immediate.exitCode,
+			stderrTail: immediate.stderr.trim().slice(-160),
+			hasAssertion: immediate.stderr.includes("Assertion failed"),
+		},
+		delayed: {
+			exitCode: delayed.exitCode,
+			contextUsagePresent: !!delayed.contextUsage,
+			assistantTexts: delayed.messages.filter((m) => m.role === "assistant").map((m) => m.text),
+		},
+	};
+}
+
+async function experimentSequentialParallelReliability() {
+	const prompt = "Reply with exactly OK and then stop.";
+	const sequentialRuns = [];
+	for (let i = 0; i < 5; i++) {
+		const result = await runPiAgent({ prompt, closeDelayMs: 100, requestSessionStats: true, timeoutMs: 20_000 });
+		sequentialRuns.push({ exitCode: result.exitCode, contextUsagePresent: !!result.contextUsage, stderrTail: result.stderr.trim().slice(-120) });
+	}
+	const parallel = await Promise.all(
+		[1, 2, 3].map(() => runPiAgent({ prompt, closeDelayMs: 100, requestSessionStats: true, timeoutMs: 20_000 })),
+	);
+	return {
+		name: "reliability",
+		sequential: {
+			runs: sequentialRuns.length,
+			successes: sequentialRuns.filter((r) => r.exitCode === 0 && r.contextUsagePresent).length,
+			results: sequentialRuns,
+		},
+		parallel: {
+			runs: parallel.length,
+			successes: parallel.filter((r) => r.exitCode === 0 && r.contextUsage).length,
+			results: parallel.map((r) => ({ exitCode: r.exitCode, contextUsagePresent: !!r.contextUsage, stderrTail: r.stderr.trim().slice(-120) })),
+		},
+	};
+}
+
+async function experimentMailboxSteering() {
+	const tempRoot = mkdtempSync(join(tmpdir(), "tp-runtime-v2-mailbox-"));
+	const batchId = "lab-batch";
+	const agentId = "lab-agent";
+	const mailboxDir = ensureDir(join(tempRoot, ".pi", "mailbox", batchId, agentId));
+	const message = writeMailboxMessage(mailboxDir, batchId, agentId, "Reply with exactly STEER-ACK and then stop.");
+	const prompt = "First reply with exactly READY. If you later receive a steering message, follow it exactly and then stop.";
+	const result = await runPiAgent({
+		prompt,
+		mailboxDir,
+		closeDelayMs: 100,
+		requestSessionStats: true,
+		timeoutMs: 30_000,
+	});
+	const ackDir = join(mailboxDir, "ack");
+	const acked = existsSync(ackDir) ? readdirSync(ackDir) : [];
+	rmSync(tempRoot, { recursive: true, force: true });
+	return {
+		name: "mailbox-steering",
+		exitCode: result.exitCode,
+		deliveredMessages: result.deliveredMessages,
+		ackFiles: acked,
+		assistantTexts: result.messages.filter((m) => m.role === "assistant").map((m) => m.text),
+		prewrittenMessageId: message.id,
+	};
+}
+
+async function experimentPacketPaths() {
+	async function runPacketAttempt() {
+		const tempRoot = mkdtempSync(join(tmpdir(), "tp-runtime-v2-packet-"));
+		const executionDir = ensureDir(join(tempRoot, "execution-repo"));
+		const packetHomeDir = ensureDir(join(tempRoot, "packet-home"));
+		const promptPath = join(packetHomeDir, "PROMPT.md");
+		const statusPath = join(packetHomeDir, "STATUS.md");
+		const donePath = join(packetHomeDir, ".DONE");
+		writeFileSync(promptPath, "# packet prompt\nDo the thing\n", "utf8");
+		writeFileSync(statusPath, "# status\nNot done\n", "utf8");
+		const prompt = `Your cwd is ${executionDir}. The packet home is different. Read these files: ${promptPath} and ${statusPath}. After reading them, write the exact text \"packet done\\n\" to ${donePath}. Then respond with exactly PACKET-OK and stop.`;
+		const result = await runPiAgent({
+			prompt,
+			tools: ["read", "write"],
+			cwd: executionDir,
+			closeDelayMs: 100,
+			requestSessionStats: true,
+			timeoutMs: 60_000,
+		});
+		const summary = {
+			exitCode: result.exitCode,
+			signal: result.signal,
+			doneExists: existsSync(donePath),
+			doneContent: existsSync(donePath) ? readFileSync(donePath, "utf8") : null,
+			toolCalls: result.toolCalls,
+			assistantTexts: result.messages.filter((m) => m.role === "assistant").map((m) => m.text),
+			stderrTail: result.stderr.trim().slice(-120),
+		};
+		rmSync(tempRoot, { recursive: true, force: true });
+		return summary;
+	}
+
+	const attempts = [];
+	attempts.push(await runPacketAttempt());
+	attempts.push(await runPacketAttempt());
+	return {
+		name: "packet-paths",
+		attempts,
+		successes: attempts.filter((attempt) => attempt.exitCode === 0 && attempt.doneExists).length,
+		note: "A passing attempt demonstrates explicit packet paths are viable outside cwd assumptions; a failing/hanging attempt indicates tool-heavy multi-step prompts still need robust retry/timeout handling in Runtime V2.",
+	};
+}
+
+async function experimentBridgeFeasibility() {
+	const prompt = "Reply with exactly BRIDGE-DEFERRED and then stop.";
+	const result = await runPiAgent({ prompt, closeDelayMs: 100, requestSessionStats: true, timeoutMs: 20_000 });
+	return {
+		name: "bridge-feasibility",
+		status: "open",
+		note: "A true synchronous file-bridge callback was not validated in this first lab run. The mailbox and packet-path experiments reduce risk, but bridge semantics still need a dedicated proof task during TP-106/TP-105 work.",
+		smokeExitCode: result.exitCode,
+		smokeAssistantTexts: result.messages.filter((m) => m.role === "assistant").map((m) => m.text),
+	};
+}
+
+async function main() {
+	const summary = {
+		runAt: new Date().toISOString(),
+		environment: {
+			node: process.version,
+			piVersion: resolvePiVersion(),
+			sessionModeBaseline: "session-attached but resumable",
+		},
+		experiments: [],
+	};
+
+	summary.experiments.push(await experimentCloseStrategies());
+	summary.experiments.push(await experimentSequentialParallelReliability());
+	summary.experiments.push(await experimentMailboxSteering());
+	summary.experiments.push(await experimentPacketPaths());
+	summary.experiments.push(await experimentBridgeFeasibility());
+
+	const outDir = ensureDir(resolve("scripts", "runtime-v2-lab", "out"));
+	const summaryPath = join(outDir, "latest-summary.json");
+	writeFileSync(summaryPath, JSON.stringify(summary, null, 2) + "\n", "utf8");
+	console.log(`Wrote ${summaryPath}`);
+	console.log(JSON.stringify(summary, null, 2));
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exitCode = 1;
+});

--- a/scripts/tmux-spawn-test.mjs
+++ b/scripts/tmux-spawn-test.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * tmux-spawn-test.mjs — Standalone test for tmux session spawn reliability.
+ * 
+ * Tests rapid sequential tmux session creation to reproduce the startup crash
+ * pattern (#335) without running a full batch.
+ * 
+ * Usage:
+ *   node scripts/tmux-spawn-test.mjs [--rounds 10] [--delay 0] [--command "echo hello"] [--wait-after 300]
+ * 
+ * Options:
+ *   --rounds N       Number of create/destroy cycles (default: 20)
+ *   --delay N        Milliseconds between destroy and next create (default: 0)
+ *   --wait-after N   Milliseconds to wait after create before checking (default: 300)
+ *   --command CMD    Command to run in the tmux session (default: "sleep 10")
+ *   --pi             Use actual rpc-wrapper + pi command (expensive! uses tokens)
+ *   --verbose        Show detailed output
+ */
+
+import { spawnSync } from "child_process";
+import { resolve, join } from "path";
+import { writeFileSync, unlinkSync, existsSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+
+const args = process.argv.slice(2);
+function getArg(name, defaultVal) {
+  const idx = args.indexOf(name);
+  if (idx === -1) return defaultVal;
+  return args[idx + 1];
+}
+const hasFlag = (name) => args.includes(name);
+
+const ROUNDS = parseInt(getArg("--rounds", "20"), 10);
+const DELAY_MS = parseInt(getArg("--delay", "0"), 10);
+const WAIT_AFTER_MS = parseInt(getArg("--wait-after", "300"), 10);
+const COMMAND = getArg("--command", "sleep 10");
+const USE_PI = hasFlag("--pi");
+const VERBOSE = hasFlag("--verbose");
+
+const SESSION_NAME = "tp-spawn-test";
+
+function sleep(ms) {
+  if (ms <= 0) return;
+  spawnSync("sleep", [`${ms / 1000}`], { shell: true });
+}
+
+function killSession() {
+  spawnSync("tmux", ["kill-session", "-t", SESSION_NAME]);
+}
+
+function hasSession() {
+  const r = spawnSync("tmux", ["has-session", "-t", SESSION_NAME]);
+  return r.status === 0;
+}
+
+function createSession(cmd) {
+  const r = spawnSync("tmux", ["new-session", "-d", "-s", SESSION_NAME, cmd]);
+  return { ok: r.status === 0, stderr: r.stderr?.toString().trim() || "" };
+}
+
+// Build the pi command if --pi flag is set
+function buildPiCommand() {
+  const rpcWrapper = resolve("bin/rpc-wrapper.mjs");
+  const sidecarDir = join(tmpdir(), "tp-spawn-test");
+  mkdirSync(sidecarDir, { recursive: true });
+  const sidecarPath = join(sidecarDir, "test-sidecar.jsonl");
+  const exitPath = join(sidecarDir, "test-exit.json");
+  const sysPrompt = join(tmpdir(), "tp-spawn-test-sys.txt");
+  const promptFile = join(tmpdir(), "tp-spawn-test-prompt.txt");
+  writeFileSync(sysPrompt, "You are a test. Reply with 'hello' then exit.");
+  writeFileSync(promptFile, "Say hello.");
+  
+  return [
+    `TERM=xterm-256color node`,
+    `'${rpcWrapper}'`,
+    `--sidecar-path '${sidecarPath}'`,
+    `--exit-summary-path '${exitPath}'`,
+    `--model anthropic/claude-sonnet-4-20250514`,
+    `--system-prompt-file '${sysPrompt}'`,
+    `--prompt-file '${promptFile}'`,
+    `--tools read,bash`,
+    `-- --thinking off --no-extensions --no-skills`,
+  ].join(" ");
+}
+
+// ── Main test loop ──────────────────────────────────────────────────
+
+console.log(`\n🧪 tmux spawn reliability test`);
+console.log(`   Rounds: ${ROUNDS}`);
+console.log(`   Delay between cycles: ${DELAY_MS}ms`);
+console.log(`   Wait after create: ${WAIT_AFTER_MS}ms`);
+console.log(`   Command: ${USE_PI ? "rpc-wrapper + pi" : COMMAND}`);
+console.log();
+
+// Ensure clean start
+killSession();
+
+const results = { success: 0, fail: 0, createFail: 0, times: [] };
+const cmd = USE_PI ? buildPiCommand() : COMMAND;
+
+for (let i = 0; i < ROUNDS; i++) {
+  const t0 = Date.now();
+  
+  // Create session
+  const { ok, stderr } = createSession(cmd);
+  if (!ok) {
+    results.createFail++;
+    console.log(`  Round ${i + 1}: ❌ tmux create failed: ${stderr}`);
+    sleep(DELAY_MS);
+    continue;
+  }
+  
+  // Wait for session to stabilize
+  sleep(WAIT_AFTER_MS);
+  
+  // Check if session is alive
+  const alive = hasSession();
+  const elapsed = Date.now() - t0;
+  results.times.push(elapsed);
+  
+  if (alive) {
+    results.success++;
+    if (VERBOSE) console.log(`  Round ${i + 1}: ✅ alive (${elapsed}ms)`);
+  } else {
+    results.fail++;
+    console.log(`  Round ${i + 1}: ❌ died within ${WAIT_AFTER_MS}ms (${elapsed}ms total)`);
+  }
+  
+  // Cleanup
+  killSession();
+  sleep(DELAY_MS);
+}
+
+// ── Results ──────────────────────────────────────────────────────────
+
+const pct = ((results.success / ROUNDS) * 100).toFixed(1);
+const avgMs = results.times.length > 0
+  ? (results.times.reduce((a, b) => a + b, 0) / results.times.length).toFixed(0)
+  : "N/A";
+
+console.log();
+console.log(`📊 Results:`);
+console.log(`   Success: ${results.success}/${ROUNDS} (${pct}%)`);
+console.log(`   Died on startup: ${results.fail}`);
+console.log(`   Create failed: ${results.createFail}`);
+console.log(`   Avg cycle time: ${avgMs}ms`);
+
+if (results.fail > 0) {
+  console.log();
+  console.log(`💡 Suggestions:`);
+  console.log(`   Try increasing --wait-after (current: ${WAIT_AFTER_MS}ms)`);
+  console.log(`   Try increasing --delay (current: ${DELAY_MS}ms)`);
+  console.log(`   Example: node scripts/tmux-spawn-test.mjs --delay 500 --wait-after 1000`);
+}
+
+// ── Sweep test: find the minimum delay for 100% success ──────────
+
+if (hasFlag("--sweep")) {
+  console.log();
+  console.log(`\n🔍 Delay sweep (finding minimum reliable delay)...`);
+  const SWEEP_ROUNDS = 10;
+  
+  for (const delay of [0, 100, 200, 500, 1000, 2000]) {
+    let ok = 0;
+    for (let i = 0; i < SWEEP_ROUNDS; i++) {
+      killSession();
+      sleep(delay);
+      createSession(COMMAND);
+      sleep(WAIT_AFTER_MS);
+      if (hasSession()) ok++;
+      killSession();
+    }
+    const rate = ((ok / SWEEP_ROUNDS) * 100).toFixed(0);
+    const icon = ok === SWEEP_ROUNDS ? "✅" : ok > SWEEP_ROUNDS / 2 ? "⚠️" : "❌";
+    console.log(`   ${icon} delay=${delay}ms: ${ok}/${SWEEP_ROUNDS} (${rate}%)`);
+    if (ok === SWEEP_ROUNDS) {
+      console.log(`   → Minimum reliable delay: ${delay}ms`);
+      break;
+    }
+  }
+}
+
+process.exit(results.fail > 0 ? 1 : 0);

--- a/taskplane-tasks/CONTEXT.md
+++ b/taskplane-tasks/CONTEXT.md
@@ -1,8 +1,8 @@
 # General — Context
 
-**Last Updated:** 2026-03-15
+**Last Updated:** 2026-03-30
 **Status:** Active
-**Next Task ID:** TP-089
+**Next Task ID:** TP-111
 
 ---
 
@@ -45,3 +45,4 @@ _Items discovered during task execution are logged here by agents._
 
 - [ ] **Update worktree naming in taskplane-settings.md** — `docs/reference/configuration/taskplane-settings.md` still describes old `{prefix}-{opId}-{N}` naming. TP-021 changed to batch-scoped `{opId}-{batchId}/lane-{N}`. Deferred to TP-024. (discovered during TP-021)
 - [ ] **Intermittent orch-state-persistence test failure** — `orch-state-persistence.test.ts` occasionally fails when run in full suite (WS-010 task record not found) but passes in isolation. Likely temp directory collision between parallel tests. (discovered during TP-022)
+- [ ] **Runtime V2 implementation program** — Use `docs/specifications/framework/taskplane-runtime-v2/` plus task packets `TP-100` through `TP-109` as the authoritative staging area for the no-TMUX / no-`/task` redesign. Re-scope legacy open tasks `TP-082` through `TP-093` against Runtime V2 before implementing them. (staged 2026-03-30)

--- a/taskplane-tasks/TP-100-runtime-v2-planning-suite-and-backlog/.DONE
+++ b/taskplane-tasks/TP-100-runtime-v2-planning-suite-and-backlog/.DONE
@@ -1,0 +1,2 @@
+Completed: 2026-03-30T00:00:00Z
+Task: TP-100

--- a/taskplane-tasks/TP-100-runtime-v2-planning-suite-and-backlog/PROMPT.md
+++ b/taskplane-tasks/TP-100-runtime-v2-planning-suite-and-backlog/PROMPT.md
@@ -1,0 +1,111 @@
+# Task: TP-100 - Runtime V2 Planning Suite and Implementation Backlog
+
+**Created:** 2026-03-30
+**Size:** M
+
+## Review Level: 1 (Plan Only)
+
+**Assessment:** Foundational architecture and task decomposition only. No runtime code changes, but it sets the direction for removing TMUX and `/task` from the v2 foundation.
+**Score:** 3/8 — Blast radius: 1, Pattern novelty: 1, Security: 0, Reversibility: 1
+
+## Canonical Task Folder
+
+```
+taskplane-tasks/TP-100-runtime-v2-planning-suite-and-backlog/
+├── PROMPT.md   ← This file (immutable above --- divider)
+├── STATUS.md   ← Execution state (worker updates this)
+├── .reviews/   ← Reviewer output (task-runner creates this)
+└── .DONE       ← Created when complete
+```
+
+## Mission
+
+Create the authoritative Runtime V2 architecture suite under `docs/specifications/framework/taskplane-runtime-v2/`, index it from the specifications docs, and restage the implementation program around a no-TMUX / no-`/task` foundation so future execution work has a durable map.
+
+## Dependencies
+
+- **None**
+
+## Context to Read First
+
+**Tier 2 (area context):**
+- `taskplane-tasks/CONTEXT.md`
+
+**Tier 3 (load only if needed):**
+- `docs/specifications/taskplane/spawn-telemetry-stability.md` — source investigation that motivated the redesign
+- `docs/specifications/framework/taskplane-runtime-v2/README.md` — new suite entry point and document map
+- `docs/specifications/README.md` — ensure the new suite is indexed correctly
+
+## Environment
+
+- **Workspace:** `docs/specifications/`, `taskplane-tasks/`
+- **Services required:** None
+
+## File Scope
+
+- `docs/specifications/framework/taskplane-runtime-v2/*`
+- `docs/specifications/README.md`
+- `docs/specifications/taskplane/spawn-telemetry-stability.md`
+- `taskplane-tasks/CONTEXT.md`
+
+## Steps
+
+### Step 0: Preflight
+
+- [ ] Review the spawn-telemetry investigation and existing architecture docs
+- [ ] Review the unimplemented mailbox and polyrepo/segment task horizon before staging the new plan
+
+### Step 1: Author Runtime V2 Planning Suite
+
+- [ ] Create the Runtime V2 architecture, process model, mailbox/bridge, observability, polyrepo compatibility, rollout, and crosswalk docs
+- [ ] Document the no-TMUX, no-`/task`, mailbox-first direction clearly enough for future sessions to pick up without conversation context
+
+### Step 2: Restage the Backlog
+
+- [ ] Map open work (`TP-082` through `TP-093`) onto the Runtime V2 foundation
+- [ ] Stage new implementation tasks required to reach a usable Runtime V2 foundation
+
+### Step 3: Validation and Delivery
+
+- [ ] Index the new docs from the specifications README
+- [ ] Update the investigation doc to point at the follow-on architecture suite
+- [ ] Record the staging outcome in task memory and mark the planning suite complete
+
+## Documentation Requirements
+
+**Must Update:**
+- `docs/specifications/framework/taskplane-runtime-v2/README.md`
+- `docs/specifications/README.md`
+- `docs/specifications/taskplane/spawn-telemetry-stability.md`
+
+**Check If Affected:**
+- `README.md`
+- `docs/explanation/architecture.md`
+
+## Completion Criteria
+
+- [ ] Runtime V2 planning docs exist and are indexed
+- [ ] The implementation crosswalk covers mailbox and polyrepo/segment horizon work
+- [ ] The planning task is durably recorded so future sessions can resume from task packets alone
+
+## Git Commit Convention
+
+Commits happen at **step boundaries** (not after every checkbox). All commits
+for this task MUST include the task ID for traceability:
+
+- **Step completion:** `feat(TP-100): complete Step N — description`
+- **Bug fixes:** `fix(TP-100): description`
+- **Tests:** `test(TP-100): description`
+- **Hydration:** `hydrate: TP-100 expand Step N checkboxes`
+
+## Do NOT
+
+- Implement runtime code in this task
+- Reintroduce TMUX or `/task` as a v2 dependency
+- Leave the new planning suite unindexed
+
+---
+
+## Amendments (Added During Execution)
+
+<!-- Workers add amendments here if issues discovered during execution. -->

--- a/taskplane-tasks/TP-100-runtime-v2-planning-suite-and-backlog/STATUS.md
+++ b/taskplane-tasks/TP-100-runtime-v2-planning-suite-and-backlog/STATUS.md
@@ -1,0 +1,80 @@
+# TP-100: Runtime V2 Planning Suite and Implementation Backlog — Status
+
+**Current Step:** Complete
+**Status:** ✅ Complete
+**Last Updated:** 2026-03-30
+**Review Level:** 1
+**Review Counter:** 0
+**Iteration:** 1
+**Size:** M
+
+---
+
+### Step 0: Preflight
+**Status:** ✅ Complete
+
+- [x] Review the spawn-telemetry investigation and existing architecture docs
+- [x] Review the unimplemented mailbox and polyrepo/segment task horizon before staging the new plan
+
+---
+
+### Step 1: Author Runtime V2 Planning Suite
+**Status:** ✅ Complete
+
+- [x] Create the Runtime V2 architecture, process model, mailbox/bridge, observability, polyrepo compatibility, rollout, and crosswalk docs
+- [x] Document the no-TMUX, no-`/task`, mailbox-first direction clearly enough for future sessions to pick up without conversation context
+
+---
+
+### Step 2: Restage the Backlog
+**Status:** ✅ Complete
+
+- [x] Map open work (`TP-082` through `TP-093`) onto the Runtime V2 foundation
+- [x] Stage new implementation tasks required to reach a usable Runtime V2 foundation
+
+---
+
+### Step 3: Validation and Delivery
+**Status:** ✅ Complete
+
+- [x] Index the new docs from the specifications README
+- [x] Update the investigation doc to point at the follow-on architecture suite
+- [x] Record the staging outcome in task memory and mark the planning suite complete
+
+---
+
+## Reviews
+
+| # | Type | Step | Verdict | File |
+|---|------|------|---------|------|
+
+---
+
+## Discoveries
+
+| Discovery | Disposition | Location |
+|-----------|-------------|----------|
+| Runtime V2 should remove both TMUX and `/task` from the correctness path | Captured in planning suite | docs/specifications/framework/taskplane-runtime-v2/ |
+
+---
+
+## Execution Log
+
+| Timestamp | Action | Outcome |
+|-----------|--------|---------|
+| 2026-03-30 | Task staged | PROMPT.md and STATUS.md created |
+| 2026-03-30 | Planning suite written | Runtime V2 architecture, process, mailbox, observability, rollout, and crosswalk docs created |
+| 2026-03-30 | Backlog restaged | New TP-100..TP-109 task graph created for Runtime V2 foundation |
+| 2026-03-30 | Task complete | .DONE created |
+
+---
+
+## Blockers
+
+*None*
+
+---
+
+## Notes
+
+*Completed during the current architecture/planning session*

--- a/taskplane-tasks/TP-101-refresh-create-taskplane-task-skill-for-runtime-v2/PROMPT.md
+++ b/taskplane-tasks/TP-101-refresh-create-taskplane-task-skill-for-runtime-v2/PROMPT.md
@@ -1,0 +1,121 @@
+# Task: TP-101 - Refresh create-taskplane-task Skill for Runtime V2
+
+**Created:** 2026-03-30
+**Size:** M
+
+## Review Level: 1 (Plan Only)
+
+**Assessment:** Public skill and template refresh. Limited code risk, but the guidance is currently stale in several important ways (`/task`, YAML-first assumptions, `PROGRESS.md` requirement, and TMUX-era wording).
+**Score:** 3/8 — Blast radius: 1, Pattern novelty: 1, Security: 0, Reversibility: 1
+
+## Canonical Task Folder
+
+```
+taskplane-tasks/TP-101-refresh-create-taskplane-task-skill-for-runtime-v2/
+├── PROMPT.md   ← This file (immutable above --- divider)
+├── STATUS.md   ← Execution state (worker updates this)
+├── .reviews/   ← Reviewer output (task-runner creates this)
+└── .DONE       ← Created when complete
+```
+
+## Mission
+
+Update the bundled `create-taskplane-task` skill and its templates so task staging guidance matches Taskplane's Runtime V2 direction: JSON config precedence, `/orch` as the execution path, no TMUX dependency, and no hard `PROGRESS.md` requirement.
+
+## Dependencies
+
+- **Task:** TP-100 (Runtime V2 planning suite exists and defines the new architecture direction)
+
+## Context to Read First
+
+**Tier 2 (area context):**
+- `taskplane-tasks/CONTEXT.md`
+
+**Tier 3 (load only if needed):**
+- `skills/create-taskplane-task/SKILL.md` — current skill behavior and stale assumptions
+- `skills/create-taskplane-task/references/prompt-template.md` — task packet template that still assumes the old execution model
+- `docs/specifications/framework/taskplane-runtime-v2/01-architecture.md` — v2 direction for removing TMUX and `/task`
+- `AGENTS.md` — project policy for JSON config precedence and current testing guidance
+
+## Environment
+
+- **Workspace:** `skills/`, `docs/`
+- **Services required:** None
+
+## File Scope
+
+- `skills/create-taskplane-task/SKILL.md`
+- `skills/create-taskplane-task/references/prompt-template.md`
+- `docs/reference/commands.md`
+- `README.md`
+
+## Steps
+
+### Step 0: Preflight
+
+- [ ] Read the current skill, prompt template, and AGENTS/config guidance
+- [ ] Identify every place the skill still assumes `/task`, TMUX, `PROGRESS.md`, or YAML-first config behavior
+
+### Step 1: Update Skill Workflow and Guidance
+
+- [ ] Switch the skill guidance to JSON config precedence while preserving fallback notes only where necessary
+- [ ] Replace `/task` launch/reporting guidance with `/orch`-based execution guidance
+- [ ] Remove TMUX-centric phrasing from the skill's architecture and workflow sections
+- [ ] Remove `PROGRESS.md` as a required tracking artifact for this project/workflow
+
+### Step 2: Update Templates and References
+
+- [ ] Refresh the prompt/status template language so it does not imply `/task` is the canonical runtime path
+- [ ] Align command references, task-creation checklists, and examples with Runtime V2 direction
+- [ ] Review user-facing docs touched by the skill for consistency
+
+### Step 3: Testing & Verification
+
+- [ ] Verify markdown links and file references in the updated skill and templates
+- [ ] Run CLI smoke checks: `node bin/taskplane.mjs help && node bin/taskplane.mjs doctor`
+- [ ] If shipped docs/commands change beyond the skill itself, run the full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
+
+### Step 4: Documentation & Delivery
+
+- [ ] Document any deliberate interim compatibility wording while Runtime V2 is still under construction
+- [ ] Log discoveries in STATUS.md
+
+## Documentation Requirements
+
+**Must Update:**
+- `skills/create-taskplane-task/SKILL.md`
+- `skills/create-taskplane-task/references/prompt-template.md`
+
+**Check If Affected:**
+- `README.md`
+- `docs/reference/commands.md`
+- `docs/README.md`
+
+## Completion Criteria
+
+- [ ] The bundled task-creation skill no longer points users at `/task` as the canonical execution path
+- [ ] Skill guidance acknowledges JSON config precedence and the Runtime V2 direction
+- [ ] `PROGRESS.md` is no longer treated as a hard requirement
+- [ ] All updated references resolve cleanly
+
+## Git Commit Convention
+
+Commits happen at **step boundaries** (not after every checkbox). All commits
+for this task MUST include the task ID for traceability:
+
+- **Step completion:** `feat(TP-101): complete Step N — description`
+- **Bug fixes:** `fix(TP-101): description`
+- **Tests:** `test(TP-101): description`
+- **Hydration:** `hydrate: TP-101 expand Step N checkboxes`
+
+## Do NOT
+
+- Leave stale `/task` launch commands in the skill
+- Introduce Runtime V2 claims that the codebase cannot yet support
+- Change task packet format semantics without updating reference docs
+
+---
+
+## Amendments (Added During Execution)
+
+<!-- Workers add amendments here if issues discovered during execution. -->

--- a/taskplane-tasks/TP-101-refresh-create-taskplane-task-skill-for-runtime-v2/STATUS.md
+++ b/taskplane-tasks/TP-101-refresh-create-taskplane-task-skill-for-runtime-v2/STATUS.md
@@ -1,0 +1,87 @@
+# TP-101: Refresh create-taskplane-task Skill for Runtime V2 — Status
+
+**Current Step:** Not Started
+**Status:** 🔵 Ready for Execution
+**Last Updated:** 2026-03-30
+**Review Level:** 1
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** M
+
+---
+
+### Step 0: Preflight
+**Status:** ⬜ Not Started
+
+- [ ] Read the current skill, prompt template, and AGENTS/config guidance
+- [ ] Identify every place the skill still assumes `/task`, TMUX, `PROGRESS.md`, or YAML-first config behavior
+
+---
+
+### Step 1: Update Skill Workflow and Guidance
+**Status:** ⬜ Not Started
+
+- [ ] Switch the skill guidance to JSON config precedence while preserving fallback notes only where necessary
+- [ ] Replace `/task` launch/reporting guidance with `/orch`-based execution guidance
+- [ ] Remove TMUX-centric phrasing from the skill's architecture and workflow sections
+- [ ] Remove `PROGRESS.md` as a required tracking artifact for this project/workflow
+
+---
+
+### Step 2: Update Templates and References
+**Status:** ⬜ Not Started
+
+- [ ] Refresh the prompt/status template language so it does not imply `/task` is the canonical runtime path
+- [ ] Align command references, task-creation checklists, and examples with Runtime V2 direction
+- [ ] Review user-facing docs touched by the skill for consistency
+
+---
+
+### Step 3: Testing & Verification
+**Status:** ⬜ Not Started
+
+- [ ] Verify markdown links and file references in the updated skill and templates
+- [ ] Run CLI smoke checks
+- [ ] Run the full suite if shipped behavior/docs changed beyond the skill itself
+
+---
+
+### Step 4: Documentation & Delivery
+**Status:** ⬜ Not Started
+
+- [ ] Document any deliberate interim compatibility wording while Runtime V2 is still under construction
+- [ ] Log discoveries in STATUS.md
+
+---
+
+## Reviews
+
+| # | Type | Step | Verdict | File |
+|---|------|------|---------|------|
+
+---
+
+## Discoveries
+
+| Discovery | Disposition | Location |
+|-----------|-------------|----------|
+
+---
+
+## Execution Log
+
+| Timestamp | Action | Outcome |
+|-----------|--------|---------|
+| 2026-03-30 | Task staged | PROMPT.md and STATUS.md created |
+
+---
+
+## Blockers
+
+*None*
+
+---
+
+## Notes
+
+*Reserved for execution notes*

--- a/taskplane-tasks/TP-102-runtime-v2-execution-unit-and-packet-path-contracts/PROMPT.md
+++ b/taskplane-tasks/TP-102-runtime-v2-execution-unit-and-packet-path-contracts/PROMPT.md
@@ -1,0 +1,120 @@
+# Task: TP-102 - Runtime V2 ExecutionUnit and Packet-Path Contracts
+
+**Created:** 2026-03-30
+**Size:** M
+
+## Review Level: 2 (Plan and Code)
+
+**Assessment:** Establishes the shared contract the rest of Runtime V2 will build on. This touches core orchestrator types and runtime interfaces, but remains mostly deterministic and reversible if kept contract-first.
+**Score:** 5/8 — Blast radius: 2, Pattern novelty: 1, Security: 0, Reversibility: 2
+
+## Canonical Task Folder
+
+```
+taskplane-tasks/TP-102-runtime-v2-execution-unit-and-packet-path-contracts/
+├── PROMPT.md   ← This file (immutable above --- divider)
+├── STATUS.md   ← Execution state (worker updates this)
+├── .reviews/   ← Reviewer output (task-runner creates this)
+└── .DONE       ← Created when complete
+```
+
+## Mission
+
+Define the foundational Runtime V2 contracts in code: execution units, packet-path authority, runtime artifact locations, registry manifests, and helper validation utilities. This task should lift the packet-home work from the old TP-082 / TP-088 path into a first-class Runtime V2 foundation.
+
+## Dependencies
+
+- **Task:** TP-100 (planning suite and crosswalk are the authoritative v2 design source)
+
+## Context to Read First
+
+**Tier 2 (area context):**
+- `taskplane-tasks/CONTEXT.md`
+
+**Tier 3 (load only if needed):**
+- `docs/specifications/framework/taskplane-runtime-v2/01-architecture.md` — target Runtime V2 component and invariants
+- `docs/specifications/framework/taskplane-runtime-v2/02-runtime-process-model.md` — required process ownership and registry contracts
+- `docs/specifications/framework/taskplane-runtime-v2/05-polyrepo-and-segment-compatibility.md` — packet-home and execution-unit compatibility rules
+- `docs/specifications/taskplane/multi-repo-task-execution.md` — existing packet-home and segment requirements to absorb
+
+## Environment
+
+- **Workspace:** `extensions/taskplane/`
+- **Services required:** None
+
+## File Scope
+
+- `extensions/taskplane/types.ts`
+- `extensions/taskplane/execution.ts`
+- `extensions/taskplane/engine.ts`
+- `extensions/taskplane/resume.ts`
+- `extensions/tests/*packet*`
+- `extensions/tests/*runtime*`
+
+## Steps
+
+### Step 0: Preflight
+
+- [ ] Trace the current task/lane runtime contracts through engine, execution, and resume
+- [ ] Identify where packet paths, runtime identity, and live artifacts are currently implicit or TMUX-derived
+
+### Step 1: Define Runtime V2 Contracts
+
+- [ ] Add ExecutionUnit, packet-path, registry manifest, and normalized event type contracts to `types.ts`
+- [ ] Add validation helpers and naming rules that preserve repo/workspace correctness
+- [ ] Document compatibility shims where legacy task/lane records still need to coexist during migration
+
+### Step 2: Thread Contracts into Orchestrator Interfaces
+
+- [ ] Update engine/execution/resume signatures to accept explicit packet-path and runtime identity data where needed
+- [ ] Add helper functions for resolving runtime artifact roots without TMUX/session assumptions
+- [ ] Ensure new contracts are additive and do not yet force the full backend cutover
+
+### Step 3: Testing & Verification
+
+- [ ] Add or update behavioral tests covering ExecutionUnit shape, packet-path authority precedence, and runtime artifact naming
+- [ ] Run the full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
+- [ ] Fix all failures
+
+### Step 4: Documentation & Delivery
+
+- [ ] Update the Runtime V2 docs if implementation naming diverges from the spec suite
+- [ ] Log discoveries in STATUS.md
+
+## Documentation Requirements
+
+**Must Update:**
+- `extensions/taskplane/types.ts`
+- `docs/specifications/framework/taskplane-runtime-v2/05-polyrepo-and-segment-compatibility.md`
+
+**Check If Affected:**
+- `docs/explanation/persistence-and-resume.md`
+- `docs/explanation/execution-model.md`
+
+## Completion Criteria
+
+- [ ] ExecutionUnit and packet-path authority are explicit code contracts
+- [ ] Runtime identity no longer depends on TMUX naming assumptions at the type layer
+- [ ] Regression tests cover the new contract surface
+
+## Git Commit Convention
+
+Commits happen at **step boundaries** (not after every checkbox). All commits
+for this task MUST include the task ID for traceability:
+
+- **Step completion:** `feat(TP-102): complete Step N — description`
+- **Bug fixes:** `fix(TP-102): description`
+- **Tests:** `test(TP-102): description`
+- **Hydration:** `hydrate: TP-102 expand Step N checkboxes`
+
+## Do NOT
+
+- Implement the full Runtime V2 backend in this task
+- Hide packet-path ambiguity behind silent fallbacks
+- Reframe packet-home authority as an optional workspace feature
+
+---
+
+## Amendments (Added During Execution)
+
+<!-- Workers add amendments here if issues discovered during execution. -->

--- a/taskplane-tasks/TP-102-runtime-v2-execution-unit-and-packet-path-contracts/STATUS.md
+++ b/taskplane-tasks/TP-102-runtime-v2-execution-unit-and-packet-path-contracts/STATUS.md
@@ -1,0 +1,86 @@
+# TP-102: Runtime V2 ExecutionUnit and Packet-Path Contracts — Status
+
+**Current Step:** Not Started
+**Status:** 🔵 Ready for Execution
+**Last Updated:** 2026-03-30
+**Review Level:** 2
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** M
+
+---
+
+### Step 0: Preflight
+**Status:** ⬜ Not Started
+
+- [ ] Trace the current task/lane runtime contracts through engine, execution, and resume
+- [ ] Identify where packet paths, runtime identity, and live artifacts are currently implicit or TMUX-derived
+
+---
+
+### Step 1: Define Runtime V2 Contracts
+**Status:** ⬜ Not Started
+
+- [ ] Add ExecutionUnit, packet-path, registry manifest, and normalized event type contracts to `types.ts`
+- [ ] Add validation helpers and naming rules that preserve repo/workspace correctness
+- [ ] Document compatibility shims where legacy task/lane records still need to coexist during migration
+
+---
+
+### Step 2: Thread Contracts into Orchestrator Interfaces
+**Status:** ⬜ Not Started
+
+- [ ] Update engine/execution/resume signatures to accept explicit packet-path and runtime identity data where needed
+- [ ] Add helper functions for resolving runtime artifact roots without TMUX/session assumptions
+- [ ] Ensure new contracts are additive and do not yet force the full backend cutover
+
+---
+
+### Step 3: Testing & Verification
+**Status:** ⬜ Not Started
+
+- [ ] Add or update behavioral tests covering ExecutionUnit shape, packet-path authority precedence, and runtime artifact naming
+- [ ] Run the full suite
+- [ ] Fix all failures
+
+---
+
+### Step 4: Documentation & Delivery
+**Status:** ⬜ Not Started
+
+- [ ] Update the Runtime V2 docs if implementation naming diverges from the spec suite
+- [ ] Log discoveries in STATUS.md
+
+---
+
+## Reviews
+
+| # | Type | Step | Verdict | File |
+|---|------|------|---------|------|
+
+---
+
+## Discoveries
+
+| Discovery | Disposition | Location |
+|-----------|-------------|----------|
+
+---
+
+## Execution Log
+
+| Timestamp | Action | Outcome |
+|-----------|--------|---------|
+| 2026-03-30 | Task staged | PROMPT.md and STATUS.md created |
+
+---
+
+## Blockers
+
+*None*
+
+---
+
+## Notes
+
+*Reserved for execution notes*

--- a/taskplane-tasks/TP-103-extract-task-executor-core-from-task-runner/PROMPT.md
+++ b/taskplane-tasks/TP-103-extract-task-executor-core-from-task-runner/PROMPT.md
@@ -1,0 +1,121 @@
+# Task: TP-103 - Extract Task Executor Core from task-runner
+
+**Created:** 2026-03-30
+**Size:** L
+
+## Review Level: 3 (Full)
+
+**Assessment:** Moves critical execution semantics out of the deprecated `/task` extension host. High blast radius across worker, reviewer, status, and completion logic; must preserve behavior while changing ownership.
+**Score:** 6/8 — Blast radius: 2, Pattern novelty: 2, Security: 0, Reversibility: 2
+
+## Canonical Task Folder
+
+```
+taskplane-tasks/TP-103-extract-task-executor-core-from-task-runner/
+├── PROMPT.md   ← This file (immutable above --- divider)
+├── STATUS.md   ← Execution state (worker updates this)
+├── .reviews/   ← Reviewer output (task-runner creates this)
+└── .DONE       ← Created when complete
+```
+
+## Mission
+
+Extract the headless task execution state machine from `extensions/task-runner.ts` into a reusable Runtime V2 core library, leaving the extension as a thin compatibility wrapper only for as long as needed. After this task, no mission-critical execution logic should live exclusively inside the deprecated `/task` path.
+
+## Dependencies
+
+- **Task:** TP-100 (Runtime V2 foundation and task graph staged)
+- **Task:** TP-102 (ExecutionUnit and packet-path contracts defined)
+
+## Context to Read First
+
+**Tier 2 (area context):**
+- `taskplane-tasks/CONTEXT.md`
+
+**Tier 3 (load only if needed):**
+- `docs/specifications/framework/taskplane-runtime-v2/02-runtime-process-model.md` — lane-runner and executor-core target ownership
+- `docs/specifications/framework/taskplane-runtime-v2/08-implementation-workpackages.md` — expected extraction work package
+- `extensions/task-runner.ts` — current execution logic to extract
+- `docs/explanation/execution-model.md` — behavioral contract that must remain intact
+
+## Environment
+
+- **Workspace:** `extensions/`
+- **Services required:** None
+
+## File Scope
+
+- `extensions/task-runner.ts`
+- `extensions/taskplane/task-executor-core.ts`
+- `extensions/taskplane/*review*`
+- `extensions/tests/persistent-worker-context.test.ts`
+- `extensions/tests/task-runner-orchestration.test.ts`
+
+## Steps
+
+### Step 0: Preflight
+
+- [ ] Map the current task-runner execution path: parsing, status mutation, worker loop, reviewer integration, quality gate, and `.DONE` semantics
+- [ ] Identify which helpers can move unchanged and which need new runtime-facing interfaces
+
+### Step 1: Extract Headless Executor Core
+
+- [ ] Create a new headless executor module that owns task execution semantics without Pi UI/session assumptions
+- [ ] Move STATUS parsing/mutation, worker iteration bookkeeping, and completion checks behind explicit interfaces
+- [ ] Move review orchestration and quality-gate helpers behind explicit runtime-facing interfaces where practical
+
+### Step 2: Thin task-runner Wrapper
+
+- [ ] Refactor `task-runner.ts` to delegate to the shared core instead of owning the logic directly
+- [ ] Keep the deprecated `/task` surface as a wrapper only if needed for interim compatibility, not as the architectural owner
+- [ ] Ensure Runtime V2 callers can invoke the shared core without `TASK_AUTOSTART` or session-start coupling
+
+### Step 3: Testing & Verification
+
+- [ ] Add or update behavioral tests proving execution semantics are preserved after extraction
+- [ ] Run the full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
+- [ ] Fix all failures
+
+### Step 4: Documentation & Delivery
+
+- [ ] Update execution architecture docs if extracted module boundaries differ from the spec
+- [ ] Log discoveries in STATUS.md
+
+## Documentation Requirements
+
+**Must Update:**
+- `extensions/taskplane/task-executor-core.ts`
+- `extensions/task-runner.ts`
+
+**Check If Affected:**
+- `docs/explanation/execution-model.md`
+- `docs/explanation/architecture.md`
+- `README.md`
+
+## Completion Criteria
+
+- [ ] A headless executor core exists and owns task execution semantics
+- [ ] `task-runner.ts` is no longer the only place where mission-critical execution logic lives
+- [ ] Regression tests prove behavior parity
+
+## Git Commit Convention
+
+Commits happen at **step boundaries** (not after every checkbox). All commits
+for this task MUST include the task ID for traceability:
+
+- **Step completion:** `feat(TP-103): complete Step N — description`
+- **Bug fixes:** `fix(TP-103): description`
+- **Tests:** `test(TP-103): description`
+- **Hydration:** `hydrate: TP-103 expand Step N checkboxes`
+
+## Do NOT
+
+- Preserve `/task` as the long-term authoritative execution path
+- Couple the extracted core to Pi UI widgets or session lifecycle
+- Change `.DONE` or STATUS semantics casually
+
+---
+
+## Amendments (Added During Execution)
+
+<!-- Workers add amendments here if issues discovered during execution. -->

--- a/taskplane-tasks/TP-103-extract-task-executor-core-from-task-runner/STATUS.md
+++ b/taskplane-tasks/TP-103-extract-task-executor-core-from-task-runner/STATUS.md
@@ -1,0 +1,86 @@
+# TP-103: Extract Task Executor Core from task-runner — Status
+
+**Current Step:** Not Started
+**Status:** 🔵 Ready for Execution
+**Last Updated:** 2026-03-30
+**Review Level:** 3
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** L
+
+---
+
+### Step 0: Preflight
+**Status:** ⬜ Not Started
+
+- [ ] Map the current task-runner execution path: parsing, status mutation, worker loop, reviewer integration, quality gate, and `.DONE` semantics
+- [ ] Identify which helpers can move unchanged and which need new runtime-facing interfaces
+
+---
+
+### Step 1: Extract Headless Executor Core
+**Status:** ⬜ Not Started
+
+- [ ] Create a new headless executor module that owns task execution semantics without Pi UI/session assumptions
+- [ ] Move STATUS parsing/mutation, worker iteration bookkeeping, and completion checks behind explicit interfaces
+- [ ] Move review orchestration and quality-gate helpers behind explicit runtime-facing interfaces where practical
+
+---
+
+### Step 2: Thin task-runner Wrapper
+**Status:** ⬜ Not Started
+
+- [ ] Refactor `task-runner.ts` to delegate to the shared core instead of owning the logic directly
+- [ ] Keep the deprecated `/task` surface as a wrapper only if needed for interim compatibility, not as the architectural owner
+- [ ] Ensure Runtime V2 callers can invoke the shared core without `TASK_AUTOSTART` or session-start coupling
+
+---
+
+### Step 3: Testing & Verification
+**Status:** ⬜ Not Started
+
+- [ ] Add or update behavioral tests proving execution semantics are preserved after extraction
+- [ ] Run the full suite
+- [ ] Fix all failures
+
+---
+
+### Step 4: Documentation & Delivery
+**Status:** ⬜ Not Started
+
+- [ ] Update execution architecture docs if extracted module boundaries differ from the spec
+- [ ] Log discoveries in STATUS.md
+
+---
+
+## Reviews
+
+| # | Type | Step | Verdict | File |
+|---|------|------|---------|------|
+
+---
+
+## Discoveries
+
+| Discovery | Disposition | Location |
+|-----------|-------------|----------|
+
+---
+
+## Execution Log
+
+| Timestamp | Action | Outcome |
+|-----------|--------|---------|
+| 2026-03-30 | Task staged | PROMPT.md and STATUS.md created |
+
+---
+
+## Blockers
+
+*None*
+
+---
+
+## Notes
+
+*Reserved for execution notes*

--- a/taskplane-tasks/TP-104-direct-agent-host-process-registry-and-normalized-events/PROMPT.md
+++ b/taskplane-tasks/TP-104-direct-agent-host-process-registry-and-normalized-events/PROMPT.md
@@ -1,0 +1,122 @@
+# Task: TP-104 - Direct Agent Host, Process Registry, and Normalized Events
+
+**Created:** 2026-03-30
+**Size:** L
+
+## Review Level: 3 (Full)
+
+**Assessment:** This replaces the most failure-prone part of the control plane: TMUX-backed child hosting. High novelty and broad runtime effect, but it is the core stability payoff of Runtime V2.
+**Score:** 7/8 — Blast radius: 2, Pattern novelty: 2, Security: 1, Reversibility: 2
+
+## Canonical Task Folder
+
+```
+taskplane-tasks/TP-104-direct-agent-host-process-registry-and-normalized-events/
+├── PROMPT.md   ← This file (immutable above --- divider)
+├── STATUS.md   ← Execution state (worker updates this)
+├── .reviews/   ← Reviewer output (task-runner creates this)
+└── .DONE       ← Created when complete
+```
+
+## Mission
+
+Implement the direct-child Runtime V2 agent host and process registry. Worker, reviewer, and merger agents must be spawnable without TMUX, with one deterministic owner, normalized event streams, durable manifests, and mailbox delivery preserved via Pi RPC steering.
+
+## Dependencies
+
+- **Task:** TP-100 (Runtime V2 architecture suite staged)
+- **Task:** TP-102 (shared runtime contracts defined)
+
+## Context to Read First
+
+**Tier 2 (area context):**
+- `taskplane-tasks/CONTEXT.md`
+
+**Tier 3 (load only if needed):**
+- `docs/specifications/framework/taskplane-runtime-v2/02-runtime-process-model.md` — target ownership and process registry model
+- `docs/specifications/framework/taskplane-runtime-v2/03-bridge-and-mailbox.md` — mailbox expectations the new host must preserve
+- `docs/specifications/framework/taskplane-runtime-v2/04-observability-and-dashboard.md` — normalized event expectations
+- `docs/specifications/taskplane/spawn-telemetry-stability.md` — failure history the new host is intended to eliminate
+
+## Environment
+
+- **Workspace:** `bin/`, `extensions/taskplane/`
+- **Services required:** None
+
+## File Scope
+
+- `bin/rpc-wrapper.mjs`
+- `bin/agent-host.mjs`
+- `extensions/taskplane/process-registry.ts`
+- `extensions/taskplane/types.ts`
+- `extensions/taskplane/cleanup.ts`
+- `extensions/tests/rpc-wrapper.test.ts`
+- `extensions/tests/*registry*`
+
+## Steps
+
+### Step 0: Preflight
+
+- [ ] Trace the current rpc-wrapper responsibilities and identify which belong in a Runtime V2 host versus higher-level runtime code
+- [ ] Define the manifest, registry, and normalized event flow before cutting code
+
+### Step 1: Implement Process Registry and Manifests
+
+- [ ] Create the runtime registry and per-agent manifest helpers
+- [ ] Persist enough metadata to replace TMUX-based liveness and cleanup checks
+- [ ] Define deterministic state transitions for running, wrapping up, exited, crashed, timed out, and killed agents
+
+### Step 2: Implement Direct Agent Host
+
+- [ ] Implement or evolve the host so it spawns `pi --mode rpc` directly with `shell: false` and no TMUX dependency
+- [ ] Normalize RPC events into durable per-agent event logs and parent-facing updates
+- [ ] Preserve mailbox inbox delivery and exit summaries on the new host
+
+### Step 3: Testing & Verification
+
+- [ ] Add or update behavioral tests for direct-child hosting, registry lifecycle, normalized event persistence, and mailbox delivery
+- [ ] Run the full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
+- [ ] Fix all failures
+
+### Step 4: Documentation & Delivery
+
+- [ ] Update Runtime V2 docs if host/registry naming differs from plan
+- [ ] Log discoveries in STATUS.md
+
+## Documentation Requirements
+
+**Must Update:**
+- `docs/specifications/framework/taskplane-runtime-v2/02-runtime-process-model.md`
+- `docs/specifications/framework/taskplane-runtime-v2/04-observability-and-dashboard.md`
+
+**Check If Affected:**
+- `docs/reference/commands.md`
+- `docs/explanation/architecture.md`
+
+## Completion Criteria
+
+- [ ] Agents can be hosted without TMUX installed
+- [ ] A runtime registry and per-agent manifests replace TMUX liveness for the new backend
+- [ ] Normalized event logs exist for downstream dashboard and supervisor work
+
+## Git Commit Convention
+
+Commits happen at **step boundaries** (not after every checkbox). All commits
+for this task MUST include the task ID for traceability:
+
+- **Step completion:** `feat(TP-104): complete Step N — description`
+- **Bug fixes:** `fix(TP-104): description`
+- **Tests:** `test(TP-104): description`
+- **Hydration:** `hydrate: TP-104 expand Step N checkboxes`
+
+## Do NOT
+
+- Retain TMUX as a hidden fallback in the correctness path
+- Use shell-composed command strings where argument arrays suffice
+- Leave mailbox delivery broken while changing transport
+
+---
+
+## Amendments (Added During Execution)
+
+<!-- Workers add amendments here if issues discovered during execution. -->

--- a/taskplane-tasks/TP-104-direct-agent-host-process-registry-and-normalized-events/STATUS.md
+++ b/taskplane-tasks/TP-104-direct-agent-host-process-registry-and-normalized-events/STATUS.md
@@ -1,0 +1,86 @@
+# TP-104: Direct Agent Host, Process Registry, and Normalized Events — Status
+
+**Current Step:** Not Started
+**Status:** 🔵 Ready for Execution
+**Last Updated:** 2026-03-30
+**Review Level:** 3
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** L
+
+---
+
+### Step 0: Preflight
+**Status:** ⬜ Not Started
+
+- [ ] Trace the current rpc-wrapper responsibilities and identify which belong in a Runtime V2 host versus higher-level runtime code
+- [ ] Define the manifest, registry, and normalized event flow before cutting code
+
+---
+
+### Step 1: Implement Process Registry and Manifests
+**Status:** ⬜ Not Started
+
+- [ ] Create the runtime registry and per-agent manifest helpers
+- [ ] Persist enough metadata to replace TMUX-based liveness and cleanup checks
+- [ ] Define deterministic state transitions for running, wrapping up, exited, crashed, timed out, and killed agents
+
+---
+
+### Step 2: Implement Direct Agent Host
+**Status:** ⬜ Not Started
+
+- [ ] Implement or evolve the host so it spawns `pi --mode rpc` directly with `shell: false` and no TMUX dependency
+- [ ] Normalize RPC events into durable per-agent event logs and parent-facing updates
+- [ ] Preserve mailbox inbox delivery and exit summaries on the new host
+
+---
+
+### Step 3: Testing & Verification
+**Status:** ⬜ Not Started
+
+- [ ] Add or update behavioral tests for direct-child hosting, registry lifecycle, normalized event persistence, and mailbox delivery
+- [ ] Run the full suite
+- [ ] Fix all failures
+
+---
+
+### Step 4: Documentation & Delivery
+**Status:** ⬜ Not Started
+
+- [ ] Update Runtime V2 docs if host/registry naming differs from plan
+- [ ] Log discoveries in STATUS.md
+
+---
+
+## Reviews
+
+| # | Type | Step | Verdict | File |
+|---|------|------|---------|------|
+
+---
+
+## Discoveries
+
+| Discovery | Disposition | Location |
+|-----------|-------------|----------|
+
+---
+
+## Execution Log
+
+| Timestamp | Action | Outcome |
+|-----------|--------|---------|
+| 2026-03-30 | Task staged | PROMPT.md and STATUS.md created |
+
+---
+
+## Blockers
+
+*None*
+
+---
+
+## Notes
+
+*Reserved for execution notes*

--- a/taskplane-tasks/TP-105-headless-lane-runner-and-single-task-orch-v2/PROMPT.md
+++ b/taskplane-tasks/TP-105-headless-lane-runner-and-single-task-orch-v2/PROMPT.md
@@ -1,0 +1,125 @@
+# Task: TP-105 - Headless Lane Runner and Single-Task /orch Runtime V2
+
+**Created:** 2026-03-30
+**Size:** L
+
+## Review Level: 3 (Full)
+
+**Assessment:** This creates the first usable vertical slice of Runtime V2 by connecting the new executor core and agent host into a single-task `/orch` flow. High coordination risk across engine, extension, and execution modules.
+**Score:** 7/8 — Blast radius: 2, Pattern novelty: 2, Security: 1, Reversibility: 2
+
+## Canonical Task Folder
+
+```
+taskplane-tasks/TP-105-headless-lane-runner-and-single-task-orch-v2/
+├── PROMPT.md   ← This file (immutable above --- divider)
+├── STATUS.md   ← Execution state (worker updates this)
+├── .reviews/   ← Reviewer output (task-runner creates this)
+└── .DONE       ← Created when complete
+```
+
+## Mission
+
+Implement the headless `lane-runner` and route single-task `/orch <PROMPT.md>` execution through Runtime V2. After this task, Taskplane should have a real no-TMUX, no-`/task` execution slice that can run one task end-to-end on the new foundation.
+
+## Dependencies
+
+- **Task:** TP-102 (Runtime V2 contracts defined)
+- **Task:** TP-103 (executor core extracted)
+- **Task:** TP-104 (direct agent host and registry available)
+
+## Context to Read First
+
+**Tier 2 (area context):**
+- `taskplane-tasks/CONTEXT.md`
+
+**Tier 3 (load only if needed):**
+- `docs/specifications/framework/taskplane-runtime-v2/01-architecture.md` — lane-runner role in the target architecture
+- `docs/specifications/framework/taskplane-runtime-v2/02-runtime-process-model.md` — required lifecycle and ownership rules
+- `docs/specifications/framework/taskplane-runtime-v2/08-implementation-workpackages.md` — lane-runner work package expectations
+- `extensions/taskplane/engine.ts` — current orchestration start path that needs a new backend
+
+## Environment
+
+- **Workspace:** `extensions/taskplane/`, `extensions/`
+- **Services required:** None
+
+## File Scope
+
+- `extensions/taskplane/lane-runner.ts`
+- `extensions/taskplane/engine.ts`
+- `extensions/taskplane/execution.ts`
+- `extensions/taskplane/extension.ts`
+- `extensions/task-runner.ts`
+- `extensions/tests/*orch*`
+
+## Steps
+
+### Step 0: Preflight
+
+- [ ] Trace current single-task `/orch` execution through engine, execution helpers, lane sessions, and task-runner autostart
+- [ ] Identify every place the current path still depends on TMUX sessions, `TASK_AUTOSTART`, or `/task` semantics
+
+### Step 1: Implement Headless Lane Runner
+
+- [ ] Add a lane-runner process/module that owns one lane's execution lifecycle using the shared executor core and direct agent host
+- [ ] Define the lane-runner launch contract, control signals, and lane snapshot outputs
+- [ ] Keep worktree/orch-branch semantics intact while changing the runtime host
+
+### Step 2: Cut Over Single-Task `/orch`
+
+- [ ] Route `/orch <PROMPT.md>` through the lane-runner backend
+- [ ] Remove mission-critical dependence on `TASK_AUTOSTART` and lane Pi session startup hooks for this path
+- [ ] Ensure no part of the single-task Runtime V2 flow requires `/task` or TMUX
+
+### Step 3: Testing & Verification
+
+- [ ] Add or update tests for lane-runner launch, single-task `/orch` execution, and new backend lifecycle behavior
+- [ ] Run the full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
+- [ ] Run CLI smoke checks: `node bin/taskplane.mjs help && node bin/taskplane.mjs doctor`
+- [ ] Fix all failures
+
+### Step 4: Documentation & Delivery
+
+- [ ] Update architecture and command docs for the new single-task Runtime V2 path
+- [ ] Log discoveries in STATUS.md
+
+## Documentation Requirements
+
+**Must Update:**
+- `docs/explanation/architecture.md`
+- `docs/reference/commands.md`
+- `docs/specifications/framework/taskplane-runtime-v2/02-runtime-process-model.md`
+
+**Check If Affected:**
+- `README.md`
+- `docs/explanation/execution-model.md`
+- `docs/explanation/waves-lanes-and-worktrees.md`
+
+## Completion Criteria
+
+- [ ] Single-task `/orch` runs end-to-end on Runtime V2 without TMUX
+- [ ] The new lane-runner owns task execution instead of a lane Pi extension session
+- [ ] `/task` is no longer required anywhere in the critical path for the first v2 slice
+
+## Git Commit Convention
+
+Commits happen at **step boundaries** (not after every checkbox). All commits
+for this task MUST include the task ID for traceability:
+
+- **Step completion:** `feat(TP-105): complete Step N — description`
+- **Bug fixes:** `fix(TP-105): description`
+- **Tests:** `test(TP-105): description`
+- **Hydration:** `hydrate: TP-105 expand Step N checkboxes`
+
+## Do NOT
+
+- Keep `TASK_AUTOSTART` as a hidden dependency in the new backend
+- Add a new Runtime V2 path that still shells out through TMUX
+- Claim batch parity before the batch migration task lands
+
+---
+
+## Amendments (Added During Execution)
+
+<!-- Workers add amendments here if issues discovered during execution. -->

--- a/taskplane-tasks/TP-105-headless-lane-runner-and-single-task-orch-v2/STATUS.md
+++ b/taskplane-tasks/TP-105-headless-lane-runner-and-single-task-orch-v2/STATUS.md
@@ -1,0 +1,87 @@
+# TP-105: Headless Lane Runner and Single-Task /orch Runtime V2 — Status
+
+**Current Step:** Not Started
+**Status:** 🔵 Ready for Execution
+**Last Updated:** 2026-03-30
+**Review Level:** 3
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** L
+
+---
+
+### Step 0: Preflight
+**Status:** ⬜ Not Started
+
+- [ ] Trace current single-task `/orch` execution through engine, execution helpers, lane sessions, and task-runner autostart
+- [ ] Identify every place the current path still depends on TMUX sessions, `TASK_AUTOSTART`, or `/task` semantics
+
+---
+
+### Step 1: Implement Headless Lane Runner
+**Status:** ⬜ Not Started
+
+- [ ] Add a lane-runner process/module that owns one lane's execution lifecycle using the shared executor core and direct agent host
+- [ ] Define the lane-runner launch contract, control signals, and lane snapshot outputs
+- [ ] Keep worktree/orch-branch semantics intact while changing the runtime host
+
+---
+
+### Step 2: Cut Over Single-Task `/orch`
+**Status:** ⬜ Not Started
+
+- [ ] Route `/orch <PROMPT.md>` through the lane-runner backend
+- [ ] Remove mission-critical dependence on `TASK_AUTOSTART` and lane Pi session startup hooks for this path
+- [ ] Ensure no part of the single-task Runtime V2 flow requires `/task` or TMUX
+
+---
+
+### Step 3: Testing & Verification
+**Status:** ⬜ Not Started
+
+- [ ] Add or update tests for lane-runner launch, single-task `/orch` execution, and new backend lifecycle behavior
+- [ ] Run the full suite
+- [ ] Run CLI smoke checks
+- [ ] Fix all failures
+
+---
+
+### Step 4: Documentation & Delivery
+**Status:** ⬜ Not Started
+
+- [ ] Update architecture and command docs for the new single-task Runtime V2 path
+- [ ] Log discoveries in STATUS.md
+
+---
+
+## Reviews
+
+| # | Type | Step | Verdict | File |
+|---|------|------|---------|------|
+
+---
+
+## Discoveries
+
+| Discovery | Disposition | Location |
+|-----------|-------------|----------|
+
+---
+
+## Execution Log
+
+| Timestamp | Action | Outcome |
+|-----------|--------|---------|
+| 2026-03-30 | Task staged | PROMPT.md and STATUS.md created |
+
+---
+
+## Blockers
+
+*None*
+
+---
+
+## Notes
+
+*Reserved for execution notes*

--- a/taskplane-tasks/TP-106-mailbox-replies-broadcast-and-registry-backed-supervisor-control/PROMPT.md
+++ b/taskplane-tasks/TP-106-mailbox-replies-broadcast-and-registry-backed-supervisor-control/PROMPT.md
@@ -1,0 +1,126 @@
+# Task: TP-106 - Mailbox Replies, Broadcast, and Registry-Backed Supervisor Control
+
+**Created:** 2026-03-30
+**Size:** L
+
+## Review Level: 2 (Plan and Code)
+
+**Assessment:** Builds directly on the new host/registry to finish the mailbox control plane. Broad but mostly deterministic work; the main risk is preserving supervisor ergonomics while changing liveness assumptions.
+**Score:** 5/8 — Blast radius: 2, Pattern novelty: 1, Security: 1, Reversibility: 1
+
+## Canonical Task Folder
+
+```
+taskplane-tasks/TP-106-mailbox-replies-broadcast-and-registry-backed-supervisor-control/
+├── PROMPT.md   ← This file (immutable above --- divider)
+├── STATUS.md   ← Execution state (worker updates this)
+├── .reviews/   ← Reviewer output (task-runner creates this)
+└── .DONE       ← Created when complete
+```
+
+## Mission
+
+Finish the mailbox-first control plane on Runtime V2: registry-backed supervisor tools, agent replies/escalations, broadcast, rate limiting, and minimal bridge tools for agent→supervisor contact. This task absorbs the pending TP-091 and TP-092 work onto the new runtime identity model.
+
+## Dependencies
+
+- **Task:** TP-104 (direct agent host and runtime registry exist)
+- **Task:** TP-105 (lane-runner single-task Runtime V2 path exists)
+
+## Context to Read First
+
+**Tier 2 (area context):**
+- `taskplane-tasks/CONTEXT.md`
+
+**Tier 3 (load only if needed):**
+- `docs/specifications/framework/taskplane-runtime-v2/03-bridge-and-mailbox.md` — target mailbox and bridge protocols
+- `docs/specifications/taskplane/agent-mailbox-steering.md` — current mailbox phases and semantics
+- `extensions/taskplane/extension.ts` — current supervisor tool surface that still assumes TMUX liveness
+- `extensions/taskplane/mailbox.ts` — existing mailbox core to extend rather than replace
+
+## Environment
+
+- **Workspace:** `extensions/taskplane/`
+- **Services required:** None
+
+## File Scope
+
+- `extensions/taskplane/extension.ts`
+- `extensions/taskplane/mailbox.ts`
+- `extensions/taskplane/types.ts`
+- `extensions/taskplane/agent-bridge-extension.ts`
+- `extensions/tests/mailbox.test.ts`
+- `extensions/tests/*supervisor*`
+
+## Steps
+
+### Step 0: Preflight
+
+- [ ] Review current mailbox implementation and identify which assumptions are session/TMUX-specific rather than agent-ID/registry-based
+- [ ] Trace the current supervisor tools (`send_agent_message`, `list_active_agents`, `read_agent_status`) and outline the Runtime V2 source of truth for each
+
+### Step 1: Registry-Backed Supervisor Tools
+
+- [ ] Rework supervisor-facing agent tools to validate and resolve against the runtime registry instead of TMUX
+- [ ] Preserve familiar agent IDs while severing the assumption that they are terminal/session names
+- [ ] Ensure delivery and liveness errors are surfaced from registry/runtime state, not terminal state
+
+### Step 2: Agent Replies, Broadcast, and Rate Limiting
+
+- [ ] Implement agent→supervisor replies/escalations on the new runtime flow
+- [ ] Implement broadcast and per-agent rate limiting on top of the mailbox model
+- [ ] Keep auditability intact for sent, delivered, replied, and rate-limited messages
+
+### Step 3: Bridge Contact Tools
+
+- [ ] Add minimal agent-side bridge/contact tools for reply/escalate flows where generic file writes would be brittle
+- [ ] Document how these tools fit with future review and segment-expansion bridge work
+
+### Step 4: Testing & Verification
+
+- [ ] Add or update behavioral tests for registry-backed tool behavior, reply flow, broadcast, and rate limiting
+- [ ] Run the full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
+- [ ] Fix all failures
+
+### Step 5: Documentation & Delivery
+
+- [ ] Update mailbox and command docs for the new Runtime V2 control model
+- [ ] Log discoveries in STATUS.md
+
+## Documentation Requirements
+
+**Must Update:**
+- `docs/specifications/taskplane/agent-mailbox-steering.md`
+- `docs/reference/commands.md`
+
+**Check If Affected:**
+- `README.md`
+- `docs/specifications/framework/taskplane-runtime-v2/03-bridge-and-mailbox.md`
+
+## Completion Criteria
+
+- [ ] Supervisor messaging tools are registry-backed rather than TMUX-backed
+- [ ] Agents can reply/escalate to the supervisor on Runtime V2
+- [ ] Broadcast and rate limiting work without reintroducing terminal assumptions
+
+## Git Commit Convention
+
+Commits happen at **step boundaries** (not after every checkbox). All commits
+for this task MUST include the task ID for traceability:
+
+- **Step completion:** `feat(TP-106): complete Step N — description`
+- **Bug fixes:** `fix(TP-106): description`
+- **Tests:** `test(TP-106): description`
+- **Hydration:** `hydrate: TP-106 expand Step N checkboxes`
+
+## Do NOT
+
+- Keep `tmuxHasSession()` as the authority for agent liveness
+- Require operators to type directly into agents
+- Split mailbox truth between registry-backed and TMUX-backed sources without a clear precedence rule
+
+---
+
+## Amendments (Added During Execution)
+
+<!-- Workers add amendments here if issues discovered during execution. -->

--- a/taskplane-tasks/TP-106-mailbox-replies-broadcast-and-registry-backed-supervisor-control/STATUS.md
+++ b/taskplane-tasks/TP-106-mailbox-replies-broadcast-and-registry-backed-supervisor-control/STATUS.md
@@ -1,0 +1,94 @@
+# TP-106: Mailbox Replies, Broadcast, and Registry-Backed Supervisor Control — Status
+
+**Current Step:** Not Started
+**Status:** 🔵 Ready for Execution
+**Last Updated:** 2026-03-30
+**Review Level:** 2
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** L
+
+---
+
+### Step 0: Preflight
+**Status:** ⬜ Not Started
+
+- [ ] Review current mailbox implementation and identify which assumptions are session/TMUX-specific rather than agent-ID/registry-based
+- [ ] Trace the current supervisor tools (`send_agent_message`, `list_active_agents`, `read_agent_status`) and outline the Runtime V2 source of truth for each
+
+---
+
+### Step 1: Registry-Backed Supervisor Tools
+**Status:** ⬜ Not Started
+
+- [ ] Rework supervisor-facing agent tools to validate and resolve against the runtime registry instead of TMUX
+- [ ] Preserve familiar agent IDs while severing the assumption that they are terminal/session names
+- [ ] Ensure delivery and liveness errors are surfaced from registry/runtime state, not terminal state
+
+---
+
+### Step 2: Agent Replies, Broadcast, and Rate Limiting
+**Status:** ⬜ Not Started
+
+- [ ] Implement agent→supervisor replies/escalations on the new runtime flow
+- [ ] Implement broadcast and per-agent rate limiting on top of the mailbox model
+- [ ] Keep auditability intact for sent, delivered, replied, and rate-limited messages
+
+---
+
+### Step 3: Bridge Contact Tools
+**Status:** ⬜ Not Started
+
+- [ ] Add minimal agent-side bridge/contact tools for reply/escalate flows where generic file writes would be brittle
+- [ ] Document how these tools fit with future review and segment-expansion bridge work
+
+---
+
+### Step 4: Testing & Verification
+**Status:** ⬜ Not Started
+
+- [ ] Add or update behavioral tests for registry-backed tool behavior, reply flow, broadcast, and rate limiting
+- [ ] Run the full suite
+- [ ] Fix all failures
+
+---
+
+### Step 5: Documentation & Delivery
+**Status:** ⬜ Not Started
+
+- [ ] Update mailbox and command docs for the new Runtime V2 control model
+- [ ] Log discoveries in STATUS.md
+
+---
+
+## Reviews
+
+| # | Type | Step | Verdict | File |
+|---|------|------|---------|------|
+
+---
+
+## Discoveries
+
+| Discovery | Disposition | Location |
+|-----------|-------------|----------|
+
+---
+
+## Execution Log
+
+| Timestamp | Action | Outcome |
+|-----------|--------|---------|
+| 2026-03-30 | Task staged | PROMPT.md and STATUS.md created |
+
+---
+
+## Blockers
+
+*None*
+
+---
+
+## Notes
+
+*Reserved for execution notes*

--- a/taskplane-tasks/TP-107-dashboard-runtime-v2-conversations-messages-and-agent-panel/PROMPT.md
+++ b/taskplane-tasks/TP-107-dashboard-runtime-v2-conversations-messages-and-agent-panel/PROMPT.md
@@ -1,0 +1,122 @@
+# Task: TP-107 - Dashboard Runtime V2 Conversations, Messages, and Agent Panel
+
+**Created:** 2026-03-30
+**Size:** M
+
+## Review Level: 2 (Plan and Code)
+
+**Assessment:** Dashboard/server/client work on top of the new runtime artifacts. Moderate blast radius across observability surfaces, but conceptually straightforward once registry and normalized events exist.
+**Score:** 4/8 — Blast radius: 1, Pattern novelty: 2, Security: 0, Reversibility: 1
+
+## Canonical Task Folder
+
+```
+taskplane-tasks/TP-107-dashboard-runtime-v2-conversations-messages-and-agent-panel/
+├── PROMPT.md   ← This file (immutable above --- divider)
+├── STATUS.md   ← Execution state (worker updates this)
+├── .reviews/   ← Reviewer output (task-runner creates this)
+└── .DONE       ← Created when complete
+```
+
+## Mission
+
+Migrate the dashboard onto Runtime V2 artifacts so it becomes the authoritative operator surface: normalized conversations, runtime agent panel, and mailbox messages. This task should eliminate TMUX pane capture as the primary visibility source and absorb TP-093 onto the new backend.
+
+## Dependencies
+
+- **Task:** TP-104 (normalized event logs and runtime registry exist)
+- **Task:** TP-105 (lane-runner emits the first Runtime V2 snapshots)
+- **Task:** TP-106 (mailbox replies/broadcast and registry-backed control are available)
+
+## Context to Read First
+
+**Tier 2 (area context):**
+- `taskplane-tasks/CONTEXT.md`
+
+**Tier 3 (load only if needed):**
+- `docs/specifications/framework/taskplane-runtime-v2/04-observability-and-dashboard.md` — target observability model
+- `dashboard/server.cjs` — current dashboard data loader paths that still mix legacy artifacts and TMUX concepts
+- `dashboard/public/app.js` — current conversation and lane rendering code
+- `docs/specifications/taskplane/agent-mailbox-steering.md` — message panel semantics to preserve
+
+## Environment
+
+- **Workspace:** `dashboard/`, `docs/`
+- **Services required:** None
+
+## File Scope
+
+- `dashboard/server.cjs`
+- `dashboard/public/app.js`
+- `dashboard/public/style.css`
+- `dashboard/public/index.html`
+- `docs/explanation/architecture.md`
+- `README.md`
+
+## Steps
+
+### Step 0: Preflight
+
+- [ ] Audit the dashboard's current dependence on lane-state files, worker-conversation logs, and TMUX pane capture
+- [ ] Map each panel to its Runtime V2 source of truth: registry, lane snapshots, normalized agent events, and mailbox state
+
+### Step 1: Runtime V2 Data Loading
+
+- [ ] Add Runtime V2 loaders for registry, per-agent events, and lane snapshots while retaining temporary compatibility shims only where necessary
+- [ ] Define clear precedence when both legacy and Runtime V2 artifacts exist during migration
+
+### Step 2: Conversations, Messages, and Agent Panel
+
+- [ ] Render conversation streams from normalized event logs instead of pane capture
+- [ ] Add/update the mailbox messages panel on top of Runtime V2 mailbox + delivery events
+- [ ] Add an agent/process panel driven by the runtime registry
+
+### Step 3: Testing & Verification
+
+- [ ] Run dashboard/server sanity checks: `node --check dashboard/server.cjs`
+- [ ] Perform manual dashboard verification for conversations, messages, and agent health on a Runtime V2 run
+- [ ] Run the full suite if shared extension/server contracts changed: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
+- [ ] Fix all failures
+
+### Step 4: Documentation & Delivery
+
+- [ ] Update README and architecture docs for the new dashboard model if behavior/user guidance changed
+- [ ] Log discoveries in STATUS.md
+
+## Documentation Requirements
+
+**Must Update:**
+- `docs/specifications/framework/taskplane-runtime-v2/04-observability-and-dashboard.md`
+
+**Check If Affected:**
+- `README.md`
+- `docs/explanation/architecture.md`
+- `docs/tutorials/use-the-dashboard.md`
+
+## Completion Criteria
+
+- [ ] The dashboard shows Runtime V2 conversations and messages without relying on TMUX pane capture
+- [ ] A runtime agent panel exists and is sourced from the registry
+- [ ] Mailbox activity is visible end-to-end on the new backend
+
+## Git Commit Convention
+
+Commits happen at **step boundaries** (not after every checkbox). All commits
+for this task MUST include the task ID for traceability:
+
+- **Step completion:** `feat(TP-107): complete Step N — description`
+- **Bug fixes:** `fix(TP-107): description`
+- **Tests:** `test(TP-107): description`
+- **Hydration:** `hydrate: TP-107 expand Step N checkboxes`
+
+## Do NOT
+
+- Keep pane capture as the primary conversation source
+- Hide legacy/v2 precedence rules in server heuristics without documenting them
+- Ship a messages panel that cannot represent delivered vs replied state correctly
+
+---
+
+## Amendments (Added During Execution)
+
+<!-- Workers add amendments here if issues discovered during execution. -->

--- a/taskplane-tasks/TP-107-dashboard-runtime-v2-conversations-messages-and-agent-panel/STATUS.md
+++ b/taskplane-tasks/TP-107-dashboard-runtime-v2-conversations-messages-and-agent-panel/STATUS.md
@@ -1,0 +1,86 @@
+# TP-107: Dashboard Runtime V2 Conversations, Messages, and Agent Panel — Status
+
+**Current Step:** Not Started
+**Status:** 🔵 Ready for Execution
+**Last Updated:** 2026-03-30
+**Review Level:** 2
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** M
+
+---
+
+### Step 0: Preflight
+**Status:** ⬜ Not Started
+
+- [ ] Audit the dashboard's current dependence on lane-state files, worker-conversation logs, and TMUX pane capture
+- [ ] Map each panel to its Runtime V2 source of truth: registry, lane snapshots, normalized agent events, and mailbox state
+
+---
+
+### Step 1: Runtime V2 Data Loading
+**Status:** ⬜ Not Started
+
+- [ ] Add Runtime V2 loaders for registry, per-agent events, and lane snapshots while retaining temporary compatibility shims only where necessary
+- [ ] Define clear precedence when both legacy and Runtime V2 artifacts exist during migration
+
+---
+
+### Step 2: Conversations, Messages, and Agent Panel
+**Status:** ⬜ Not Started
+
+- [ ] Render conversation streams from normalized event logs instead of pane capture
+- [ ] Add/update the mailbox messages panel on top of Runtime V2 mailbox + delivery events
+- [ ] Add an agent/process panel driven by the runtime registry
+
+---
+
+### Step 3: Testing & Verification
+**Status:** ⬜ Not Started
+
+- [ ] Run dashboard/server sanity checks
+- [ ] Perform manual dashboard verification for conversations, messages, and agent health on a Runtime V2 run
+- [ ] Run the full suite if shared extension/server contracts changed
+- [ ] Fix all failures
+
+---
+
+### Step 4: Documentation & Delivery
+**Status:** ⬜ Not Started
+
+- [ ] Update README and architecture docs for the new dashboard model if behavior/user guidance changed
+- [ ] Log discoveries in STATUS.md
+
+---
+
+## Reviews
+
+| # | Type | Step | Verdict | File |
+|---|------|------|---------|------|
+
+---
+
+## Discoveries
+
+| Discovery | Disposition | Location |
+|-----------|-------------|----------|
+
+---
+
+## Execution Log
+
+| Timestamp | Action | Outcome |
+|-----------|--------|---------|
+| 2026-03-30 | Task staged | PROMPT.md and STATUS.md created |
+
+---
+
+## Blockers
+
+*None*
+
+---
+
+## Notes
+
+*Reserved for execution notes*

--- a/taskplane-tasks/TP-108-batch-and-merge-runtime-v2-migration/PROMPT.md
+++ b/taskplane-tasks/TP-108-batch-and-merge-runtime-v2-migration/PROMPT.md
@@ -1,0 +1,132 @@
+# Task: TP-108 - Batch and Merge Runtime V2 Migration
+
+**Created:** 2026-03-30
+**Size:** L
+
+## Review Level: 3 (Full)
+
+**Assessment:** This is the full-wave orchestration cutover: engine, lane execution, merge hosting, and recovery all stop depending on TMUX-backed infrastructure. Highest-risk runtime task after the foundational extraction.
+**Score:** 7/8 — Blast radius: 3, Pattern novelty: 2, Security: 0, Reversibility: 2
+
+## Canonical Task Folder
+
+```
+taskplane-tasks/TP-108-batch-and-merge-runtime-v2-migration/
+├── PROMPT.md   ← This file (immutable above --- divider)
+├── STATUS.md   ← Execution state (worker updates this)
+├── .reviews/   ← Reviewer output (task-runner creates this)
+└── .DONE       ← Created when complete
+```
+
+## Mission
+
+Migrate full batch execution and merge hosting onto Runtime V2. The engine should launch lane-runners for waves, merge agents should run through the direct agent host, and batch correctness/recovery should no longer depend on TMUX sessions anywhere in the critical path.
+
+## Dependencies
+
+- **Task:** TP-104 (direct agent host and registry exist)
+- **Task:** TP-105 (lane-runner and single-task Runtime V2 path exist)
+
+## Context to Read First
+
+**Tier 2 (area context):**
+- `taskplane-tasks/CONTEXT.md`
+
+**Tier 3 (load only if needed):**
+- `docs/specifications/framework/taskplane-runtime-v2/01-architecture.md` — full target architecture
+- `docs/specifications/framework/taskplane-runtime-v2/02-runtime-process-model.md` — required ownership and cleanup semantics
+- `docs/specifications/framework/taskplane-runtime-v2/06-migration-and-rollout.md` — batch migration and rollout plan
+- `extensions/taskplane/engine.ts` — current wave execution control flow
+- `extensions/taskplane/merge.ts` — current merge host path still built around TMUX
+
+## Environment
+
+- **Workspace:** `extensions/taskplane/`, `bin/`
+- **Services required:** None
+
+## File Scope
+
+- `extensions/taskplane/engine.ts`
+- `extensions/taskplane/execution.ts`
+- `extensions/taskplane/merge.ts`
+- `extensions/taskplane/extension.ts`
+- `extensions/taskplane/sessions.ts`
+- `extensions/taskplane/cleanup.ts`
+- `extensions/tests/*merge*`
+- `extensions/tests/*resume*`
+
+## Steps
+
+### Step 0: Preflight
+
+- [ ] Trace current wave execution, lane provisioning, merge hosting, and cleanup/recovery logic from the perspective of TMUX dependency
+- [ ] Define exactly which runtime responsibilities shift to engine, lane-runner, and agent-host in the batch path
+
+### Step 1: Lane-Runner Batch Integration
+
+- [ ] Update engine/execution flow to launch lane-runners for batch waves
+- [ ] Replace lane-session/TMUX liveness assumptions with registry-backed lifecycle handling
+- [ ] Preserve worktree and orch-branch semantics during the cutover
+
+### Step 2: Merge Host Migration
+
+- [ ] Move merge agent execution onto the direct agent host/backend
+- [ ] Preserve structured merge telemetry, verification behavior, and failure classification on the new path
+- [ ] Ensure merge recovery and pause behavior still works without TMUX
+
+### Step 3: Recovery, Cleanup, and Tooling
+
+- [ ] Replace TMUX-centric active-session discovery and orphan cleanup with registry/process-based behavior
+- [ ] Keep pause/resume/abort semantics recoverable under the new ownership model
+- [ ] Review operator tooling affected by the backend cutover
+
+### Step 4: Testing & Verification
+
+- [ ] Add or update behavioral tests for full-wave Runtime V2 execution and merge lifecycle
+- [ ] Run the full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
+- [ ] Run CLI smoke checks: `node bin/taskplane.mjs help && node bin/taskplane.mjs doctor`
+- [ ] Fix all failures
+
+### Step 5: Documentation & Delivery
+
+- [ ] Update rollout docs, architecture docs, and any operator guidance changed by the batch cutover
+- [ ] Log discoveries in STATUS.md
+
+## Documentation Requirements
+
+**Must Update:**
+- `docs/specifications/framework/taskplane-runtime-v2/06-migration-and-rollout.md`
+- `docs/explanation/architecture.md`
+
+**Check If Affected:**
+- `README.md`
+- `docs/reference/commands.md`
+- `docs/explanation/persistence-and-resume.md`
+
+## Completion Criteria
+
+- [ ] Full batch execution runs on Runtime V2 without TMUX in the correctness path
+- [ ] Merge hosting and recovery also use the Runtime V2 backend
+- [ ] Registry/process-owned cleanup replaces TMUX-based batch liveness assumptions
+
+## Git Commit Convention
+
+Commits happen at **step boundaries** (not after every checkbox). All commits
+for this task MUST include the task ID for traceability:
+
+- **Step completion:** `feat(TP-108): complete Step N — description`
+- **Bug fixes:** `fix(TP-108): description`
+- **Tests:** `test(TP-108): description`
+- **Hydration:** `hydrate: TP-108 expand Step N checkboxes`
+
+## Do NOT
+
+- Leave merge execution on TMUX while claiming the batch backend is migrated
+- Break orch-branch/worktree invariants during the runtime cutover
+- Ship the cutover without full-suite validation
+
+---
+
+## Amendments (Added During Execution)
+
+<!-- Workers add amendments here if issues discovered during execution. -->

--- a/taskplane-tasks/TP-108-batch-and-merge-runtime-v2-migration/STATUS.md
+++ b/taskplane-tasks/TP-108-batch-and-merge-runtime-v2-migration/STATUS.md
@@ -1,0 +1,96 @@
+# TP-108: Batch and Merge Runtime V2 Migration — Status
+
+**Current Step:** Not Started
+**Status:** 🔵 Ready for Execution
+**Last Updated:** 2026-03-30
+**Review Level:** 3
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** L
+
+---
+
+### Step 0: Preflight
+**Status:** ⬜ Not Started
+
+- [ ] Trace current wave execution, lane provisioning, merge hosting, and cleanup/recovery logic from the perspective of TMUX dependency
+- [ ] Define exactly which runtime responsibilities shift to engine, lane-runner, and agent-host in the batch path
+
+---
+
+### Step 1: Lane-Runner Batch Integration
+**Status:** ⬜ Not Started
+
+- [ ] Update engine/execution flow to launch lane-runners for batch waves
+- [ ] Replace lane-session/TMUX liveness assumptions with registry-backed lifecycle handling
+- [ ] Preserve worktree and orch-branch semantics during the cutover
+
+---
+
+### Step 2: Merge Host Migration
+**Status:** ⬜ Not Started
+
+- [ ] Move merge agent execution onto the direct agent host/backend
+- [ ] Preserve structured merge telemetry, verification behavior, and failure classification on the new path
+- [ ] Ensure merge recovery and pause behavior still works without TMUX
+
+---
+
+### Step 3: Recovery, Cleanup, and Tooling
+**Status:** ⬜ Not Started
+
+- [ ] Replace TMUX-centric active-session discovery and orphan cleanup with registry/process-based behavior
+- [ ] Keep pause/resume/abort semantics recoverable under the new ownership model
+- [ ] Review operator tooling affected by the backend cutover
+
+---
+
+### Step 4: Testing & Verification
+**Status:** ⬜ Not Started
+
+- [ ] Add or update behavioral tests for full-wave Runtime V2 execution and merge lifecycle
+- [ ] Run the full suite
+- [ ] Run CLI smoke checks
+- [ ] Fix all failures
+
+---
+
+### Step 5: Documentation & Delivery
+**Status:** ⬜ Not Started
+
+- [ ] Update rollout docs, architecture docs, and any operator guidance changed by the batch cutover
+- [ ] Log discoveries in STATUS.md
+
+---
+
+## Reviews
+
+| # | Type | Step | Verdict | File |
+|---|------|------|---------|------|
+
+---
+
+## Discoveries
+
+| Discovery | Disposition | Location |
+|-----------|-------------|----------|
+
+---
+
+## Execution Log
+
+| Timestamp | Action | Outcome |
+|-----------|--------|---------|
+| 2026-03-30 | Task staged | PROMPT.md and STATUS.md created |
+
+---
+
+## Blockers
+
+*None*
+
+---
+
+## Notes
+
+*Reserved for execution notes*

--- a/taskplane-tasks/TP-109-workspace-packet-home-and-resume-on-runtime-v2/PROMPT.md
+++ b/taskplane-tasks/TP-109-workspace-packet-home-and-resume-on-runtime-v2/PROMPT.md
@@ -1,0 +1,124 @@
+# Task: TP-109 - Workspace Packet-Home and Resume on Runtime V2
+
+**Created:** 2026-03-30
+**Size:** L
+
+## Review Level: 3 (Full)
+
+**Assessment:** This completes the critical workspace-mode correctness story for Runtime V2. High blast radius across engine, resume, and packet-home path handling, but it directly resolves a core polyrepo model gap.
+**Score:** 7/8 — Blast radius: 2, Pattern novelty: 2, Security: 1, Reversibility: 2
+
+## Canonical Task Folder
+
+```
+taskplane-tasks/TP-109-workspace-packet-home-and-resume-on-runtime-v2/
+├── PROMPT.md   ← This file (immutable above --- divider)
+├── STATUS.md   ← Execution state (worker updates this)
+├── .reviews/   ← Reviewer output (task-runner creates this)
+└── .DONE       ← Created when complete
+```
+
+## Mission
+
+Thread authoritative packet-home paths through Runtime V2 end-to-end and make workspace-mode resume/reconciliation trustworthy on the new backend. This task should absorb the practical packet-path work from TP-082 / TP-088 into the now-real Runtime V2 execution path.
+
+## Dependencies
+
+- **Task:** TP-102 (packet-path and ExecutionUnit contracts exist)
+- **Task:** TP-105 (lane-runner Runtime V2 path exists)
+- **Task:** TP-108 (batch and merge Runtime V2 migration is in place)
+
+## Context to Read First
+
+**Tier 2 (area context):**
+- `taskplane-tasks/CONTEXT.md`
+
+**Tier 3 (load only if needed):**
+- `docs/specifications/framework/taskplane-runtime-v2/05-polyrepo-and-segment-compatibility.md` — Runtime V2 packet-home requirements
+- `docs/specifications/taskplane/multi-repo-task-execution.md` — existing packet-home and workspace semantics to preserve
+- `extensions/taskplane/resume.ts` — current reconciliation logic that must become packet-path authoritative
+- `extensions/tests/polyrepo-regression.test.ts` — existing workspace-mode regression coverage to extend
+
+## Environment
+
+- **Workspace:** `extensions/taskplane/`, `docs/`
+- **Services required:** None
+
+## File Scope
+
+- `extensions/taskplane/engine.ts`
+- `extensions/taskplane/execution.ts`
+- `extensions/taskplane/lane-runner.ts`
+- `extensions/taskplane/resume.ts`
+- `extensions/taskplane/merge.ts`
+- `extensions/tests/polyrepo-regression.test.ts`
+- `extensions/tests/orch-state-persistence.test.ts`
+
+## Steps
+
+### Step 0: Preflight
+
+- [ ] Trace every Runtime V2 completion, artifact, and reconciliation path that reads or writes packet files
+- [ ] Identify every place remaining `cwd`-derived assumptions could still corrupt packet-home authority in workspace mode
+
+### Step 1: Packet-Home Threading in Runtime V2 Execution
+
+- [ ] Ensure Runtime V2 engine, lane-runner, and merge flows receive and use authoritative packet paths consistently
+- [ ] Make `.DONE`, `STATUS.md`, and `.reviews/` checks fully packet-path authoritative when explicit paths exist
+- [ ] Preserve single-repo backward behavior when packet paths are local
+
+### Step 2: Resume and Reconciliation
+
+- [ ] Make resume/reconciliation use authoritative packet paths end-to-end on the Runtime V2 backend
+- [ ] Verify archive-path and completion fallback behavior remains correct for packet-home repos
+- [ ] Preserve deterministic batch-state reconstruction under interruption
+
+### Step 3: Testing & Verification
+
+- [ ] Add or extend workspace/polyrepo behavioral tests covering packet-home execution and resume on Runtime V2
+- [ ] Run the full suite: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
+- [ ] Fix all failures
+
+### Step 4: Documentation & Delivery
+
+- [ ] Update Runtime V2 and multi-repo docs if implementation details or names differ from plan
+- [ ] Log discoveries in STATUS.md
+
+## Documentation Requirements
+
+**Must Update:**
+- `docs/specifications/framework/taskplane-runtime-v2/05-polyrepo-and-segment-compatibility.md`
+- `docs/specifications/taskplane/multi-repo-task-execution.md`
+
+**Check If Affected:**
+- `docs/explanation/persistence-and-resume.md`
+- `docs/explanation/execution-model.md`
+- `README.md`
+
+## Completion Criteria
+
+- [ ] Runtime V2 treats packet-home paths as authoritative in workspace mode
+- [ ] Resume/reconciliation is packet-path-correct on the new backend
+- [ ] Polyrepo regression coverage exercises the new Runtime V2 path
+
+## Git Commit Convention
+
+Commits happen at **step boundaries** (not after every checkbox). All commits
+for this task MUST include the task ID for traceability:
+
+- **Step completion:** `feat(TP-109): complete Step N — description`
+- **Bug fixes:** `fix(TP-109): description`
+- **Tests:** `test(TP-109): description`
+- **Hydration:** `hydrate: TP-109 expand Step N checkboxes`
+
+## Do NOT
+
+- Fall back silently to `cwd`-derived packet authority when explicit packet paths are present
+- Mark workspace mode solved without resume/reconciliation proof
+- Re-open split-brain packet handling during migration
+
+---
+
+## Amendments (Added During Execution)
+
+<!-- Workers add amendments here if issues discovered during execution. -->

--- a/taskplane-tasks/TP-109-workspace-packet-home-and-resume-on-runtime-v2/STATUS.md
+++ b/taskplane-tasks/TP-109-workspace-packet-home-and-resume-on-runtime-v2/STATUS.md
@@ -1,0 +1,86 @@
+# TP-109: Workspace Packet-Home and Resume on Runtime V2 — Status
+
+**Current Step:** Not Started
+**Status:** 🔵 Ready for Execution
+**Last Updated:** 2026-03-30
+**Review Level:** 3
+**Review Counter:** 0
+**Iteration:** 0
+**Size:** L
+
+---
+
+### Step 0: Preflight
+**Status:** ⬜ Not Started
+
+- [ ] Trace every Runtime V2 completion, artifact, and reconciliation path that reads or writes packet files
+- [ ] Identify every place remaining `cwd`-derived assumptions could still corrupt packet-home authority in workspace mode
+
+---
+
+### Step 1: Packet-Home Threading in Runtime V2 Execution
+**Status:** ⬜ Not Started
+
+- [ ] Ensure Runtime V2 engine, lane-runner, and merge flows receive and use authoritative packet paths consistently
+- [ ] Make `.DONE`, `STATUS.md`, and `.reviews/` checks fully packet-path authoritative when explicit paths exist
+- [ ] Preserve single-repo backward behavior when packet paths are local
+
+---
+
+### Step 2: Resume and Reconciliation
+**Status:** ⬜ Not Started
+
+- [ ] Make resume/reconciliation use authoritative packet paths end-to-end on the Runtime V2 backend
+- [ ] Verify archive-path and completion fallback behavior remains correct for packet-home repos
+- [ ] Preserve deterministic batch-state reconstruction under interruption
+
+---
+
+### Step 3: Testing & Verification
+**Status:** ⬜ Not Started
+
+- [ ] Add or extend workspace/polyrepo behavioral tests covering packet-home execution and resume on Runtime V2
+- [ ] Run the full suite
+- [ ] Fix all failures
+
+---
+
+### Step 4: Documentation & Delivery
+**Status:** ⬜ Not Started
+
+- [ ] Update Runtime V2 and multi-repo docs if implementation details or names differ from plan
+- [ ] Log discoveries in STATUS.md
+
+---
+
+## Reviews
+
+| # | Type | Step | Verdict | File |
+|---|------|------|---------|------|
+
+---
+
+## Discoveries
+
+| Discovery | Disposition | Location |
+|-----------|-------------|----------|
+
+---
+
+## Execution Log
+
+| Timestamp | Action | Outcome |
+|-----------|--------|---------|
+| 2026-03-30 | Task staged | PROMPT.md and STATUS.md created |
+
+---
+
+## Blockers
+
+*None*
+
+---
+
+## Notes
+
+*Reserved for execution notes*

--- a/taskplane-tasks/TP-110-runtime-v2-assumption-lab/.DONE
+++ b/taskplane-tasks/TP-110-runtime-v2-assumption-lab/.DONE
@@ -1,0 +1,2 @@
+Completed: 2026-03-30T00:00:00Z
+Task: TP-110

--- a/taskplane-tasks/TP-110-runtime-v2-assumption-lab/PROMPT.md
+++ b/taskplane-tasks/TP-110-runtime-v2-assumption-lab/PROMPT.md
@@ -1,0 +1,120 @@
+# Task: TP-110 - Runtime V2 Assumption Lab
+
+**Created:** 2026-03-30
+**Size:** M
+
+## Review Level: 1 (Plan Only)
+
+**Assessment:** Focused validation harness and report work outside the main runtime path. Moderate blast radius because it may add scripts and docs, but it is intentionally isolated from production behavior.
+**Score:** 3/8 — Blast radius: 1, Pattern novelty: 1, Security: 0, Reversibility: 1
+
+## Canonical Task Folder
+
+```
+taskplane-tasks/TP-110-runtime-v2-assumption-lab/
+├── PROMPT.md   ← This file (immutable above --- divider)
+├── STATUS.md   ← Execution state (worker updates this)
+├── .reviews/   ← Reviewer output (task-runner creates this)
+└── .DONE       ← Created when complete
+```
+
+## Mission
+
+Validate the highest-risk Runtime V2 architectural assumptions outside the current TMUX- and `/task`-based production path before the main refactor begins. Build a small standalone lab harness, run the most important direct-spawn / RPC / mailbox / packet-path experiments, and record the results in a durable project file that future sessions can review.
+
+## Dependencies
+
+- **Task:** TP-100 (Runtime V2 planning suite and roadmap exist)
+
+## Context to Read First
+
+**Tier 2 (area context):**
+- `taskplane-tasks/CONTEXT.md`
+
+**Tier 3 (load only if needed):**
+- `docs/specifications/framework/taskplane-runtime-v2/01-architecture.md` — target Runtime V2 assumptions to validate
+- `docs/specifications/framework/taskplane-runtime-v2/02-runtime-process-model.md` — direct-host and registry assumptions
+- `docs/specifications/framework/taskplane-runtime-v2/03-bridge-and-mailbox.md` — mailbox and bridge assumptions
+- `docs/specifications/taskplane/spawn-telemetry-stability.md` — incident history motivating the lab
+- `bin/rpc-wrapper.mjs` — current RPC transport reference
+
+## Environment
+
+- **Workspace:** `scripts/`, `docs/specifications/framework/taskplane-runtime-v2/`, `taskplane-tasks/`
+- **Services required:** Local `pi` CLI must be available on PATH
+
+## File Scope
+
+- `scripts/runtime-v2-lab/*`
+- `docs/specifications/framework/taskplane-runtime-v2/assumption-lab-report.md`
+- `taskplane-tasks/TP-110-runtime-v2-assumption-lab/*`
+
+## Steps
+
+### Step 0: Preflight
+
+- [ ] Confirm the local environment can invoke `pi` directly
+- [ ] Define the minimum viable assumption matrix and success criteria before writing the harness
+
+### Step 1: Build the Lab Harness
+
+- [ ] Create standalone scripts under `scripts/runtime-v2-lab/` for direct child spawn, RPC event capture, and mailbox injection experiments
+- [ ] Keep the harness independent from TMUX and the current `/task` production path
+- [ ] Make the harness cheap to run repeatedly with tiny prompts and bounded iterations
+
+### Step 2: Run Core Assumption Experiments
+
+- [ ] Run direct-spawn reliability experiments (sequential and limited parallel)
+- [ ] Run direct-host RPC event/usage capture experiments
+- [ ] Run mailbox steering experiments without TMUX
+- [ ] Run at least one explicit packet-path / `cwd != packet home` experiment
+- [ ] If feasible within the harness, run one minimal bridge-style request/response experiment
+
+### Step 3: Analyze and Document Results
+
+- [ ] Write a durable report summarizing environment, experiment design, results, and interpretation
+- [ ] Record which Runtime V2 assumptions are validated, partially validated, or still open
+- [ ] Record recommended adjustments to the implementation roadmap before TP-102+ proceeds
+
+### Step 4: Verification & Delivery
+
+- [ ] Re-run the harness after any fixes to confirm the final conclusions
+- [ ] Ensure the report references concrete script paths and captured evidence
+- [ ] Log discoveries in STATUS.md and mark the task complete
+
+## Documentation Requirements
+
+**Must Update:**
+- `docs/specifications/framework/taskplane-runtime-v2/assumption-lab-report.md`
+
+**Check If Affected:**
+- `docs/specifications/framework/taskplane-runtime-v2/06-migration-and-rollout.md`
+- `docs/specifications/framework/taskplane-runtime-v2/07-task-crosswalk-and-roadmap.md`
+
+## Completion Criteria
+
+- [ ] A standalone Runtime V2 assumption harness exists in the repo
+- [ ] The highest-risk architectural assumptions have been tested with concrete evidence
+- [ ] A durable report exists that future sessions can review before refactor work continues
+
+## Git Commit Convention
+
+Commits happen at **step boundaries** (not after every checkbox). All commits
+for this task MUST include the task ID for traceability:
+
+- **Step completion:** `feat(TP-110): complete Step N — description`
+- **Bug fixes:** `fix(TP-110): description`
+- **Tests:** `test(TP-110): description`
+- **Hydration:** `hydrate: TP-110 expand Step N checkboxes`
+
+## Do NOT
+
+- Depend on TMUX for any experiment in this task
+- Rewrite production orchestrator code before the assumptions are validated
+- Leave the conclusions only in conversation; they must be captured in a project file
+
+---
+
+## Amendments (Added During Execution)
+
+<!-- Workers add amendments here if issues discovered during execution. -->

--- a/taskplane-tasks/TP-110-runtime-v2-assumption-lab/STATUS.md
+++ b/taskplane-tasks/TP-110-runtime-v2-assumption-lab/STATUS.md
@@ -1,0 +1,99 @@
+# TP-110: Runtime V2 Assumption Lab — Status
+
+**Current Step:** Complete
+**Status:** ✅ Complete
+**Last Updated:** 2026-03-30
+**Review Level:** 1
+**Review Counter:** 0
+**Iteration:** 1
+**Size:** M
+
+---
+
+### Step 0: Preflight
+**Status:** ✅ Complete
+
+- [x] Confirm the local environment can invoke `pi` directly
+- [x] Define the minimum viable assumption matrix and success criteria before writing the harness
+
+---
+
+### Step 1: Build the Lab Harness
+**Status:** ✅ Complete
+
+- [x] Create standalone scripts under `scripts/runtime-v2-lab/` for direct child spawn, RPC event capture, and mailbox injection experiments
+- [x] Keep the harness independent from TMUX and the current `/task` production path
+- [x] Make the harness cheap to run repeatedly with tiny prompts and bounded iterations
+
+---
+
+### Step 2: Run Core Assumption Experiments
+**Status:** ✅ Complete
+
+- [x] Run direct-spawn reliability experiments (sequential and limited parallel)
+- [x] Run direct-host RPC event/usage capture experiments
+- [x] Run mailbox steering experiments without TMUX
+- [x] Run at least one explicit packet-path / `cwd != packet home` experiment
+- [x] If feasible within the harness, run one minimal bridge-style request/response experiment
+
+---
+
+### Step 3: Analyze and Document Results
+**Status:** ✅ Complete
+
+- [x] Write a durable report summarizing environment, experiment design, results, and interpretation
+- [x] Record which Runtime V2 assumptions are validated, partially validated, or still open
+- [x] Record recommended adjustments to the implementation roadmap before TP-102+ proceeds
+
+---
+
+### Step 4: Verification & Delivery
+**Status:** ✅ Complete
+
+- [x] Re-run the harness after any fixes to confirm the final conclusions
+- [x] Ensure the report references concrete script paths and captured evidence
+- [x] Log discoveries in STATUS.md and mark the task complete
+
+---
+
+## Reviews
+
+| # | Type | Step | Verdict | File |
+|---|------|------|---------|------|
+
+---
+
+## Discoveries
+
+| Discovery | Disposition | Location |
+|-----------|-------------|----------|
+| Direct child Pi RPC hosting is viable without TMUX for simple prompts and small parallelism on this Windows machine | Validated in harness; proceed with TP-102/103/104 | scripts/runtime-v2-lab/out/latest-summary.json |
+| Mailbox steering works without TMUX when injected via RPC `steer` at message boundaries | Validated in harness; keep mailbox-first control model | docs/specifications/framework/taskplane-runtime-v2/assumption-lab-report.md |
+| Packet-home path handling is still open in a reproducible harness run | Keep packet-path contracts early, but require dedicated proof during Runtime V2 execution work | docs/specifications/framework/taskplane-runtime-v2/assumption-lab-report.md |
+| Bridge-style callback semantics remain open and need explicit proof work | Carry forward into TP-105/TP-106 instead of assuming solved | docs/specifications/framework/taskplane-runtime-v2/assumption-lab-report.md |
+
+---
+
+## Execution Log
+
+| Timestamp | Action | Outcome |
+|-----------|--------|---------|
+| 2026-03-30 | Task staged | PROMPT.md and STATUS.md created |
+| 2026-03-30 | Task started | Preflight and lab setup initiated |
+| 2026-03-30 | Harness built | Added standalone scripts under `scripts/runtime-v2-lab/` |
+| 2026-03-30 | Assumption experiments run | Direct host, telemetry, mailbox, packet-path, and bridge feasibility probes executed |
+| 2026-03-30 | Report written | Results captured in `docs/specifications/framework/taskplane-runtime-v2/assumption-lab-report.md` |
+| 2026-03-30 | Task complete | Final harness rerun and conclusions recorded |
+
+---
+
+## Blockers
+
+*None*
+
+---
+
+## Notes
+
+*Session-attached but resumable is the baseline assumption for Runtime V2 in this lab.*
+*The lab justified proceeding with TP-102/103/104, while leaving packet-path reproducibility and bridge callbacks as explicit open risks.*


### PR DESCRIPTION
## Summary

Foundational Runtime V2 planning work. No production code changes — entirely docs, task packets, and a standalone validation harness.

## What's in this PR

### Architecture planning suite
`docs/specifications/framework/taskplane-runtime-v2/`

The full no-TMUX / no-`/task` redesign specification:
- **01** — target architecture and core invariants
- **02** — process ownership, stable agent IDs, `/task` deprecation path
- **03** — mailbox-first control plane and bridge protocols
- **04** — normalized event model, visibility without TMUX
- **05** — packet-home authority and polyrepo compatibility
- **06** — phased migration plan (now includes Phase 0 assumption lab gate)
- **07** — TP-082..TP-093 crosswalk and recommended build order
- **08** — concrete implementation work packages
- **assumption-lab-report** — TP-110 lab results

### Implementation task backlog (TP-100..TP-110)
Staged under `taskplane-tasks/` — 10 new task packets covering the full Runtime V2 program:
- **TP-100** ✅ planning suite (complete)
- **TP-101** skill refresh for Runtime V2
- **TP-102** ExecutionUnit and packet-path contracts
- **TP-103** extract task-executor-core from task-runner
- **TP-104** direct agent host, process registry, normalized events
- **TP-105** headless lane runner + single-task /orch Runtime V2
- **TP-106** mailbox replies, broadcast, registry-backed supervisor control
- **TP-107** dashboard Runtime V2 observability
- **TP-108** batch and merge Runtime V2 migration
- **TP-109** workspace packet-home and resume on Runtime V2
- **TP-110** ✅ assumption lab (complete)

### Assumption lab harness
`scripts/runtime-v2-lab/`
- Standalone no-TMUX direct-child host validation scripts
- Captured results in `out/latest-summary.json`

### Lab results summary
| Assumption | Result |
|---|---|
| Direct child spawn without TMUX | ✅ 5/5 sequential, 3/3 parallel |
| RPC telemetry + contextUsage capture | ✅ Validated |
| Mailbox steering without TMUX | ✅ Validated |
| Packet-home / cwd != packet home | ⚠️ Open (ad hoc success, harness timed out) |
| Bridge callbacks | ⚠️ Open |

### Other
- `taskplane-tasks/CONTEXT.md` — Next Task ID updated to TP-111, Runtime V2 program note added
- `docs/specifications/README.md` — new suite indexed
- `docs/specifications/taskplane/spawn-telemetry-stability.md` — linked to follow-on suite

## No runtime code touched
All changes are docs, task packets, and a standalone test harness that doesn't import from `extensions/taskplane/*`.