### PR TITLE
Release v0.25.6

### DIFF
--- a/extensions/taskplane/execution.ts
+++ b/extensions/taskplane/execution.ts
@@ -10,7 +10,7 @@ import { userInfo } from "os";
 import { DONE_GRACE_MS, EXECUTION_POLL_INTERVAL_MS, ExecutionError, SESSION_SPAWN_RETRY_MAX } from "./types.ts";
 import type { AllocatedLane, AllocatedTask, DependencyGraph, LaneExecutionResult, LaneMonitorSnapshot, LaneTaskOutcome, LaneTaskStatus, MonitorState, MtimeTracker, OrchestratorConfig, ParsedTask, TaskMonitorSnapshot, WaveExecutionResult, WorkspaceConfig, ExecutionUnit, PacketPaths, RuntimeAgentId, RuntimeAgentRole, SupervisorAlertCallback } from "./types.ts";
 import { resolvePacketPaths, buildRuntimeAgentId } from "./types.ts";
-import { readRegistrySnapshot, readLaneSnapshot, isTerminalStatus, isProcessAlive, detectOrphans, markOrphansCrashed } from "./process-registry.ts";
+import { readRegistrySnapshot, readLaneSnapshot, isTerminalStatus, isProcessAlive, detectOrphans, markOrphansCrashed, buildRegistrySnapshot, writeRegistrySnapshot } from "./process-registry.ts";
 import { allocateLanes } from "./waves.ts";
 import { resolveOperatorId } from "./naming.ts";
 import { runGit } from "./git.ts";
@@ -1138,11 +1138,15 @@ export async function monitorLanes(
 				if (registry) {
 					const orphans = detectOrphans(registry);
 					if (orphans.length > 0) {
+						// Mark individual agent manifests as crashed
 						markOrphansCrashed(stateRootForRegistry ?? repoRoot, batchId, orphans);
-						// Refresh cache so this poll cycle sees the updated crashed status
-						setV2LivenessRegistryCache(
-							readRegistrySnapshot(stateRootForRegistry ?? repoRoot, batchId)
-						);
+						// Rebuild and write registry.json from the updated individual manifests.
+						// markOrphansCrashed only updates per-agent files; registry.json is a
+						// cached aggregate that must be explicitly rebuilt so readRegistrySnapshot()
+						// and the dashboard see the crashed status within this poll cycle.
+						const freshRegistry = buildRegistrySnapshot(stateRootForRegistry ?? repoRoot, batchId);
+						writeRegistrySnapshot(stateRootForRegistry ?? repoRoot, freshRegistry);
+						setV2LivenessRegistryCache(freshRegistry);
 					}
 				}
 			} catch {

--- a/extensions/taskplane/extension.ts
+++ b/extensions/taskplane/extension.ts
@@ -1920,8 +1920,9 @@ export default function (pi: ExtensionAPI) {
 		// "Discovery had fatal errors" on first /orch run after config creation.
 		// Skip if a batch is already active to avoid swapping config mid-run.
 		const _activePhase = orchBatchState.phase;
+		// Treat paused as active — config must not change for a resumable batch
 		const _isActiveBatch = _activePhase === "executing" || _activePhase === "launching"
-			|| _activePhase === "merging" || _activePhase === "planning";
+			|| _activePhase === "merging" || _activePhase === "planning" || _activePhase === "paused";
 		if (!_isActiveBatch) {
 			try {
 				// Build everything into temporaries first, then commit atomically

--- a/extensions/taskplane/path-resolver.ts
+++ b/extensions/taskplane/path-resolver.ts
@@ -188,11 +188,15 @@ export function resolveTaskplanePackageFile(repoRoot: string, relPath: string): 
 	candidates.push(join("/usr", "local", "lib", "node_modules", "taskplane", relPath));
 	candidates.push(join("/opt", "homebrew", "lib", "node_modules", "taskplane", relPath));
 
-	// 8. Peer of pi's package (look adjacent to pi's CLI entrypoint)
+	// 8. Peer of pi's package (look adjacent to pi's CLI entrypoint).
+	// pi is at: <npmRoot>/@mariozechner/pi-coding-agent/dist/cli.js
+	// so piPkgDir = <npmRoot>/@mariozechner/pi-coding-agent  (resolve up 2 levels from cli.js)
+	// then go up TWO more levels to reach <npmRoot>, then into taskplane/
 	try {
 		const piPath = process.argv[1] || "";
-		const piPkgDir = resolve(piPath, "..", "..");
-		candidates.push(join(piPkgDir, "..", "taskplane", relPath));
+		const piPkgDir = resolve(piPath, "..", ".."); // <npmRoot>/@mariozechner/pi-coding-agent
+		const npmRootFromPi = resolve(piPkgDir, "..", ".."); // <npmRoot>
+		candidates.push(join(npmRootFromPi, "taskplane", relPath));
 	} catch { /* ignore — process.argv[1] may be undefined in test contexts */ }
 
 	for (const candidate of candidates) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.25.5",
+  "version": "0.25.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.25.5",
+      "version": "0.25.6",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.25.5",
+  "version": "0.25.6",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Sage review follow-up for TP-157/158/159:
- TP-157: Fix peer fallback path (was resolving to `@mariozechner/taskplane` instead of `taskplane`)
- TP-158: Add `paused` to reload-skip phase check (resumable batch config must not change)
- TP-159: Rebuild+write registry.json after markOrphansCrashed so crashed status is visible within one poll cycle