### PR TITLE
fix(TP-106): review agent follow-up — alerts + registry freshness

### DIFF
--- a/extensions/taskplane/agent-bridge-extension.ts
+++ b/extensions/taskplane/agent-bridge-extension.ts
@@ -24,8 +24,8 @@
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type } from "@mariozechner/pi-ai";
-import { writeFileSync, mkdirSync, existsSync, renameSync } from "fs";
-import { join, dirname } from "path";
+import { writeFileSync, mkdirSync, renameSync } from "fs";
+import { join } from "path";
 import { randomBytes } from "crypto";
 
 /**
@@ -44,6 +44,11 @@ function resolveOutboxDir(): string {
 function writeOutbox(type: "reply" | "escalate", content: string, replyTo?: string): { id: string } {
 	const outboxDir = resolveOutboxDir();
 	mkdirSync(outboxDir, { recursive: true });
+
+	const contentBytes = Buffer.byteLength(content, "utf8");
+	if (contentBytes > 4096) {
+		throw new Error(`Outbox message exceeds 4096 bytes (${contentBytes})`);
+	}
 
 	const timestamp = Date.now();
 	const nonce = randomBytes(3).toString("hex").slice(0, 5);

--- a/extensions/taskplane/agent-host.ts
+++ b/extensions/taskplane/agent-host.ts
@@ -42,7 +42,10 @@ import {
 	createManifest,
 	writeManifest,
 	updateManifestStatus,
+	buildRegistrySnapshot,
+	writeRegistrySnapshot,
 } from "./process-registry.ts";
+import { appendMailboxAuditEvent } from "./mailbox.ts";
 
 // ── Pi CLI Resolution ────────────────────────────────────────────────
 
@@ -146,6 +149,8 @@ export interface AgentHostOptions {
 	stateRoot?: string | null;
 	/** Packet paths for registry manifest (null for merge agents) */
 	packet?: PacketPaths | null;
+	/** Extra environment variables for the child process */
+	env?: Record<string, string>;
 }
 
 /**
@@ -268,7 +273,7 @@ export function spawnAgent(
 		shell: false,
 		cwd: opts.cwd,
 		stdio: ["pipe", "pipe", "pipe"],
-		env: { ...process.env },
+		env: { ...process.env, ...(opts.env ?? {}) },
 	});
 
 	// State accumulator
@@ -295,6 +300,19 @@ export function spawnAgent(
 		}, timeoutMs);
 	}
 
+	const REGISTRY_REFRESH_INTERVAL_MS = 1_000;
+	let lastRegistryRefreshAt = 0;
+	const refreshRegistrySnapshot = (force: boolean = false) => {
+		if (!opts.stateRoot) return;
+		const now = Date.now();
+		if (!force && (now - lastRegistryRefreshAt) < REGISTRY_REFRESH_INTERVAL_MS) return;
+		try {
+			const snapshot = buildRegistrySnapshot(opts.stateRoot, opts.batchId);
+			writeRegistrySnapshot(opts.stateRoot, snapshot);
+			lastRegistryRefreshAt = now;
+		} catch { /* best effort */ }
+	};
+
 	// Registry integration: write manifest before process is considered visible
 	if (opts.stateRoot) {
 		const manifest = createManifest({
@@ -311,6 +329,7 @@ export function spawnAgent(
 		});
 		manifest.status = "running";
 		writeManifest(opts.stateRoot, manifest);
+		refreshRegistrySnapshot(true);
 	}
 
 	// Helper: close stdin safely with delay
@@ -375,9 +394,7 @@ export function spawnAgent(
 			const msgFiles = entries.filter(f => f.endsWith(".msg.json") && !f.endsWith(".msg.json.tmp")).sort();
 			if (msgFiles.length === 0) continue;
 
-			const ackDir = isBroadcast
-				? join(dirname(inboxDir), "ack")
-				: join(opts.mailboxDir, "ack");
+			const ackDir = join(opts.mailboxDir, "ack");
 
 			for (const filename of msgFiles) {
 				try {
@@ -389,12 +406,34 @@ export function spawnAgent(
 					if (!isBroadcast && msg.to !== expectedSessionName) continue;
 					if (isBroadcast && msg.to !== "_broadcast") continue;
 
+					mkdirSync(ackDir, { recursive: true });
+					const ackPath = join(ackDir, filename);
+					// Broadcast fan-out: if this agent already acked this broadcast message,
+					// skip to avoid duplicate delivery while preserving message for peers.
+					if (isBroadcast && existsSync(ackPath)) continue;
+
 					proc.stdin.write(JSON.stringify({ type: "steer", message: msg.content }) + "\n");
 
-					mkdirSync(ackDir, { recursive: true });
-					try { renameSync(join(inboxDir, filename), join(ackDir, filename)); } catch { /* race ok */ }
+					if (isBroadcast) {
+						// Do NOT remove the shared broadcast inbox file. Persist a per-agent
+						// ack marker so all agents can consume the same broadcast exactly once.
+						try { writeFileSync(ackPath, raw, "utf-8"); } catch { /* best effort */ }
+					} else {
+						try { renameSync(join(inboxDir, filename), ackPath); } catch { /* race ok */ }
+					}
 
 					emitEvent("message_delivered", { messageId: msg.id, content: msg.content, broadcast: isBroadcast });
+					if (opts.stateRoot) {
+						appendMailboxAuditEvent(opts.stateRoot, expectedBatchId, {
+							type: "message_delivered",
+							from: msg.from,
+							to: isBroadcast ? expectedSessionName : msg.to,
+							messageId: msg.id,
+							messageType: msg.type,
+							contentPreview: msg.content.slice(0, 200),
+							broadcast: isBroadcast,
+						});
+					}
 
 					// TP-090: steering-pending flag
 					if (opts.steeringPendingPath) {
@@ -476,6 +515,7 @@ export function spawnAgent(
 					(exitCode === 0 && agentEnded) ? "exited" as const :
 					"crashed" as const;
 				updateManifestStatus(opts.stateRoot, opts.batchId, opts.agentId, terminalStatus);
+				refreshRegistrySnapshot(true);
 			}
 
 			resolvePromise(result);
@@ -514,6 +554,8 @@ export function spawnAgent(
 						}
 						// Check mailbox
 						checkMailbox();
+						// Keep registry snapshot freshness while agent is active.
+						refreshRegistrySnapshot(false);
 						// Emit telemetry update
 						if (onTelemetry) {
 							onTelemetry({ inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens, costUsd, toolCalls, lastTool, contextUsage });

--- a/extensions/taskplane/engine.ts
+++ b/extensions/taskplane/engine.ts
@@ -629,6 +629,7 @@ async function attemptStaleWorktreeRecovery(
 	onLanesAllocated: (lanes: AllocatedLane[]) => void,
 	stateRoot: string,
 	runtimeBackend?: RuntimeBackend,
+	onSupervisorAlert?: SupervisorAlertCallback,
 ): Promise<WaveExecutionResult | null> {
 	// Only attempt recovery for ALLOC_WORKTREE_FAILED
 	if (!waveResult.allocationError || waveResult.allocationError.code !== "ALLOC_WORKTREE_FAILED") {
@@ -729,6 +730,7 @@ async function attemptStaleWorktreeRecovery(
 		onLanesAllocated,
 		workspaceConfig,
 		runtimeBackend,
+		onSupervisorAlert,
 	);
 
 	return retryResult;
@@ -1194,6 +1196,7 @@ export async function executeOrchBatch(
 			onLanesAllocatedCb,
 			workspaceConfig,
 			selectedBackend,
+			emitAlert,
 		);
 
 		// ── TP-039: Tier 0 — Stale worktree recovery ────────────
@@ -1214,6 +1217,7 @@ export async function executeOrchBatch(
 				onLanesAllocatedCb,
 				stateRoot,
 				selectedBackend,
+				emitAlert,
 			);
 			if (retryResult) {
 				const staleRecovered = !retryResult.allocationError;

--- a/extensions/taskplane/execution.ts
+++ b/extensions/taskplane/execution.ts
@@ -9,7 +9,7 @@ import { join, dirname, basename, resolve, relative, delimiter as pathDelimiter 
 import { userInfo } from "os";
 
 import { DONE_GRACE_MS, EXECUTION_POLL_INTERVAL_MS, ExecutionError, SESSION_SPAWN_RETRY_MAX } from "./types.ts";
-import type { AllocatedLane, AllocatedTask, DependencyGraph, LaneExecutionResult, LaneMonitorSnapshot, LaneTaskOutcome, LaneTaskStatus, MonitorState, MtimeTracker, OrchestratorConfig, ParsedTask, TaskMonitorSnapshot, WaveExecutionResult, WorkspaceConfig, ExecutionUnit, PacketPaths, RuntimeAgentId, RuntimeAgentRole } from "./types.ts";
+import type { AllocatedLane, AllocatedTask, DependencyGraph, LaneExecutionResult, LaneMonitorSnapshot, LaneTaskOutcome, LaneTaskStatus, MonitorState, MtimeTracker, OrchestratorConfig, ParsedTask, TaskMonitorSnapshot, WaveExecutionResult, WorkspaceConfig, ExecutionUnit, PacketPaths, RuntimeAgentId, RuntimeAgentRole, SupervisorAlertCallback } from "./types.ts";
 import { resolvePacketPaths, buildRuntimeAgentId } from "./types.ts";
 import { allocateLanes } from "./waves.ts";
 import { runGit } from "./git.ts";
@@ -2321,6 +2321,7 @@ export async function executeWave(
 	onLanesAllocated?: (lanes: AllocatedLane[]) => void,
 	workspaceConfig?: WorkspaceConfig | null,
 	runtimeBackend?: RuntimeBackend,
+	onSupervisorAlert?: SupervisorAlertCallback,
 ): Promise<WaveExecutionResult> {
 	const startedAt = Date.now();
 	const policy = config.failure.on_task_failure;
@@ -2410,7 +2411,7 @@ export async function executeWave(
 
 	const lanePromises = lanes.map(lane =>
 		backend === "v2"
-			? executeLaneV2(lane, config, repoRoot, wavePauseSignal, wsRoot, isWsMode, { ORCH_BATCH_ID: batchId })
+			? executeLaneV2(lane, config, repoRoot, wavePauseSignal, wsRoot, isWsMode, { ORCH_BATCH_ID: batchId }, onSupervisorAlert)
 			: executeLane(lane, config, repoRoot, wavePauseSignal, wsRoot, isWsMode, { ORCH_BATCH_ID: batchId }),
 	);
 
@@ -2847,6 +2848,7 @@ export async function executeLaneV2(
 	workspaceRoot?: string,
 	isWorkspaceMode?: boolean,
 	extraEnvVars?: Record<string, string>,
+	onSupervisorAlert?: SupervisorAlertCallback,
 ): Promise<LaneExecutionResult> {
 	const laneId = lane.laneId;
 	const laneStartTime = Date.now();
@@ -2914,6 +2916,7 @@ export async function executeLaneV2(
 			maxWorkerMinutes: config.failure?.maxWorkerMinutes || 30,
 			warnPercent: 85,
 			killPercent: 95,
+			onSupervisorAlert,
 		};
 
 		try {

--- a/extensions/taskplane/extension.ts
+++ b/extensions/taskplane/extension.ts
@@ -34,12 +34,11 @@ import type { EngineWorkerData, WorkerToMainMessage } from "./engine-worker.ts";
 import { cleanupPostIntegrate, formatPostIntegrateCleanup, sweepStaleArtifacts, formatPreflightSweep, rotateSupervisorLogs, formatLogRotation } from "./cleanup.ts";
 import {
 	writeMailboxMessage,
-	readInbox,
 	readOutbox,
 	writeBroadcastMessage,
 	checkRateLimit,
 	recordSend,
-	sessionOutboxDir,
+	appendMailboxAuditEvent,
 } from "./mailbox.ts";
 import {
 	readRegistrySnapshot,
@@ -3702,6 +3701,34 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
+	function collectKnownAgentIds(stateRoot: string, state: PersistedBatchState): string[] {
+		const ids = new Set<string>();
+
+		// Runtime V2 source of truth first.
+		const registry = readRegistrySnapshot(stateRoot, state.batchId);
+		if (registry) {
+			for (const manifest of Object.values(registry.agents)) {
+				if (manifest.role !== "worker" && manifest.role !== "reviewer" && manifest.role !== "merger") continue;
+				if (isTerminalStatus(manifest.status) || !registryIsProcessAlive(manifest.pid)) continue;
+				ids.add(manifest.agentId);
+			}
+		}
+
+		// Legacy fallback from lane naming when registry is absent/empty.
+		if (ids.size === 0) {
+			const orchConfig = execCtx?.orchestratorConfig;
+			const tmuxPrefix = orchConfig?.orchestrator?.tmux_prefix ?? "orch";
+			const opId = orchConfig ? resolveOperatorId(orchConfig) : "op";
+			for (const lane of state.lanes) {
+				ids.add(`${lane.tmuxSessionName}-worker`);
+				ids.add(`${lane.tmuxSessionName}-reviewer`);
+				ids.add(`${tmuxPrefix}-${opId}-merge-${lane.laneNumber}`);
+			}
+		}
+
+		return [...ids];
+	}
+
 	/**
 	 * Send a steering message to a running agent via the mailbox system.
 	 *
@@ -3735,19 +3762,8 @@ export default function (pi: ExtensionAPI) {
 			return `❌ Batch ${state.batchId} is in terminal phase (${state.phase}). Start or resume a batch before sending messages.`;
 		}
 
-		// Build the set of valid agent session names from batch state
-		const validSessions = new Set<string>();
-		const orchConfig = execCtx?.orchestratorConfig;
-		const tmuxPrefix = orchConfig?.orchestrator?.tmux_prefix ?? "orch";
-		const opId = orchConfig ? resolveOperatorId(orchConfig) : "op";
-
-		for (const lane of state.lanes) {
-			// Worker and reviewer are derived from lane session name
-			validSessions.add(`${lane.tmuxSessionName}-worker`);
-			validSessions.add(`${lane.tmuxSessionName}-reviewer`);
-			// Merger: {tmuxPrefix}-{opId}-merge-{laneNumber}
-			validSessions.add(`${tmuxPrefix}-${opId}-merge-${lane.laneNumber}`);
-		}
+		// Build valid runtime agent IDs (registry-first, legacy fallback).
+		const validSessions = new Set<string>(collectKnownAgentIds(stateRoot, state));
 
 		// Validate target session
 		if (!validSessions.has(to)) {
@@ -3779,8 +3795,13 @@ export default function (pi: ExtensionAPI) {
 		const rateCheck = checkRateLimit(to);
 		if (!rateCheck.allowed) {
 			const waitSec = Math.ceil((rateCheck.retryAfterMs ?? 0) / 1000);
-			// TP-106: Emit rate_limited event for auditability
-			console.error(`[mailbox] rate-limited: ${to} (retry after ${waitSec}s)`);
+			appendMailboxAuditEvent(stateRoot, state.batchId, {
+				type: "message_rate_limited",
+				from: "supervisor",
+				to,
+				reason: "per-agent rate limit",
+				retryAfterMs: rateCheck.retryAfterMs,
+			});
 			return `⏳ Rate limited: wait ${waitSec}s before sending another message to \`${to}\`.`;
 		}
 
@@ -3792,6 +3813,15 @@ export default function (pi: ExtensionAPI) {
 				content,
 			});
 			recordSend(to);
+			appendMailboxAuditEvent(stateRoot, state.batchId, {
+				type: "message_sent",
+				from: "supervisor",
+				to,
+				messageId: msg.id,
+				messageType,
+				contentPreview: content.slice(0, 200),
+				broadcast: false,
+			});
 			return `✅ Message sent to \`${to}\` (batch ${state.batchId})\n` +
 				`- **ID:** ${msg.id}\n` +
 				`- **Type:** ${messageType}\n` +
@@ -3839,16 +3869,9 @@ export default function (pi: ExtensionAPI) {
 		const state = loadBatchState(stateRoot);
 		if (!state) return "❌ No batch state found.";
 
-		const agentIds: string[] = [];
-		if (from) {
-			agentIds.push(from);
-		} else {
-			// Collect all known agent IDs from batch lanes
-			for (const lane of state.lanes) {
-				agentIds.push(`${lane.tmuxSessionName}-worker`);
-				agentIds.push(`${lane.tmuxSessionName}-reviewer`);
-			}
-		}
+		const agentIds = from
+			? [from]
+			: collectKnownAgentIds(stateRoot, state);
 
 		const allMessages: Array<{ agentId: string; message: import("./types.ts").MailboxMessage }> = [];
 		for (const agentId of agentIds) {
@@ -3923,15 +3946,55 @@ export default function (pi: ExtensionAPI) {
 			return `❌ Batch ${state.batchId} is in terminal phase (${state.phase}).`;
 		}
 
+		const validTypes = new Set(["steer", "info", "abort"]);
+		if (!validTypes.has(messageType)) {
+			return `❌ Invalid broadcast type "${messageType}". Valid types: steer, info, abort.`;
+		}
+
+		const recipients = collectKnownAgentIds(stateRoot, state);
+		if (recipients.length === 0) {
+			return `❌ No known agents found in batch ${state.batchId} for broadcast delivery.`;
+		}
+
+		const blocked = recipients
+			.map((agentId) => ({ agentId, check: checkRateLimit(agentId) }))
+			.filter(({ check }) => !check.allowed);
+		if (blocked.length > 0) {
+			for (const b of blocked) {
+				appendMailboxAuditEvent(stateRoot, state.batchId, {
+					type: "message_rate_limited",
+					from: "supervisor",
+					to: b.agentId,
+					reason: "broadcast blocked by per-agent rate limit",
+					retryAfterMs: b.check.retryAfterMs,
+				});
+			}
+			const preview = blocked.slice(0, 5).map(b => `${b.agentId} (${Math.ceil((b.check.retryAfterMs ?? 0) / 1000)}s)`).join(", ");
+			return `⏳ Broadcast rate limited for ${blocked.length}/${recipients.length} agent(s): ${preview}${blocked.length > 5 ? " ..." : ""}`;
+		}
+
 		try {
 			const msg = writeBroadcastMessage(stateRoot, state.batchId, {
 				from: "supervisor",
 				type: messageType as MailboxMessageType,
 				content,
 			});
+			for (const agentId of recipients) {
+				recordSend(agentId);
+			}
+			appendMailboxAuditEvent(stateRoot, state.batchId, {
+				type: "message_sent",
+				from: "supervisor",
+				to: "_broadcast",
+				messageId: msg.id,
+				messageType,
+				contentPreview: content.slice(0, 200),
+				broadcast: true,
+			});
 			return `✅ Broadcast sent (batch ${state.batchId})\n` +
 				`- **ID:** ${msg.id}\n` +
 				`- **Type:** ${messageType}\n` +
+				`- **Recipients:** ${recipients.length}\n` +
 				`- **Size:** ${Buffer.byteLength(content, "utf8")} bytes\n` +
 				`Message will be delivered to all agents at their next turn boundary.`;
 		} catch (err) {

--- a/extensions/taskplane/lane-runner.ts
+++ b/extensions/taskplane/lane-runner.ts
@@ -17,6 +17,7 @@
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from "fs";
 import { join, dirname, resolve } from "path";
+import { fileURLToPath } from "url";
 
 import {
 	parsePromptMd,
@@ -30,19 +31,18 @@ import {
 	type CoreParsedTask,
 } from "./task-executor-core.ts";
 
-import { spawnAgent, resolvePiCliPath, type AgentHostOptions, type AgentHostResult } from "./agent-host.ts";
+import { spawnAgent, type AgentHostOptions, type AgentHostResult } from "./agent-host.ts";
 
 import {
-	createManifest,
-	writeManifest,
-	updateManifestStatus,
 	appendAgentEvent,
 	writeLaneSnapshot,
-	buildRegistrySnapshot,
-	writeRegistrySnapshot,
 } from "./process-registry.ts";
 
-import { readOutbox } from "./mailbox.ts";
+import {
+	readOutbox,
+	ackOutboxMessage,
+	appendMailboxAuditEvent,
+} from "./mailbox.ts";
 
 import {
 	resolvePacketPaths,
@@ -57,7 +57,10 @@ import {
 	type PacketPaths,
 	type LaneTaskOutcome,
 	type LaneTaskStatus,
+	type SupervisorAlertCallback,
 } from "./types.ts";
+
+const LANE_RUNNER_DIR = dirname(fileURLToPath(import.meta.url));
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -99,6 +102,8 @@ export interface LaneRunnerConfig {
 	warnPercent: number;
 	/** Context pressure kill threshold (0-100) */
 	killPercent: number;
+	/** Optional callback for surfacing runtime mailbox replies/escalations to supervisor */
+	onSupervisorAlert?: SupervisorAlertCallback;
 }
 
 /**
@@ -164,12 +169,6 @@ export async function executeTaskV2(
 	updateStatusField(statusPath, "Status", "🟡 In Progress");
 	updateStatusField(statusPath, "Last Updated", new Date().toISOString().slice(0, 10));
 	logExecution(statusPath, "Task started", "Runtime V2 lane-runner execution");
-
-	// ── TP-106: Write initial registry snapshot ──────────────────
-	try {
-		const initRegistry = buildRegistrySnapshot(config.stateRoot, config.batchId);
-		writeRegistrySnapshot(config.stateRoot, initRegistry);
-	} catch { /* best effort */ }
 
 	// ── 2. Iteration loop ───────────────────────────────────────────
 	let noProgressCount = 0;
@@ -244,9 +243,9 @@ export async function executeTaskV2(
 
 		const steeringPendingPath = join(taskFolder, ".steering-pending");
 
-		// TP-106: Resolve bridge extension for agent-side reply/escalate tools
-		// The outbox dir is set via the mailbox sessionOutboxDir convention
+		// TP-106: Bridge extension wiring for agent-side reply/escalate tools
 		const outboxDir = join(config.stateRoot, ".pi", "mailbox", config.batchId, workerAgentId, "outbox");
+		const bridgeExtensionPath = join(LANE_RUNNER_DIR, "agent-bridge-extension.ts");
 
 		const hostOpts: AgentHostOptions = {
 			agentId: workerAgentId,
@@ -268,6 +267,12 @@ export async function executeTaskV2(
 			timeoutMs: config.maxWorkerMinutes * 60_000,
 			stateRoot: config.stateRoot,
 			packet: unit.packet,
+			extensions: [bridgeExtensionPath],
+			env: {
+				TASKPLANE_OUTBOX_DIR: outboxDir,
+				TASKPLANE_AGENT_ID: workerAgentId,
+				ORCH_BATCH_ID: config.batchId,
+			},
 		};
 
 		// Context pressure: write wrap-up signal before kill
@@ -301,18 +306,64 @@ export async function executeTaskV2(
 		cumulativeTokens += workerResult.inputTokens + workerResult.outputTokens +
 			workerResult.cacheReadTokens + workerResult.cacheWriteTokens;
 
-		// ── TP-106: Update registry snapshot after worker exit ──────
-		try {
-			const registrySnap = buildRegistrySnapshot(config.stateRoot, config.batchId);
-			writeRegistrySnapshot(config.stateRoot, registrySnap);
-		} catch { /* best effort */ }
-
 		// ── TP-106: Poll worker outbox for replies/escalations ─────
 		try {
 			const outboxMessages = readOutbox(config.stateRoot, config.batchId, workerAgentId);
 			for (const msg of outboxMessages) {
-				logExecution(statusPath, `Agent ${msg.type}`,
-					msg.content.replace(/\r?\n/g, " / ").slice(0, 200));
+				const sanitized = msg.content.replace(/\r?\n/g, " / ").slice(0, 200);
+				logExecution(statusPath, `Agent ${msg.type}`, sanitized);
+
+				if (msg.type === "reply" || msg.type === "escalate") {
+					appendAgentEvent(config.stateRoot, config.batchId, workerAgentId, {
+						batchId: config.batchId,
+						agentId: workerAgentId,
+						role: "worker",
+						laneNumber: config.laneNumber,
+						taskId,
+						repoId: config.repoId,
+						ts: Date.now(),
+						type: msg.type === "reply" ? "reply_sent" : "escalation_sent",
+						payload: {
+							messageId: msg.id,
+							replyTo: msg.replyTo ?? null,
+							content: sanitized,
+						},
+					});
+
+					appendMailboxAuditEvent(config.stateRoot, config.batchId, {
+						type: msg.type === "reply" ? "message_replied" : "message_escalated",
+						from: workerAgentId,
+						to: "supervisor",
+						messageId: msg.id,
+						messageType: msg.type,
+						contentPreview: sanitized,
+					});
+
+					if (config.onSupervisorAlert) {
+						const isEscalation = msg.type === "escalate";
+						try {
+							config.onSupervisorAlert({
+								category: "agent-message",
+								summary:
+									`${isEscalation ? "🚨" : "📨"} Agent ${isEscalation ? "escalation" : "reply"} from ${workerAgentId}\n` +
+									`  Task: ${taskId}\n` +
+									`  Lane: lane-${config.laneNumber}\n` +
+									`  Message: ${sanitized}`,
+								context: {
+									taskId,
+									laneId: `lane-${config.laneNumber}`,
+									laneNumber: config.laneNumber,
+									agentId: workerAgentId,
+									messageId: msg.id,
+									exitReason: `${isEscalation ? "agent_escalation" : "agent_reply"}: ${sanitized}`,
+								},
+							});
+						} catch { /* best effort */ }
+					}
+				}
+
+				// Consume outbox message to prevent duplicate processing in later iterations.
+				ackOutboxMessage(config.stateRoot, config.batchId, workerAgentId, msg.id);
 			}
 		} catch { /* best effort */ }
 

--- a/extensions/taskplane/mailbox.ts
+++ b/extensions/taskplane/mailbox.ts
@@ -24,7 +24,7 @@
  */
 
 import { join, dirname } from "path";
-import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync, renameSync, unlinkSync } from "fs";
+import { existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync, renameSync, unlinkSync, appendFileSync } from "fs";
 import { randomBytes } from "crypto";
 import type { MailboxMessage, MailboxMessageType, WriteMailboxMessageOpts } from "./types.ts";
 import { MAILBOX_DIR_NAME, MAILBOX_MAX_CONTENT_BYTES, MAILBOX_MESSAGE_TYPES } from "./types.ts";
@@ -460,6 +460,84 @@ export function readOutbox(
 
 	messages.sort((a, b) => a.timestamp - b.timestamp);
 	return messages;
+}
+
+/**
+ * Ack (consume) a specific outbox message by moving it to processed/.
+ *
+ * Returns false if the message is already gone (race-safe/idempotent).
+ *
+ * @since TP-106
+ */
+export function ackOutboxMessage(
+	stateRoot: string,
+	batchId: string,
+	agentId: string,
+	messageId: string,
+): boolean {
+	const outboxDir = sessionOutboxDir(stateRoot, batchId, agentId);
+	const processedDir = join(outboxDir, "processed");
+	const file = `${messageId}.msg.json`;
+	const srcPath = join(outboxDir, file);
+	const dstPath = join(processedDir, file);
+
+	try {
+		mkdirSync(processedDir, { recursive: true });
+		renameSync(srcPath, dstPath);
+		return true;
+	} catch (err: unknown) {
+		const code = (err as NodeJS.ErrnoException).code;
+		if (code === "ENOENT") return false;
+		process.stderr.write(
+			`[mailbox] WARNING: failed to ack outbox ${file}: ${err instanceof Error ? err.message : String(err)}\n`,
+		);
+		return false;
+	}
+}
+
+export type MailboxAuditEventType =
+	| "message_sent"
+	| "message_delivered"
+	| "message_replied"
+	| "message_escalated"
+	| "message_rate_limited";
+
+/**
+ * Append a mailbox audit event to .pi/mailbox/{batchId}/events.jsonl.
+ *
+ * Best-effort: logs warning but never throws.
+ *
+ * @since TP-106
+ */
+export function appendMailboxAuditEvent(
+	stateRoot: string,
+	batchId: string,
+	event: {
+		type: MailboxAuditEventType;
+		ts?: number;
+		from?: string;
+		to?: string;
+		messageId?: string;
+		messageType?: string;
+		contentPreview?: string;
+		broadcast?: boolean;
+		reason?: string;
+		retryAfterMs?: number;
+	},
+): void {
+	const eventsPath = join(mailboxRoot(stateRoot, batchId), "events.jsonl");
+	try {
+		mkdirSync(dirname(eventsPath), { recursive: true });
+		appendFileSync(
+			eventsPath,
+			JSON.stringify({ batchId, ts: event.ts ?? Date.now(), ...event }) + "\n",
+			"utf-8",
+		);
+	} catch (err) {
+		process.stderr.write(
+			`[mailbox] WARNING: failed to append mailbox event: ${err instanceof Error ? err.message : String(err)}\n`,
+		);
+	}
 }
 
 

--- a/extensions/taskplane/resume.ts
+++ b/extensions/taskplane/resume.ts
@@ -1603,6 +1603,8 @@ export async function resumeOrchBatch(
 				}
 			},
 			workspaceConfig,
+			undefined,
+			emitAlert,
 		);
 
 		batchState.waveResults.push(waveResult);

--- a/extensions/taskplane/types.ts
+++ b/extensions/taskplane/types.ts
@@ -1895,13 +1895,14 @@ export type EngineEventCallback = (event: EngineEvent) => void;
  * - `task-failure`:   A task failed after deterministic recovery was exhausted
  * - `merge-failure`:  Wave merge failed and batch paused
  * - `batch-complete`: Batch finished (all waves done)
+ * - `agent-message`:  Runtime mailbox reply/escalation from a running agent
  *
  * Note: `stall` detection is deferred to a future phase (requires
  * last-activity tracking not yet built).
  *
  * @since TP-076
  */
-export type SupervisorAlertCategory = "task-failure" | "merge-failure" | "batch-complete";
+export type SupervisorAlertCategory = "task-failure" | "merge-failure" | "batch-complete" | "agent-message";
 
 /**
  * Structured context payload for supervisor alerts.
@@ -1922,6 +1923,10 @@ export interface SupervisorAlertContext {
 	waveIndex?: number;
 	/** Exit reason string (for task-failure alerts) */
 	exitReason?: string;
+	/** Agent ID (for agent-message alerts) */
+	agentId?: string;
+	/** Mailbox message ID (for agent-message alerts) */
+	messageId?: string;
 	/** Whether partial progress was preserved (for task-failure alerts) */
 	partialProgress?: boolean;
 	/** Batch progress summary */

--- a/extensions/tests/mailbox-v2.test.ts
+++ b/extensions/tests/mailbox-v2.test.ts
@@ -19,6 +19,8 @@ import {
 	readOutbox,
 	writeBroadcastMessage,
 	sessionOutboxDir,
+	ackOutboxMessage,
+	appendMailboxAuditEvent,
 	checkRateLimit,
 	recordSend,
 	_resetRateLimits,
@@ -99,6 +101,19 @@ describe("1.x: Agent outbox", () => {
 		}
 		expect(threw).toBe(true);
 	});
+
+	it("1.6: ackOutboxMessage moves message to processed and prevents reread", () => {
+		const msg = writeOutboxMessage(tmpDir, batchId, agentId, {
+			from: agentId,
+			type: "reply",
+			content: "processed once",
+		});
+		expect(readOutbox(tmpDir, batchId, agentId).length).toBe(1);
+		expect(ackOutboxMessage(tmpDir, batchId, agentId, msg.id)).toBe(true);
+		expect(readOutbox(tmpDir, batchId, agentId).length).toBe(0);
+		const processedPath = join(tmpDir, ".pi", "mailbox", batchId, agentId, "outbox", "processed", `${msg.id}.msg.json`);
+		expect(existsSync(processedPath)).toBe(true);
+	});
 });
 
 // ── 2. Broadcast ─────────────────────────────────────────────────────
@@ -117,6 +132,21 @@ describe("2.x: Broadcast messages", () => {
 		const files = readdirSync(broadcastInbox).filter(f => f.endsWith(".msg.json"));
 		expect(files.length).toBe(1);
 		expect(msg.to).toBe("_broadcast");
+	});
+
+	it("2.2: appendMailboxAuditEvent writes JSONL event", () => {
+		appendMailboxAuditEvent(tmpDir, batchId, {
+			type: "message_sent",
+			from: "supervisor",
+			to: "agent-1",
+			messageType: "info",
+			contentPreview: "hello",
+		});
+		const eventsPath = join(tmpDir, ".pi", "mailbox", batchId, "events.jsonl");
+		expect(existsSync(eventsPath)).toBe(true);
+		const lines = readFileSync(eventsPath, "utf-8").trim().split("\n");
+		expect(lines.length).toBe(1);
+		expect(lines[0]).toContain('"type":"message_sent"');
 	});
 });
 
@@ -199,6 +229,18 @@ describe("4.x: Registry-backed supervisor tool contracts", () => {
 	it("4.7: broadcast_message calls writeBroadcastMessage", () => {
 		expect(extensionSrc).toContain("writeBroadcastMessage(stateRoot");
 	});
+
+	it("4.8: read_agent_replies uses registry-backed agent discovery helper", () => {
+		expect(extensionSrc).toContain("collectKnownAgentIds(stateRoot, state)");
+	});
+
+	it("4.9: broadcast_message applies per-agent rate limiting", () => {
+		const fnIdx = extensionSrc.indexOf("function doBroadcastMessage(");
+		const block = extensionSrc.slice(fnIdx, fnIdx + 3500);
+		expect(block).toContain("collectKnownAgentIds");
+		expect(block).toContain("checkRateLimit(agentId)");
+		expect(block).toContain("recordSend(agentId)");
+	});
 });
 
 // ── 5. Broadcast delivery in agent-host (TP-106 remediation) ──────
@@ -206,29 +248,52 @@ describe("4.x: Registry-backed supervisor tool contracts", () => {
 describe("5.x: Agent-host broadcast delivery", () => {
 	const agentHostSrc = readFileSync(join(__dirname, "..", "taskplane", "agent-host.ts"), "utf-8");
 
-	it("8.1: checkMailbox reads _broadcast/inbox in addition to own inbox", () => {
+	it("5.1: checkMailbox reads _broadcast/inbox in addition to own inbox", () => {
 		expect(agentHostSrc).toContain("_broadcast");
 		expect(agentHostSrc).toContain("broadcastInbox");
 		expect(agentHostSrc).toContain("isBroadcast");
 	});
 
-	it("8.2: broadcast messages are validated with to === _broadcast", () => {
+	it("5.2: broadcast messages are validated with to === _broadcast", () => {
 		expect(agentHostSrc).toContain('msg.to !== "_broadcast"');
+	});
+
+	it("5.3: broadcast delivery uses per-agent ack markers (fan-out safe)", () => {
+		expect(agentHostSrc).toContain("if (isBroadcast && existsSync(ackPath)) continue");
+		expect(agentHostSrc).toContain("writeFileSync(ackPath, raw");
+	});
+
+	it("5.4: registry snapshot freshness is maintained while agent is running", () => {
+		expect(agentHostSrc).toContain("REGISTRY_REFRESH_INTERVAL_MS");
+		expect(agentHostSrc).toContain("refreshRegistrySnapshot(false)");
 	});
 });
 
-// ── 6. Registry wiring in lane-runner (TP-106 remediation) ────────
+// ── 6. Lane-runner outbox + bridge wiring (TP-106 remediation) ─────
 
-describe("6.x: Lane-runner registry and outbox wiring", () => {
+describe("6.x: Lane-runner outbox and bridge wiring", () => {
 	const laneRunnerSrc = readFileSync(join(__dirname, "..", "taskplane", "lane-runner.ts"), "utf-8");
 
-	it("6.1: lane-runner writes registry snapshot", () => {
-		expect(laneRunnerSrc).toContain("writeRegistrySnapshot");
-		expect(laneRunnerSrc).toContain("buildRegistrySnapshot");
+	it("6.1: lane-runner polls and acks outbox messages", () => {
+		expect(laneRunnerSrc).toContain("readOutbox");
+		expect(laneRunnerSrc).toContain("ackOutboxMessage");
 	});
 
-	it("6.2: lane-runner polls outbox after worker exit", () => {
-		expect(laneRunnerSrc).toContain("readOutbox");
+	it("6.2: lane-runner emits reply/escalation audit events", () => {
+		expect(laneRunnerSrc).toContain("reply_sent");
+		expect(laneRunnerSrc).toContain("escalation_sent");
+		expect(laneRunnerSrc).toContain("appendMailboxAuditEvent");
+	});
+
+	it("6.3: lane-runner wires agent bridge extension and env", () => {
+		expect(laneRunnerSrc).toContain("agent-bridge-extension.ts");
+		expect(laneRunnerSrc).toContain("TASKPLANE_OUTBOX_DIR");
+		expect(laneRunnerSrc).toContain("TASKPLANE_AGENT_ID");
+	});
+
+	it("6.4: lane-runner can fan out outbox messages to supervisor alerts", () => {
+		expect(laneRunnerSrc).toContain("onSupervisorAlert");
+		expect(laneRunnerSrc).toContain('category: "agent-message"');
 	});
 });
 
@@ -287,5 +352,13 @@ describe("8.x: Mailbox V2 exports", () => {
 
 	it("8.6: sessionOutboxDir is a function", () => {
 		expect(typeof sessionOutboxDir).toBe("function");
+	});
+
+	it("8.7: ackOutboxMessage is a function", () => {
+		expect(typeof ackOutboxMessage).toBe("function");
+	});
+
+	it("8.8: appendMailboxAuditEvent is a function", () => {
+		expect(typeof appendMailboxAuditEvent).toBe("function");
 	});
 });

--- a/extensions/tests/supervisor-alerts.test.ts
+++ b/extensions/tests/supervisor-alerts.test.ts
@@ -120,8 +120,8 @@ describe("1.x — SupervisorAlert type structure", () => {
 		expect(alert.context.batchDurationMs).toBe(120000);
 	});
 
-	it("1.4 — all three alert categories are valid", () => {
-		const categories: SupervisorAlertCategory[] = ["task-failure", "merge-failure", "batch-complete"];
+	it("1.4 — all alert categories are valid", () => {
+		const categories: SupervisorAlertCategory[] = ["task-failure", "merge-failure", "batch-complete", "agent-message"];
 		for (const cat of categories) {
 			const alert: SupervisorAlert = {
 				category: cat,


### PR DESCRIPTION
## Summary

Follow-up remediations from the review agent covering mailbox alert fanout and registry freshness gaps.

## Changes

- 063574a merge: TP-106 follow-up remediations (alerts + registry freshness)
- d34e729 fix(TP-106): close mailbox alert fanout and registry freshness gaps

## Diff stats

 extensions/taskplane/agent-bridge-extension.ts |   9 +-
 extensions/taskplane/agent-host.ts             |  54 ++++++++++--
 extensions/taskplane/engine.ts                 |   4 +
 extensions/taskplane/execution.ts              |   7 +-
 extensions/taskplane/extension.ts              | 117 +++++++++++++++++++------
 extensions/taskplane/lane-runner.ts            |  97 +++++++++++++++-----
 extensions/taskplane/mailbox.ts                |  80 ++++++++++++++++-
 extensions/taskplane/resume.ts                 |   2 +
 extensions/taskplane/types.ts                  |   7 +-
 extensions/tests/mailbox-v2.test.ts            |  91 +++++++++++++++++--
 extensions/tests/supervisor-alerts.test.ts     |   4 +-
 11 files changed, 399 insertions(+), 73 deletions(-)