### PR TITLE
Release v0.25.8

### DIFF
--- a/dashboard/server.cjs
+++ b/dashboard/server.cjs
@@ -1121,18 +1121,19 @@ function buildDashboardState() {
 
   // TP-164: Inject merge snapshot telemetry into the telemetry map so
   // `telemetry[sessionName]` resolves for the merge pane.
-  // Only inject when a JSONL-backed entry is absent or stale — the snapshot
-  // provides real-time tool-call / cost / context data even before the
-  // JSONL accumulator has accumulated enough events.
+  // Snapshots are the PRIMARY source for merge telemetry — merge agents don't
+  // write to .pi/telemetry/*.jsonl (the JSONL path is for lane workers only).
+  // Inject snapshot data when no JSONL-backed entry exists for this session.
   for (const snap of Object.values(runtimeMergeSnapshots)) {
     const key = snap.sessionName;
     if (!key) continue;
     const agent = snap.agent;
     if (!agent) continue;
-    // Only inject if there is no existing telemetry entry, or if the snapshot
-    // is more recent than the latest accumulator update.
+    // Only inject if there is no existing JSONL-backed telemetry entry.
+    // Merge agents don't emit to .pi/telemetry/, so existing will always be
+    // absent unless something else wrote to it — in that case defer to it.
     const existing = telemetry[key];
-    if (!existing || (snap.updatedAt && snap.updatedAt > (existing._updatedAt || 0))) {
+    if (!existing) {
       telemetry[key] = {
         inputTokens: agent.inputTokens || 0,
         outputTokens: agent.outputTokens || 0,

--- a/extensions/taskplane/merge.ts
+++ b/extensions/taskplane/merge.ts
@@ -557,6 +557,7 @@ export async function spawnMergeAgentV2(
 	stateRoot?: string,
 	agentRoot?: string,
 	batchId?: string,
+	waveIndex?: number,
 ): Promise<AgentHostResult> {
 	execLog("merge", sessionName, "spawning merge agent via Runtime V2 (direct agent-host)", {
 		mergeWorkDir,
@@ -617,6 +618,9 @@ export async function spawnMergeAgentV2(
 	// Derive the 1-indexed merge number from the session name
 	// (e.g. "orch-henry-merge-1" → 1, "orch-henry-merge-2" → 2).
 	const mergeNumberMatch = sessionName.match(/-merge-(\d+)$/);
+	if (!mergeNumberMatch) {
+		execLog("merge", sessionName, "warning: could not parse merge number from session name — defaulting to 1", { sessionName });
+	}
 	const mergeNumber = mergeNumberMatch ? parseInt(mergeNumberMatch[1], 10) : 1;
 	const mergeStartedAt = Date.now();
 	const mergeStateRoot = stateRoot ?? repoRoot;
@@ -644,7 +648,7 @@ export async function spawnMergeAgentV2(
 				batchId: bid,
 				mergeNumber,
 				sessionName,
-				waveIndex: 0,
+				waveIndex: waveIndex ?? 0,
 				status: "running",
 				agent: buildAgentSnap(tel, "running"),
 				updatedAt: Date.now(),
@@ -662,7 +666,7 @@ export async function spawnMergeAgentV2(
 			batchId: bid,
 			mergeNumber,
 			sessionName,
-			waveIndex: 0,
+			waveIndex: waveIndex ?? 0,
 			status: "running",
 			agent: buildAgentSnap({}, "running"),
 			updatedAt: Date.now(),
@@ -688,14 +692,27 @@ export async function spawnMergeAgentV2(
 		// Write terminal snapshot. Promise resolves for both successful and
 		// failed exits, so derive status from result fields rather than
 		// relying on .catch to handle failures.
-		const terminalStatus: RuntimeMergeSnapshot["status"] =
-			(result.killed || result.exitCode !== 0 || !result.agentEnded) ? "failed" : "complete";
+		// Determine terminal status. A clean post-success kill sets registry
+		// manifest to "exited" via killMergeAgentV2(name, true=cleanExit).
+		// Check the registry first so a successful-then-killed agent is shown
+		// as "complete" rather than "failed".
+		let terminalStatus: RuntimeMergeSnapshot["status"] = "complete";
+		try {
+			const manifest = readManifest(mergeStateRoot, bid, sessionName as any);
+			if (manifest?.status === "exited") {
+				terminalStatus = "complete";
+			} else if (result.exitCode !== 0 || !result.agentEnded) {
+				terminalStatus = "failed";
+			}
+		} catch {
+			if (result.exitCode !== 0 || !result.agentEnded) terminalStatus = "failed";
+		}
 		try {
 			const snap: RuntimeMergeSnapshot = {
 				batchId: bid,
 				mergeNumber,
 				sessionName,
-				waveIndex: 0,
+				waveIndex: waveIndex ?? 0,
 				status: terminalStatus,
 				agent: buildAgentSnap(result, terminalStatus === "complete" ? "exited" : "crashed"),
 				updatedAt: Date.now(),
@@ -711,7 +728,7 @@ export async function spawnMergeAgentV2(
 				batchId: bid,
 				mergeNumber,
 				sessionName,
-				waveIndex: 0,
+				waveIndex: waveIndex ?? 0,
 				status: "failed",
 				agent: buildAgentSnap({}, "crashed"),
 				updatedAt: Date.now(),
@@ -1565,10 +1582,10 @@ export async function mergeWave(
 						// Re-spawn merge agent for the retry.
 						// Kill previous V2 agent handle to prevent orphan/duplicate.
 						killMergeAgentV2(sessionName);
-						await spawnMergeAgentV2(sessionName, repoRoot, mergeWorkDir, requestFilePath, config, stateRoot, agentRoot, batchId);
+						await spawnMergeAgentV2(sessionName, repoRoot, mergeWorkDir, requestFilePath, config, stateRoot, agentRoot, batchId, waveIndex);
 					} else {
 						// First attempt: spawn merge agent (Runtime V2)
-						await spawnMergeAgentV2(sessionName, repoRoot, mergeWorkDir, requestFilePath, config, stateRoot, agentRoot, batchId);
+						await spawnMergeAgentV2(sessionName, repoRoot, mergeWorkDir, requestFilePath, config, stateRoot, agentRoot, batchId, waveIndex);
 					}
 
 					try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.25.7",
+  "version": "0.25.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.25.7",
+      "version": "0.25.8",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.25.7",
+  "version": "0.25.8",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Sage review follow-up for TP-164 merge agent telemetry:
- Fix telemetry precedence: snapshots now primary source (no JSONL override logic)
- Fix terminal status: clean-exit kill after successful merge shows 'complete' not 'failed'
- Add waveIndex param to spawnMergeAgentV2, thread through to snapshots
- Log warning when merge session name doesn't match expected pattern