### PR TITLE
fix(TP-102/103/104): remediate cross-model code review findings

### DIFF
--- a/docs/specifications/framework/taskplane-runtime-v2/02-runtime-process-model.md
+++ b/docs/specifications/framework/taskplane-runtime-v2/02-runtime-process-model.md
@@ -1,6 +1,6 @@
 # Runtime Process Model
 
-**Status:** Proposed  
+**Status:** Proposed (updated 2026-03-30 with implementation findings from TP-102/103/104)  
 **Related:** [01-architecture.md](01-architecture.md)
 
 ## 1. Purpose
@@ -349,7 +349,39 @@ Required rules:
 4. avoid shell quoting as a primary correctness mechanism
 5. use process-registry-based cleanup instead of server/session cleanup
 
-## 13. Acceptance criteria
+## 13. Implementation notes (from TP-102/103/104)
+
+### Executor-core extraction scope
+
+TP-103 extracted 15 pure helper functions (parsing, status mutation, review
+request generation, verdict extraction, git helpers) into
+`extensions/taskplane/task-executor-core.ts`. The execution state machine
+functions (`executeTask`, `runWorker`, `doReview`) remain in `task-runner.ts`
+because they depend on Pi's `ExtensionContext` for spawn modes and UI callbacks.
+TP-105 (lane-runner) will consume the core module directly and provide its own
+execution state machine without the extension host coupling.
+
+### Registry lifecycle wiring
+
+The process registry (`extensions/taskplane/process-registry.ts`) is wired into
+`agent-host.ts` `spawnAgent()`: manifests are written before the agent is
+considered visible, and updated to terminal status on exit/crash/timeout/kill.
+Callers opt in to registry integration by providing `stateRoot` in
+`AgentHostOptions`.
+
+### Timeout vs killed distinction
+
+`agent-host.ts` tracks a separate `timedOut` flag. The exit event type is
+`agent_timeout` for timeouts and `agent_killed` for explicit kills. The registry
+manifest status maps to `timed_out` vs `killed` accordingly.
+
+### Extension loading safety
+
+`agent-host.ts` always passes `--no-extensions` to prevent auto-discovery from
+cwd, even when explicit `-e` entries are provided. This matches the fix from
+TP-095 that eliminated duplicate extension loading in the legacy TMUX path.
+
+## 14. Acceptance criteria
 
 This process model is accepted when:
 

--- a/docs/specifications/framework/taskplane-runtime-v2/04-observability-and-dashboard.md
+++ b/docs/specifications/framework/taskplane-runtime-v2/04-observability-and-dashboard.md
@@ -1,6 +1,6 @@
 # Observability and Dashboard Model
 
-**Status:** Proposed  
+**Status:** Proposed (updated 2026-03-30 with implementation findings from TP-104)  
 **Related:** [01-architecture.md](01-architecture.md), [03-bridge-and-mailbox.md](03-bridge-and-mailbox.md)
 
 ## 1. Goal
@@ -317,7 +317,22 @@ Required controls:
 - per-panel truncation and pagination where needed
 - log rotation/archival policies for runtime event files
 
-## 13. Success criteria
+## 13. Implementation notes (from TP-104)
+
+### Event envelope attribution
+
+`AgentHostOptions` carries `batchId`, `laneNumber`, `taskId`, and `repoId`.
+All normalized `RuntimeAgentEvent` instances emitted by the agent-host include
+these attribution fields from the caller-provided options — no empty-string
+placeholders.
+
+### Timeout event type
+
+Timeout exits emit `agent_timeout` (not `agent_killed`). The distinction
+is preserved in both the event stream and the registry manifest status
+(`timed_out` vs `killed`).
+
+## 14. Success criteria
 
 This observability model is accepted when:
 

--- a/docs/specifications/framework/taskplane-runtime-v2/05-polyrepo-and-segment-compatibility.md
+++ b/docs/specifications/framework/taskplane-runtime-v2/05-polyrepo-and-segment-compatibility.md
@@ -1,6 +1,6 @@
 # Polyrepo and Segment Compatibility
 
-**Status:** Proposed  
+**Status:** Proposed (updated 2026-03-30 with implementation findings from TP-102)  
 **Related:** [01-architecture.md](01-architecture.md), `docs/specifications/taskplane/multi-repo-task-execution.md`
 
 ## 1. Purpose
@@ -222,7 +222,21 @@ acceptance conditions:
 | TP-087 | should persist graph revisions alongside runtime execution-unit state |
 | TP-088 | becomes mandatory for all engine/resume paths in Runtime V2 |
 
-## 14. Recommendation
+## 14. Implementation notes (from TP-102)
+
+### Cross-repo packet path status
+
+In workspace mode when the task packet home repo differs from the execution repo,
+the legacy path copies packet files into the worktree under `.taskplane-tasks/`.
+`buildExecutionUnit()` wraps this faithfully — the `packet` paths point to the
+execution-local copy, while `packetHomeRepoId` reflects the true home repo.
+
+This means `packetHomeRepoId` may not match the filesystem root of
+`packet.taskFolder` in cross-repo scenarios. TP-109 will tighten this so
+authoritative packet-home paths are always available separately from any
+execution-local copies.
+
+## 15. Recommendation
 
 Do **not** postpone packet-path authority until after the no-TMUX runtime lands.
 

--- a/extensions/taskplane/agent-host.ts
+++ b/extensions/taskplane/agent-host.ts
@@ -38,6 +38,12 @@ import type {
 	PacketPaths,
 } from "./types.ts";
 
+import {
+	createManifest,
+	writeManifest,
+	updateManifestStatus,
+} from "./process-registry.ts";
+
 // ── Pi CLI Resolution ────────────────────────────────────────────────
 
 /**
@@ -102,6 +108,14 @@ export interface AgentHostOptions {
 	agentId: RuntimeAgentId;
 	/** Agent role */
 	role: RuntimeAgentRole;
+	/** Batch ID this agent belongs to */
+	batchId: string;
+	/** Lane number (null for merge agents) */
+	laneNumber: number | null;
+	/** Task ID being executed (null before first assignment) */
+	taskId: string | null;
+	/** Repo ID the agent is operating in */
+	repoId: string;
 	/** Working directory for the Pi process */
 	cwd: string;
 	/** User prompt content */
@@ -128,6 +142,10 @@ export interface AgentHostOptions {
 	timeoutMs?: number;
 	/** Delay in ms before closing stdin after agent_end (default: 100) */
 	closeDelayMs?: number;
+	/** State root for process registry (null = no registry integration) */
+	stateRoot?: string | null;
+	/** Packet paths for registry manifest (null for merge agents) */
+	packet?: PacketPaths | null;
 }
 
 /**
@@ -233,12 +251,14 @@ export function spawnAgent(
 	if (opts.model) piArgs.push("--model", opts.model);
 	if (opts.tools) piArgs.push("--tools", opts.tools);
 	if (opts.systemPrompt) piArgs.push("--system-prompt", opts.systemPrompt);
+	// Always pass --no-extensions to prevent auto-discovery from cwd.
+	// Explicit -e entries are still honored by pi even with --no-extensions.
+	// This matches the fix from TP-095 that eliminated duplicate extension loading.
+	piArgs.push("--no-extensions");
 	if (opts.extensions && opts.extensions.length > 0) {
 		for (const ext of opts.extensions) {
 			piArgs.push("-e", ext);
 		}
-	} else {
-		piArgs.push("--no-extensions");
 	}
 	piArgs.push("--no-skills");
 	if (opts.thinking) piArgs.push("--thinking", opts.thinking);
@@ -254,6 +274,7 @@ export function spawnAgent(
 	// State accumulator
 	const startedAt = Date.now();
 	let killed = false;
+	let timedOut = false;
 	let agentEnded = false;
 	let stdinClosed = false;
 	let statsRequested = false;
@@ -268,9 +289,28 @@ export function spawnAgent(
 	let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
 	if (timeoutMs > 0) {
 		timeoutHandle = setTimeout(() => {
+			timedOut = true;
 			killed = true;
 			try { proc.kill("SIGTERM"); } catch { /* ignore */ }
 		}, timeoutMs);
+	}
+
+	// Registry integration: write manifest before process is considered visible
+	if (opts.stateRoot) {
+		const manifest = createManifest({
+			batchId: opts.batchId,
+			agentId: opts.agentId,
+			role: opts.role,
+			laneNumber: opts.laneNumber,
+			taskId: opts.taskId,
+			repoId: opts.repoId,
+			pid: proc.pid ?? 0,
+			parentPid: process.pid,
+			cwd: opts.cwd,
+			packet: opts.packet ?? null,
+		});
+		manifest.status = "running";
+		writeManifest(opts.stateRoot, manifest);
 	}
 
 	// Helper: close stdin safely with delay
@@ -289,12 +329,12 @@ export function spawnAgent(
 	// Helper: emit normalized event
 	function emitEvent(type: RuntimeAgentEventType, payload: Record<string, unknown> = {}) {
 		const event: RuntimeAgentEvent = {
-			batchId: "",  // caller enriches via onEvent
+			batchId: opts.batchId,
 			agentId: opts.agentId,
 			role: opts.role,
-			laneNumber: null,
-			taskId: null,
-			repoId: "",
+			laneNumber: opts.laneNumber,
+			taskId: opts.taskId,
+			repoId: opts.repoId,
 			ts: Date.now(),
 			type,
 			payload,
@@ -404,9 +444,22 @@ export function spawnAgent(
 				} catch { /* best effort */ }
 			}
 
-			emitEvent(killed ? "agent_killed" : (exitCode === 0 && agentEnded ? "agent_exited" : "agent_crashed"), {
-				exitCode, signal, durationMs: result.durationMs,
-			});
+			const exitEventType: RuntimeAgentEventType =
+				timedOut ? "agent_timeout" :
+				killed ? "agent_killed" :
+				(exitCode === 0 && agentEnded) ? "agent_exited" :
+				"agent_crashed";
+			emitEvent(exitEventType, { exitCode, signal, durationMs: result.durationMs, timedOut });
+
+			// Registry integration: update manifest to terminal status
+			if (opts.stateRoot) {
+				const terminalStatus =
+					timedOut ? "timed_out" as const :
+					killed ? "killed" as const :
+					(exitCode === 0 && agentEnded) ? "exited" as const :
+					"crashed" as const;
+				updateManifestStatus(opts.stateRoot, opts.batchId, opts.agentId, terminalStatus);
+			}
 
 			resolvePromise(result);
 		}

--- a/extensions/taskplane/execution.ts
+++ b/extensions/taskplane/execution.ts
@@ -2694,6 +2694,15 @@ export async function executeWithStopAll(
  * archive fallback). This preserves current behavior while surfacing
  * it through the Runtime V2 contract.
  *
+ * **Cross-repo note (TP-109 follow-up):** In workspace mode, when the
+ * task packet home repo differs from the execution repo, the legacy path
+ * copies packet files into the worktree under `.taskplane-tasks/`. The
+ * resolved `packet` paths here point to that execution-local copy, not
+ * the original packet-home location. This is intentional for current
+ * compatibility but means `packetHomeRepoId` may not match the filesystem
+ * root of `packet.taskFolder`. TP-109 will tighten this so that
+ * authoritative packet-home paths are always available separately.
+ *
  * @param lane - Allocated lane containing worktree and identity info
  * @param task - Allocated task to build an execution unit for
  * @param repoRoot - Main repository root

--- a/extensions/tests/process-registry.test.ts
+++ b/extensions/tests/process-registry.test.ts
@@ -15,8 +15,11 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import { expect } from "./expect.ts";
 import { mkdtempSync, existsSync, readFileSync, mkdirSync, writeFileSync, rmSync } from "fs";
-import { join } from "path";
+import { join, dirname } from "path";
 import { tmpdir } from "os";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 import {
 	writeManifest,
@@ -359,5 +362,55 @@ describe("8.x: Agent-host export contract", () => {
 				throw err;
 			}
 		}
+	});
+});
+
+// ── 9. Agent-host option and event attribution contract (remediation) ─
+
+describe("9.x: Agent-host option and event attribution contract", () => {
+	const hostSrc = readFileSync(join(__dirname, "..", "taskplane", "agent-host.ts"), "utf-8");
+
+	it("9.1: AgentHostOptions requires batch/lane/task/repo fields", () => {
+		expect(hostSrc).toContain("batchId: string");
+		expect(hostSrc).toContain("laneNumber: number | null");
+		expect(hostSrc).toContain("taskId: string | null");
+		expect(hostSrc).toContain("repoId: string");
+	});
+
+	it("9.2: emitEvent uses opts fields, not empty placeholders", () => {
+		expect(hostSrc).toContain("batchId: opts.batchId");
+		expect(hostSrc).toContain("laneNumber: opts.laneNumber");
+		expect(hostSrc).toContain("taskId: opts.taskId");
+		expect(hostSrc).toContain("repoId: opts.repoId");
+	});
+
+	it("9.3: timeout produces agent_timeout not agent_killed", () => {
+		expect(hostSrc).toContain("agent_timeout");
+		expect(hostSrc).toContain("timedOut");
+		expect(hostSrc).toContain("timed_out");
+	});
+
+	it("9.4: --no-extensions is always passed (even with explicit -e)", () => {
+		const noExtIdx = hostSrc.indexOf('piArgs.push("--no-extensions")');
+		const eIdx = hostSrc.indexOf('piArgs.push("-e"');
+		expect(noExtIdx).toBeGreaterThan(-1);
+		expect(eIdx).toBeGreaterThan(noExtIdx);
+	});
+
+	it("9.5: registry integration writes manifest on spawn", () => {
+		expect(hostSrc).toContain("writeManifest(opts.stateRoot");
+		expect(hostSrc).toContain("updateManifestStatus(opts.stateRoot");
+	});
+
+	it("9.6: registry manifest transitions to terminal status on exit", () => {
+		expect(hostSrc).toContain('"timed_out"');
+		expect(hostSrc).toContain('"killed"');
+		expect(hostSrc).toContain('"exited"');
+		expect(hostSrc).toContain('"crashed"');
+	});
+
+	it("9.7: stateRoot and packet are optional (for callers without registry)", () => {
+		expect(hostSrc).toContain("stateRoot?: string | null");
+		expect(hostSrc).toContain("packet?: PacketPaths | null");
 	});
 });


### PR DESCRIPTION
## Summary

Addresses all 7 findings from a cross-model code review of the TP-102/103/104 Runtime V2 foundation PRs.

## Finding remediation matrix

| # | Severity | Finding | Action |
|---|---|---|---|
| 1 | **High** | Event attribution empty strings | Fixed: `AgentHostOptions` now carries `batchId/laneNumber/taskId/repoId`; `emitEvent()` uses them |
| 2 | **High** | Registry not wired into runtime | Fixed: `spawnAgent()` writes manifest on spawn and updates to terminal status on exit |
| 3 | **Medium** | Timeout classified as killed | Fixed: separate `timedOut` flag; `agent_timeout` event; `timed_out` registry status |
| 4 | **Medium** | Duplicate extension loading risk | Fixed: `--no-extensions` always passed, even with explicit `-e` |
| 5 | **Medium** | Executor-core extraction partial | Documented: intentional scope — `executeTask/runWorker/doReview` depend on Pi ExtensionContext, belong to TP-105 |
| 6 | **Medium** | Packet-home inconsistency | Documented: cross-repo copy is legacy behavior; TP-109 will tighten; clarifying doc comments added |
| 7 | **Low** | Spec docs not updated | Fixed: implementation notes added to 02, 04, 05 spec docs |

## Tests

7 new remediation tests (9.1-9.7) covering:
- Attribution fields in AgentHostOptions
- Event envelope uses opts (not placeholders)
- Timeout vs killed event/status distinction
- Extension loading order (--no-extensions before -e)
- Registry manifest write on spawn + terminal update on exit
- Terminal status coverage (all 4 terminal states)
- stateRoot/packet optionality

**Full suite: 3222 pass, 0 failures**