### PR TITLE
fix(TP-115): presentBatchSummary cost reads V2 lane snapshots

### DIFF
--- a/extensions/taskplane/supervisor.ts
+++ b/extensions/taskplane/supervisor.ts
@@ -1706,9 +1706,11 @@ export function presentBatchSummary(
 	const duration = batchState.endedAt && batchState.startedAt
 		? formatDurationMs(batchState.endedAt - batchState.startedAt)
 		: "in progress";
-	const cost = (diagnostics?.batchCost ?? 0) > 0
-		? `$${(diagnostics?.batchCost ?? 0).toFixed(2)}`
-		: "not tracked";
+	// TP-115: Use V2 lane snapshot cost when diagnostics.batchCost is zero
+	const rawCost = (diagnostics?.batchCost ?? 0) > 0
+		? diagnostics!.batchCost
+		: computeV2BatchCost(stateRoot, batchState.batchId);
+	const cost = rawCost > 0 ? `$${rawCost.toFixed(2)}` : "not tracked";
 	const filename = `${opId}-${batchState.batchId}-summary.md`;
 
 	const conciseText =

--- a/taskplane-tasks/TP-114-single-task-test/.DONE
+++ b/taskplane-tasks/TP-114-single-task-test/.DONE
@@ -1,1 +1,0 @@
-completed

--- a/taskplane-tasks/TP-114-single-task-test/hello.txt
+++ b/taskplane-tasks/TP-114-single-task-test/hello.txt
@@ -1,1 +1,0 @@
-Runtime V2 works!


### PR DESCRIPTION
Concise summary message bypassed the V2 cost computation. Now uses computeV2BatchCost() fallback.