### PR TITLE
fix: switch merge strategy from squash-first to merge-first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,8 +180,8 @@ When in doubt, optimize for: **determinism, recoverability, and clear operator v
    - `git push -u origin <branch>`
    - `gh pr create --fill`
 5. Ensure required checks pass (`ci`) and conversations are resolved.
-6. Merge via squash and delete branch:
-   - `gh pr merge --squash --delete-branch`
+6. Merge and delete branch:
+   - `gh pr merge --merge --delete-branch`
 7. Sync local after merge:
    - `git switch main && git pull --ff-only`
 

--- a/extensions/taskplane/supervisor.ts
+++ b/extensions/taskplane/supervisor.ts
@@ -665,8 +665,12 @@ export async function pollPrCiStatus(
 /**
  * Merge a PR via gh CLI after CI passes.
  *
- * Tries squash merge first (cleanest for integration PRs), then falls
- * back to regular merge if squash is not allowed by repo rules.
+ * Uses regular merge (preserves per-commit history from orch branches).
+ * Falls back to squash if regular merge is not allowed by repo rules.
+ *
+ * Regular merge is preferred because squash collapses all branch commits
+ * into one, which loses per-task attribution and can silently drop
+ * commits made by other agents between push and merge.
  *
  * @param orchBranch - The branch the PR was created from
  * @param deps - CI deps (runCommand for gh CLI)
@@ -678,15 +682,7 @@ export function mergePr(
 	orchBranch: string,
 	deps: CiDeps,
 ): { success: boolean; detail: string } {
-	// Try squash merge first
-	const squashResult = deps.runCommand("gh", [
-		"pr", "merge", orchBranch, "--squash", "--delete-branch",
-	]);
-	if (squashResult.ok) {
-		return { success: true, detail: "PR merged (squash) and remote branch deleted." };
-	}
-
-	// Squash not allowed — try regular merge
+	// Try regular merge first (preserves per-commit history)
 	const mergeResult = deps.runCommand("gh", [
 		"pr", "merge", orchBranch, "--merge", "--delete-branch",
 	]);
@@ -694,9 +690,17 @@ export function mergePr(
 		return { success: true, detail: "PR merged and remote branch deleted." };
 	}
 
+	// Regular merge not allowed — try squash as fallback
+	const squashResult = deps.runCommand("gh", [
+		"pr", "merge", orchBranch, "--squash", "--delete-branch",
+	]);
+	if (squashResult.ok) {
+		return { success: true, detail: "PR merged (squash) and remote branch deleted." };
+	}
+
 	return {
 		success: false,
-		detail: `PR merge failed: ${mergeResult.stderr || squashResult.stderr}`,
+		detail: `PR merge failed: ${squashResult.stderr || mergeResult.stderr}`,
 	};
 }
 

--- a/extensions/tests/auto-integration.integration.test.ts
+++ b/extensions/tests/auto-integration.integration.test.ts
@@ -538,10 +538,10 @@ describe("11.x — pollPrCiStatus", () => {
 });
 
 describe("11.x — mergePr", () => {
-	it("11.7: tries squash merge first", () => {
+	it("11.7: tries regular merge first (preserves per-commit history)", () => {
 		const deps = makeMockCiDeps({
 			runCommand: (cmd, args) => {
-				if (args.includes("--squash")) {
+				if (args.includes("--merge")) {
 					return { ok: true, stdout: "Merged", stderr: "" };
 				}
 				return { ok: false, stdout: "", stderr: "not called" };
@@ -549,16 +549,16 @@ describe("11.x — mergePr", () => {
 		});
 		const result = mergePr("orch/test", deps);
 		expect(result.success).toBe(true);
-		expect(result.detail).toContain("squash");
+		expect(result.detail).toContain("PR merged");
 	});
 
-	it("11.8: falls back to regular merge if squash fails", () => {
+	it("11.8: falls back to squash if regular merge fails", () => {
 		const deps = makeMockCiDeps({
 			runCommand: (cmd, args) => {
-				if (args.includes("--squash")) {
-					return { ok: false, stdout: "", stderr: "squash not allowed" };
-				}
 				if (args.includes("--merge")) {
+					return { ok: false, stdout: "", stderr: "merge not allowed" };
+				}
+				if (args.includes("--squash")) {
 					return { ok: true, stdout: "Merged", stderr: "" };
 				}
 				return { ok: false, stdout: "", stderr: "unknown" };
@@ -566,7 +566,7 @@ describe("11.x — mergePr", () => {
 		});
 		const result = mergePr("orch/test", deps);
 		expect(result.success).toBe(true);
-		expect(result.detail).toContain("PR merged");
+		expect(result.detail).toContain("squash");
 	});
 
 	it("11.9: reports failure when both merge methods fail", () => {


### PR DESCRIPTION
Squash merging was silently dropping commits made by other agents between push and merge. Switches to regular merge (preserves per-commit history) with squash as fallback.

**Changes:**
- `AGENTS.md`: `--squash` → `--merge`
- `supervisor.ts mergePr()`: regular merge first, squash fallback
- Tests updated (11.7/11.8)

**Not a systemic taskplane issue** — merge agents in `merge.ts` already use regular git merge for lane→orch branch. Only affected our operator workflow and `/orch-integrate --pr`.