### PR TITLE
release: v0.28.4 — settings TUI description fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.4] - 2026-04-20
+
+### Fixed
+
+- **Settings TUI: Agent Extensions description:** Shows "Toggle extensions per
+  agent type" instead of generic "Read-only collection/record fields" label.
+
 ## [0.28.3] - 2026-04-20
 
 ### New

--- a/extensions/taskplane/settings-tui.ts
+++ b/extensions/taskplane/settings-tui.ts
@@ -1211,9 +1211,11 @@ async function showSectionSelectorLoop(
 		const sectionItems: SelectItem[] = SECTIONS.map((section, i) => ({
 			value: String(i),
 			label: section.name,
-			description: section.readOnly
-				? "Read-only collection/record fields"
-				: `${section.fields.length} setting${section.fields.length === 1 ? "" : "s"}`,
+			description: section.name === "Agent Extensions"
+				? "Toggle extensions per agent type"
+				: section.readOnly
+					? "Read-only collection/record fields"
+					: `${section.fields.length} setting${section.fields.length === 1 ? "" : "s"}`,
 		}));
 
 		const selectedSection = await ctx.ui.custom<string | null>((tui, theme, _kb, done) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.28.3",
+      "version": "0.28.4",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Patch fix: Agent Extensions section in `/taskplane-settings` now shows "Toggle extensions per agent type" instead of generic "Read-only collection/record fields" label.