### PR TITLE
fix: wire worker model from preferences through to lane runner

### DIFF
--- a/extensions/taskplane/config-loader.ts
+++ b/extensions/taskplane/config-loader.ts
@@ -21,30 +21,34 @@
  * @module config/loader
  */
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync } from "fs";
-import { join } from "path";
-import { homedir } from "os";
-import { parse as yamlParse } from "yaml";
-import { resolvePointer, loadWorkspaceConfig } from "./workspace.ts";
-import type { PointerResolution } from "./types.ts";
-
 import {
-	CONFIG_VERSION,
-	PROJECT_CONFIG_FILENAME,
-	DEFAULT_PROJECT_CONFIG,
-	DEFAULT_GLOBAL_PREFERENCES,
-	DEFAULT_BOOTSTRAP_GLOBAL_PREFERENCES,
-	GLOBAL_PREFERENCES_FILENAME,
-	GLOBAL_PREFERENCES_SUBDIR,
-} from "./config-schema.ts";
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	writeFileSync,
+} from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { parse as yamlParse } from "yaml";
 import type {
+	GlobalPreferences,
+	OrchestratorSection,
 	TaskplaneConfig,
 	TaskRunnerSection,
-	OrchestratorSection,
 	WorkspaceSectionConfig,
-	GlobalPreferences,
 } from "./config-schema.ts";
-
+import {
+	CONFIG_VERSION,
+	DEFAULT_BOOTSTRAP_GLOBAL_PREFERENCES,
+	DEFAULT_GLOBAL_PREFERENCES,
+	DEFAULT_PROJECT_CONFIG,
+	GLOBAL_PREFERENCES_FILENAME,
+	GLOBAL_PREFERENCES_SUBDIR,
+	PROJECT_CONFIG_FILENAME,
+} from "./config-schema.ts";
+import type { PointerResolution } from "./types.ts";
+import { loadWorkspaceConfig, resolvePointer } from "./workspace.ts";
 
 // ── Error Types ──────────────────────────────────────────────────────
 
@@ -72,14 +76,12 @@ export class ConfigLoadError extends Error {
 	}
 }
 
-
 // ── Deep Clone Helper ────────────────────────────────────────────────
 
 /** Deep clone a config object to avoid cross-call mutation. */
 function deepClone<T>(obj: T): T {
 	return JSON.parse(JSON.stringify(obj));
 }
-
 
 // ── Deep Merge Helper ────────────────────────────────────────────────
 
@@ -88,7 +90,10 @@ function deepClone<T>(obj: T): T {
  * Only merges plain objects (not arrays, dates, etc).
  * Returns `target` for chaining.
  */
-function deepMerge<T extends Record<string, any>>(target: T, source: Record<string, any>): T {
+function deepMerge<T extends Record<string, any>>(
+	target: T,
+	source: Record<string, any>,
+): T {
 	for (const key of Object.keys(source)) {
 		const srcVal = source[key];
 		const tgtVal = (target as any)[key];
@@ -111,7 +116,7 @@ function deepMerge<T extends Record<string, any>>(target: T, source: Record<stri
 }
 
 function hasOwn(obj: unknown, key: string): boolean {
-	return !!obj && typeof obj === "object" && Object.prototype.hasOwnProperty.call(obj, key);
+	return !!obj && typeof obj === "object" && Object.hasOwn(obj, key);
 }
 
 function normalizeInheritAlias(value: string): string {
@@ -137,8 +142,14 @@ function normalizeInheritanceAliases(config: TaskplaneConfig): void {
 	normalizeField(config.taskRunner.reviewer as Record<string, any>, "thinking");
 	normalizeField(config.orchestrator.merge as Record<string, any>, "model");
 	normalizeField(config.orchestrator.merge as Record<string, any>, "thinking");
-	normalizeField(config.orchestrator.supervisor as Record<string, any>, "model");
-	normalizeField(config.taskRunner.qualityGate as Record<string, any>, "reviewModel");
+	normalizeField(
+		config.orchestrator.supervisor as Record<string, any>,
+		"model",
+	);
+	normalizeField(
+		config.taskRunner.qualityGate as Record<string, any>,
+		"reviewModel",
+	);
 }
 
 // throwLegacyFieldError removed — replaced by auto-migration functions that fix config in-place
@@ -159,29 +170,40 @@ let _projectMigrationDone = false;
  *
  * @returns true if any migrations were applied
  */
-function migrateGlobalPreferences(raw: Record<string, any>, prefsPath: string): boolean {
+function migrateGlobalPreferences(
+	raw: Record<string, any>,
+	prefsPath: string,
+): boolean {
 	let migrated = false;
 	if (hasOwn(raw, "tmuxPrefix")) {
 		if (!hasOwn(raw, "sessionPrefix") || raw.sessionPrefix === undefined) {
 			raw.sessionPrefix = raw.tmuxPrefix;
 		}
 		delete raw.tmuxPrefix;
-		console.error(`[taskplane] Auto-migrated global preference: tmuxPrefix → sessionPrefix`);
+		console.error(
+			`[taskplane] Auto-migrated global preference: tmuxPrefix → sessionPrefix`,
+		);
 		migrated = true;
 	}
 	if (raw.spawnMode === "tmux") {
 		raw.spawnMode = "subprocess";
-		console.error(`[taskplane] Auto-migrated global preference: spawnMode "tmux" → "subprocess"`);
+		console.error(
+			`[taskplane] Auto-migrated global preference: spawnMode "tmux" → "subprocess"`,
+		);
 		migrated = true;
 	}
 	if (raw.orchestrator?.orchestrator?.spawnMode === "tmux") {
 		raw.orchestrator.orchestrator.spawnMode = "subprocess";
-		console.error(`[taskplane] Auto-migrated global preference: orchestrator.orchestrator.spawnMode "tmux" → "subprocess"`);
+		console.error(
+			`[taskplane] Auto-migrated global preference: orchestrator.orchestrator.spawnMode "tmux" → "subprocess"`,
+		);
 		migrated = true;
 	}
 	if (raw.taskRunner?.worker?.spawnMode === "tmux") {
 		raw.taskRunner.worker.spawnMode = "subprocess";
-		console.error(`[taskplane] Auto-migrated global preference: taskRunner.worker.spawnMode "tmux" → "subprocess"`);
+		console.error(
+			`[taskplane] Auto-migrated global preference: taskRunner.worker.spawnMode "tmux" → "subprocess"`,
+		);
 		migrated = true;
 	}
 	if (migrated) {
@@ -191,15 +213,18 @@ function migrateGlobalPreferences(raw: Record<string, any>, prefsPath: string): 
 			renameSync(tmpPath, prefsPath);
 			console.error(`[taskplane] Preferences file updated: ${prefsPath}`);
 		} catch (err) {
-			console.error(`[taskplane] Warning: could not persist preferences migration to disk: ${err instanceof Error ? err.message : err}`);
+			console.error(
+				`[taskplane] Warning: could not persist preferences migration to disk: ${err instanceof Error ? err.message : err}`,
+			);
 		}
 	}
 	return migrated;
 }
 
 /** Reset migration guard (for testing). @internal */
-export function _resetMigrationGuard(): void { _projectMigrationDone = false; }
-
+export function _resetMigrationGuard(): void {
+	_projectMigrationDone = false;
+}
 
 // ── YAML snake_case → camelCase Mapping ──────────────────────────────
 
@@ -300,18 +325,22 @@ function mapTaskRunnerYaml(raw: any): Partial<TaskRunnerSection> {
 
 	// Record sections with structural inner keys
 	if (raw.task_areas) result.taskAreas = convertRecordSection(raw.task_areas);
-	if (raw.standards_overrides) result.standardsOverrides = convertRecordSection(raw.standards_overrides);
+	if (raw.standards_overrides)
+		result.standardsOverrides = convertRecordSection(raw.standards_overrides);
 
 	// Flat record sections (keys are identifiers, values are strings)
-	if (raw.reference_docs) result.referenceDocs = preserveRecord(raw.reference_docs);
-	if (raw.self_doc_targets) result.selfDocTargets = preserveRecord(raw.self_doc_targets);
+	if (raw.reference_docs)
+		result.referenceDocs = preserveRecord(raw.reference_docs);
+	if (raw.self_doc_targets)
+		result.selfDocTargets = preserveRecord(raw.self_doc_targets);
 
 	// Array sections (preserve verbatim)
 	if (raw.never_load) result.neverLoad = [...raw.never_load];
 	if (raw.protected_docs) result.protectedDocs = [...raw.protected_docs];
 
 	// Quality gate (structural — all keys are schema-defined)
-	if (raw.quality_gate) result.qualityGate = convertStructuralKeys(raw.quality_gate);
+	if (raw.quality_gate)
+		result.qualityGate = convertStructuralKeys(raw.quality_gate);
 
 	// Model fallback (scalar — "inherit" or "fail")
 	if (raw.model_fallback) result.modelFallback = raw.model_fallback;
@@ -331,8 +360,10 @@ function mapOrchestratorYaml(raw: any): Partial<OrchestratorSection> {
 	const result: any = {};
 
 	// Structural sections
-	if (raw.orchestrator) result.orchestrator = convertStructuralKeys(raw.orchestrator);
-	if (raw.dependencies) result.dependencies = convertStructuralKeys(raw.dependencies);
+	if (raw.orchestrator)
+		result.orchestrator = convertStructuralKeys(raw.orchestrator);
+	if (raw.dependencies)
+		result.dependencies = convertStructuralKeys(raw.dependencies);
 	if (raw.merge) result.merge = convertStructuralKeys(raw.merge);
 	if (raw.failure) result.failure = convertStructuralKeys(raw.failure);
 	if (raw.monitoring) result.monitoring = convertStructuralKeys(raw.monitoring);
@@ -340,20 +371,27 @@ function mapOrchestratorYaml(raw: any): Partial<OrchestratorSection> {
 	// assignment: strategy is structural, size_weights is a user-defined record
 	if (raw.assignment) {
 		result.assignment = {};
-		if (raw.assignment.strategy !== undefined) result.assignment.strategy = raw.assignment.strategy;
-		if (raw.assignment.size_weights) result.assignment.sizeWeights = preserveRecord(raw.assignment.size_weights);
+		if (raw.assignment.strategy !== undefined)
+			result.assignment.strategy = raw.assignment.strategy;
+		if (raw.assignment.size_weights)
+			result.assignment.sizeWeights = preserveRecord(
+				raw.assignment.size_weights,
+			);
 	}
 
 	// pre_warm: auto_detect is structural, commands is user-defined, always is array
 	if (raw.pre_warm) {
 		result.preWarm = {};
-		if (raw.pre_warm.auto_detect !== undefined) result.preWarm.autoDetect = raw.pre_warm.auto_detect;
-		if (raw.pre_warm.commands) result.preWarm.commands = preserveRecord(raw.pre_warm.commands);
+		if (raw.pre_warm.auto_detect !== undefined)
+			result.preWarm.autoDetect = raw.pre_warm.auto_detect;
+		if (raw.pre_warm.commands)
+			result.preWarm.commands = preserveRecord(raw.pre_warm.commands);
 		if (raw.pre_warm.always) result.preWarm.always = [...raw.pre_warm.always];
 	}
 
 	// verification: all keys are structural (TP-032)
-	if (raw.verification) result.verification = convertStructuralKeys(raw.verification);
+	if (raw.verification)
+		result.verification = convertStructuralKeys(raw.verification);
 
 	// supervisor: all keys are structural (TP-041)
 	if (raw.supervisor) result.supervisor = convertStructuralKeys(raw.supervisor);
@@ -371,7 +409,11 @@ function normalizeWorkspaceSection(
 	rawWorkspace: any,
 	sourcePath: string,
 ): WorkspaceSectionConfig | undefined {
-	if (!rawWorkspace || typeof rawWorkspace !== "object" || Array.isArray(rawWorkspace)) {
+	if (
+		!rawWorkspace ||
+		typeof rawWorkspace !== "object" ||
+		Array.isArray(rawWorkspace)
+	) {
 		return undefined;
 	}
 
@@ -381,26 +423,42 @@ function normalizeWorkspaceSection(
 	}
 
 	const rawRouting = rawWorkspace.routing;
-	if (!rawRouting || typeof rawRouting !== "object" || Array.isArray(rawRouting)) {
+	if (
+		!rawRouting ||
+		typeof rawRouting !== "object" ||
+		Array.isArray(rawRouting)
+	) {
 		return undefined;
 	}
 
 	const repos: WorkspaceSectionConfig["repos"] = {};
-	for (const [repoId, repoVal] of Object.entries(rawRepos as Record<string, any>)) {
-		if (!repoVal || typeof repoVal !== "object" || Array.isArray(repoVal)) continue;
+	for (const [repoId, repoVal] of Object.entries(
+		rawRepos as Record<string, any>,
+	)) {
+		if (!repoVal || typeof repoVal !== "object" || Array.isArray(repoVal))
+			continue;
 		const repoObj = repoVal as Record<string, any>;
-		if (typeof repoObj.path !== "string" || repoObj.path.trim() === "") continue;
+		if (typeof repoObj.path !== "string" || repoObj.path.trim() === "")
+			continue;
 		repos[repoId] = {
 			path: repoObj.path,
-			...(typeof repoObj.defaultBranch === "string" && repoObj.defaultBranch.trim()
+			...(typeof repoObj.defaultBranch === "string" &&
+			repoObj.defaultBranch.trim()
 				? { defaultBranch: repoObj.defaultBranch }
 				: {}),
 		};
 	}
 
-	const defaultRepo = typeof rawRouting.defaultRepo === "string" ? rawRouting.defaultRepo.trim() : "";
-	const tasksRoot = typeof rawRouting.tasksRoot === "string" ? rawRouting.tasksRoot.trim() : "";
-	let taskPacketRepo = typeof rawRouting.taskPacketRepo === "string" ? rawRouting.taskPacketRepo.trim() : "";
+	const defaultRepo =
+		typeof rawRouting.defaultRepo === "string"
+			? rawRouting.defaultRepo.trim()
+			: "";
+	const tasksRoot =
+		typeof rawRouting.tasksRoot === "string" ? rawRouting.tasksRoot.trim() : "";
+	let taskPacketRepo =
+		typeof rawRouting.taskPacketRepo === "string"
+			? rawRouting.taskPacketRepo.trim()
+			: "";
 
 	if (!taskPacketRepo && defaultRepo) {
 		taskPacketRepo = defaultRepo;
@@ -425,7 +483,6 @@ function normalizeWorkspaceSection(
 		},
 	};
 }
-
 
 // ── Config File Path Resolution ──────────────────────────────────────
 
@@ -490,7 +547,7 @@ function loadJsonConfig(configRoot: string): Partial<TaskplaneConfig> | null {
 		throw new ConfigLoadError(
 			"CONFIG_VERSION_MISSING",
 			`${jsonPath} is missing required field "configVersion". ` +
-			`Expected configVersion: ${CONFIG_VERSION}.`,
+				`Expected configVersion: ${CONFIG_VERSION}.`,
 		);
 	}
 
@@ -498,19 +555,30 @@ function loadJsonConfig(configRoot: string): Partial<TaskplaneConfig> | null {
 		throw new ConfigLoadError(
 			"CONFIG_VERSION_UNSUPPORTED",
 			`${jsonPath} has configVersion ${parsed.configVersion}, but this version of Taskplane ` +
-			`only supports configVersion ${CONFIG_VERSION}. Please upgrade Taskplane.`,
+				`only supports configVersion ${CONFIG_VERSION}. Please upgrade Taskplane.`,
 		);
 	}
 
 	const overrides: Partial<TaskplaneConfig> = {};
-	if (parsed.taskRunner && typeof parsed.taskRunner === "object" && !Array.isArray(parsed.taskRunner)) {
+	if (
+		parsed.taskRunner &&
+		typeof parsed.taskRunner === "object" &&
+		!Array.isArray(parsed.taskRunner)
+	) {
 		overrides.taskRunner = deepClone(parsed.taskRunner);
 	}
-	if (parsed.orchestrator && typeof parsed.orchestrator === "object" && !Array.isArray(parsed.orchestrator)) {
+	if (
+		parsed.orchestrator &&
+		typeof parsed.orchestrator === "object" &&
+		!Array.isArray(parsed.orchestrator)
+	) {
 		overrides.orchestrator = deepClone(parsed.orchestrator);
 	}
 	if (parsed.workspace) {
-		const normalizedWorkspace = normalizeWorkspaceSection(parsed.workspace, jsonPath);
+		const normalizedWorkspace = normalizeWorkspaceSection(
+			parsed.workspace,
+			jsonPath,
+		);
 		if (normalizedWorkspace) {
 			overrides.workspace = normalizedWorkspace;
 		}
@@ -518,7 +586,6 @@ function loadJsonConfig(configRoot: string): Partial<TaskplaneConfig> | null {
 
 	return overrides;
 }
-
 
 // ── YAML Loading ─────────────────────────────────────────────────────
 
@@ -548,7 +615,8 @@ function loadTaskRunnerYaml(configRoot: string): Partial<TaskRunnerSection> {
 		if (mapped.taskAreas) {
 			for (const area of Object.values(mapped.taskAreas)) {
 				if (area.repoId !== undefined) {
-					const trimmed = typeof area.repoId === "string" ? area.repoId.trim() : "";
+					const trimmed =
+						typeof area.repoId === "string" ? area.repoId.trim() : "";
 					if (trimmed) {
 						area.repoId = trimmed;
 					} else {
@@ -573,7 +641,9 @@ function loadTaskRunnerYaml(configRoot: string): Partial<TaskRunnerSection> {
  * Uses section-aware mapping that preserves user-defined record keys.
  * Returns sparse overrides (empty object when missing/malformed).
  */
-function loadOrchestratorYaml(configRoot: string): Partial<OrchestratorSection> {
+function loadOrchestratorYaml(
+	configRoot: string,
+): Partial<OrchestratorSection> {
 	const yamlPath = resolveConfigFilePath(configRoot, "task-orchestrator.yaml");
 	if (!existsSync(yamlPath)) return {};
 
@@ -596,8 +666,13 @@ function loadOrchestratorYaml(configRoot: string): Partial<OrchestratorSection> 
  * section is not present. Malformed files are ignored here — strict validation
  * still happens in workspace runtime loading (`workspace.ts`).
  */
-function loadWorkspaceYaml(configRoot: string): WorkspaceSectionConfig | undefined {
-	const yamlPath = resolveConfigFilePath(configRoot, "taskplane-workspace.yaml");
+function loadWorkspaceYaml(
+	configRoot: string,
+): WorkspaceSectionConfig | undefined {
+	const yamlPath = resolveConfigFilePath(
+		configRoot,
+		"taskplane-workspace.yaml",
+	);
 	if (!existsSync(yamlPath)) return undefined;
 
 	try {
@@ -611,7 +686,6 @@ function loadWorkspaceYaml(configRoot: string): WorkspaceSectionConfig | undefin
 		return undefined;
 	}
 }
-
 
 // ── Global Preferences (Layer 2) ─────────────────────────────────────
 
@@ -628,9 +702,19 @@ function loadWorkspaceYaml(configRoot: string): WorkspaceSectionConfig | undefin
 export function resolveGlobalPreferencesPath(): string {
 	const agentDir = process.env.PI_CODING_AGENT_DIR;
 	if (agentDir) {
-		return join(agentDir, GLOBAL_PREFERENCES_SUBDIR, GLOBAL_PREFERENCES_FILENAME);
+		return join(
+			agentDir,
+			GLOBAL_PREFERENCES_SUBDIR,
+			GLOBAL_PREFERENCES_FILENAME,
+		);
 	}
-	return join(homedir(), ".pi", "agent", GLOBAL_PREFERENCES_SUBDIR, GLOBAL_PREFERENCES_FILENAME);
+	return join(
+		homedir(),
+		".pi",
+		"agent",
+		GLOBAL_PREFERENCES_SUBDIR,
+		GLOBAL_PREFERENCES_FILENAME,
+	);
 }
 
 /** Result envelope for global preferences loading. */
@@ -640,7 +724,10 @@ export interface GlobalPreferencesLoadResult {
 }
 
 /** Persist preferences JSON atomically (temp file + rename). */
-function writePreferencesAtomically(prefsPath: string, prefs: GlobalPreferences): void {
+function writePreferencesAtomically(
+	prefsPath: string,
+	prefs: GlobalPreferences,
+): void {
 	const tmpPath = `${prefsPath}.tmp-${process.pid}-${Date.now()}`;
 	writeFileSync(tmpPath, JSON.stringify(prefs, null, 2) + "\n", "utf-8");
 	renameSync(tmpPath, prefsPath);
@@ -683,7 +770,10 @@ export function loadGlobalPreferencesWithMeta(): GlobalPreferencesLoadResult {
 	try {
 		raw = readFileSync(prefsPath, "utf-8");
 	} catch {
-		return { preferences: deepClone(DEFAULT_GLOBAL_PREFERENCES), wasBootstrapped: false };
+		return {
+			preferences: deepClone(DEFAULT_GLOBAL_PREFERENCES),
+			wasBootstrapped: false,
+		};
 	}
 
 	if (!raw.trim()) {
@@ -703,7 +793,12 @@ export function loadGlobalPreferencesWithMeta(): GlobalPreferencesLoadResult {
 		};
 	}
 
-	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed) || Object.keys(parsed).length === 0) {
+	if (
+		!parsed ||
+		typeof parsed !== "object" ||
+		Array.isArray(parsed) ||
+		Object.keys(parsed).length === 0
+	) {
 		return {
 			preferences: bootstrapGlobalPreferencesFile(prefsPath),
 			wasBootstrapped: true,
@@ -730,7 +825,9 @@ export function loadGlobalPreferences(): GlobalPreferences {
  * Unknown keys are silently dropped — this is the Layer 2 boundary guardrail.
  */
 function normalizePreferenceThinkingMode(value: unknown): string {
-	const cleaned = String(value ?? "").trim().toLowerCase();
+	const cleaned = String(value ?? "")
+		.trim()
+		.toLowerCase();
 	if (!cleaned || cleaned === "inherit") return "";
 	if (cleaned === "on") return "high";
 	if (["off", "minimal", "low", "medium", "high", "xhigh"].includes(cleaned)) {
@@ -739,32 +836,58 @@ function normalizePreferenceThinkingMode(value: unknown): string {
 	return "";
 }
 
-function extractInitAgentDefaults(rawInitDefaults: unknown): GlobalPreferences["initAgentDefaults"] | undefined {
-	if (!rawInitDefaults || typeof rawInitDefaults !== "object" || Array.isArray(rawInitDefaults)) {
+function extractInitAgentDefaults(
+	rawInitDefaults: unknown,
+): GlobalPreferences["initAgentDefaults"] | undefined {
+	if (
+		!rawInitDefaults ||
+		typeof rawInitDefaults !== "object" ||
+		Array.isArray(rawInitDefaults)
+	) {
 		return undefined;
 	}
 
 	const raw = rawInitDefaults as Record<string, unknown>;
 	const extracted: NonNullable<GlobalPreferences["initAgentDefaults"]> = {};
 
-	if (typeof raw.workerModel === "string") extracted.workerModel = raw.workerModel;
-	if (typeof raw.reviewerModel === "string") extracted.reviewerModel = raw.reviewerModel;
+	if (typeof raw.workerModel === "string")
+		extracted.workerModel = raw.workerModel;
+	if (typeof raw.reviewerModel === "string")
+		extracted.reviewerModel = raw.reviewerModel;
 	if (typeof raw.mergeModel === "string") extracted.mergeModel = raw.mergeModel;
-	if (raw.workerThinking !== undefined) extracted.workerThinking = normalizePreferenceThinkingMode(raw.workerThinking);
-	if (raw.reviewerThinking !== undefined) extracted.reviewerThinking = normalizePreferenceThinkingMode(raw.reviewerThinking);
-	if (raw.mergeThinking !== undefined) extracted.mergeThinking = normalizePreferenceThinkingMode(raw.mergeThinking);
+	if (raw.workerThinking !== undefined)
+		extracted.workerThinking = normalizePreferenceThinkingMode(
+			raw.workerThinking,
+		);
+	if (raw.reviewerThinking !== undefined)
+		extracted.reviewerThinking = normalizePreferenceThinkingMode(
+			raw.reviewerThinking,
+		);
+	if (raw.mergeThinking !== undefined)
+		extracted.mergeThinking = normalizePreferenceThinkingMode(
+			raw.mergeThinking,
+		);
 
 	return Object.keys(extracted).length > 0 ? extracted : undefined;
 }
 
-function extractConfigOverrideSection(rawSection: unknown): Record<string, any> | undefined {
-	if (!rawSection || typeof rawSection !== "object" || Array.isArray(rawSection)) {
+function extractConfigOverrideSection(
+	rawSection: unknown,
+): Record<string, any> | undefined {
+	if (
+		!rawSection ||
+		typeof rawSection !== "object" ||
+		Array.isArray(rawSection)
+	) {
 		return undefined;
 	}
 	return deepClone(rawSection as Record<string, any>);
 }
 
-function extractAllowlistedPreferences(raw: Record<string, any>, prefsPath: string): GlobalPreferences {
+function extractAllowlistedPreferences(
+	raw: Record<string, any>,
+	prefsPath: string,
+): GlobalPreferences {
 	migrateGlobalPreferences(raw, prefsPath);
 
 	const prefs: GlobalPreferences = {};
@@ -776,7 +899,8 @@ function extractAllowlistedPreferences(raw: Record<string, any>, prefsPath: stri
 
 	const orchestratorOverrides = extractConfigOverrideSection(raw.orchestrator);
 	if (orchestratorOverrides) {
-		prefs.orchestrator = orchestratorOverrides as GlobalPreferences["orchestrator"];
+		prefs.orchestrator =
+			orchestratorOverrides as GlobalPreferences["orchestrator"];
 	}
 
 	const workspaceOverrides = extractConfigOverrideSection(raw.workspace);
@@ -793,13 +917,19 @@ function extractAllowlistedPreferences(raw: Record<string, any>, prefsPath: stri
 		prefs.spawnMode = "subprocess";
 	}
 	if (typeof raw.workerModel === "string") prefs.workerModel = raw.workerModel;
-	if (typeof raw.reviewerModel === "string") prefs.reviewerModel = raw.reviewerModel;
+	if (typeof raw.reviewerModel === "string")
+		prefs.reviewerModel = raw.reviewerModel;
 	if (typeof raw.mergeModel === "string") prefs.mergeModel = raw.mergeModel;
-	if (typeof raw.mergeThinking === "string") prefs.mergeThinking = raw.mergeThinking;
-	if (typeof raw.supervisorModel === "string") prefs.supervisorModel = raw.supervisorModel;
+	if (typeof raw.mergeThinking === "string")
+		prefs.mergeThinking = raw.mergeThinking;
+	if (typeof raw.supervisorModel === "string")
+		prefs.supervisorModel = raw.supervisorModel;
 
 	// Preferences-only fields (intentionally not merged into runtime config)
-	if (typeof raw.dashboardPort === "number" && Number.isFinite(raw.dashboardPort)) {
+	if (
+		typeof raw.dashboardPort === "number" &&
+		Number.isFinite(raw.dashboardPort)
+	) {
 		prefs.dashboardPort = raw.dashboardPort;
 	}
 	const initAgentDefaults = extractInitAgentDefaults(raw.initAgentDefaults);
@@ -821,52 +951,87 @@ function extractAllowlistedPreferences(raw: Record<string, any>, prefsPath: stri
  * Preferences-only fields (`dashboardPort`, `initAgentDefaults`) are preserved
  * in `GlobalPreferences` but intentionally not merged into runtime config.
  */
-export function applyGlobalPreferences(config: TaskplaneConfig, prefs: GlobalPreferences): TaskplaneConfig {
+export function applyGlobalPreferences(
+	config: TaskplaneConfig,
+	prefs: GlobalPreferences,
+): TaskplaneConfig {
 	// Helper: only apply non-empty string values
 	const applyStr = (val: string | undefined, setter: (v: string) => void) => {
 		if (val !== undefined && val !== "") setter(val);
 	};
 
 	// 1) Legacy flat aliases
-	applyStr(prefs.operatorId, (v) => { config.orchestrator.orchestrator.operatorId = v; });
-	applyStr(prefs.sessionPrefix, (v) => { config.orchestrator.orchestrator.sessionPrefix = v; });
-	applyStr(prefs.workerModel, (v) => { config.taskRunner.worker.model = v; });
-	applyStr(prefs.reviewerModel, (v) => { config.taskRunner.reviewer.model = v; });
-	applyStr(prefs.mergeModel, (v) => { config.orchestrator.merge.model = v; });
-	applyStr(prefs.mergeThinking, (v) => { config.orchestrator.merge.thinking = v; });
-	applyStr(prefs.supervisorModel, (v) => { config.orchestrator.supervisor.model = v; });
+	applyStr(prefs.operatorId, (v) => {
+		config.orchestrator.orchestrator.operatorId = v;
+	});
+	applyStr(prefs.sessionPrefix, (v) => {
+		config.orchestrator.orchestrator.sessionPrefix = v;
+	});
+	applyStr(prefs.workerModel, (v) => {
+		config.taskRunner.worker.model = v;
+	});
+	applyStr(prefs.reviewerModel, (v) => {
+		config.taskRunner.reviewer.model = v;
+	});
+	applyStr(prefs.mergeModel, (v) => {
+		config.orchestrator.merge.model = v;
+	});
+	applyStr(prefs.mergeThinking, (v) => {
+		config.orchestrator.merge.thinking = v;
+	});
+	applyStr(prefs.supervisorModel, (v) => {
+		config.orchestrator.supervisor.model = v;
+	});
 
 	// spawnMode: enum — apply if defined (not a string-empty check)
 	if (prefs.spawnMode !== undefined) {
 		if (prefs.spawnMode === "tmux") {
 			prefs.spawnMode = "subprocess";
-			console.error(`[taskplane] Auto-migrated runtime preference: spawnMode "tmux" → "subprocess"`);
+			console.error(
+				`[taskplane] Auto-migrated runtime preference: spawnMode "tmux" → "subprocess"`,
+			);
 		}
 		config.orchestrator.orchestrator.spawnMode = prefs.spawnMode;
 	}
 
 	// 2) Config-shaped nested overrides
 	if (prefs.taskRunner) {
-		deepMerge(config.taskRunner as Record<string, any>, prefs.taskRunner as Record<string, any>);
+		deepMerge(
+			config.taskRunner as Record<string, any>,
+			prefs.taskRunner as Record<string, any>,
+		);
 	}
 	if (prefs.orchestrator) {
-		deepMerge(config.orchestrator as Record<string, any>, prefs.orchestrator as Record<string, any>);
+		deepMerge(
+			config.orchestrator as Record<string, any>,
+			prefs.orchestrator as Record<string, any>,
+		);
 	}
 	if (prefs.workspace) {
 		if (!config.workspace || typeof config.workspace !== "object") {
 			config.workspace = {} as TaskplaneConfig["workspace"];
 		}
-		deepMerge(config.workspace as Record<string, any>, prefs.workspace as Record<string, any>);
+		deepMerge(
+			config.workspace as Record<string, any>,
+			prefs.workspace as Record<string, any>,
+		);
 	}
 
 	// Runtime safety: nested legacy values may arrive through config-shaped overrides.
-	if ((config.orchestrator.orchestrator as Record<string, any>).spawnMode === "tmux") {
+	if (
+		(config.orchestrator.orchestrator as Record<string, any>).spawnMode ===
+		"tmux"
+	) {
 		config.orchestrator.orchestrator.spawnMode = "subprocess";
-		console.error(`[taskplane] Auto-migrated runtime global preference: orchestrator.orchestrator.spawnMode "tmux" → "subprocess"`);
+		console.error(
+			`[taskplane] Auto-migrated runtime global preference: orchestrator.orchestrator.spawnMode "tmux" → "subprocess"`,
+		);
 	}
 	if ((config.taskRunner.worker as Record<string, any>).spawnMode === "tmux") {
 		config.taskRunner.worker.spawnMode = "subprocess";
-		console.error(`[taskplane] Auto-migrated runtime global preference: taskRunner.worker.spawnMode "tmux" → "subprocess"`);
+		console.error(
+			`[taskplane] Auto-migrated runtime global preference: taskRunner.worker.spawnMode "tmux" → "subprocess"`,
+		);
 	}
 
 	return config;
@@ -897,7 +1062,8 @@ export function hasConfigFiles(root: string): boolean {
 		"task-orchestrator.yaml",
 	];
 	for (const f of files) {
-		if (existsSync(join(root, ".pi", f)) || existsSync(join(root, f))) return true;
+		if (existsSync(join(root, ".pi", f)) || existsSync(join(root, f)))
+			return true;
 	}
 	return false;
 }
@@ -922,12 +1088,16 @@ export function hasConfigFiles(root: string): boolean {
  * @param cwd - Current working directory (project root or worktree)
  * @param pointerConfigRoot - Resolved config root from pointer file (optional, workspace mode only)
  */
-export function resolveConfigRoot(cwd: string, pointerConfigRoot?: string): string {
+export function resolveConfigRoot(
+	cwd: string,
+	pointerConfigRoot?: string,
+): string {
 	// Prefer cwd if it has actual config files (local override always wins)
 	if (hasConfigFiles(cwd)) return cwd;
 
 	// Pointer-resolved config root — workspace mode with valid pointer
-	if (pointerConfigRoot && hasConfigFiles(pointerConfigRoot)) return pointerConfigRoot;
+	if (pointerConfigRoot && hasConfigFiles(pointerConfigRoot))
+		return pointerConfigRoot;
 
 	// Workspace mode fallback — check for actual config files at workspace root
 	const wsRoot = process.env.TASKPLANE_WORKSPACE_ROOT;
@@ -937,26 +1107,43 @@ export function resolveConfigRoot(cwd: string, pointerConfigRoot?: string): stri
 	return cwd;
 }
 
-function mergeProjectOverrides(config: TaskplaneConfig, overrides: Partial<TaskplaneConfig>): void {
+function mergeProjectOverrides(
+	config: TaskplaneConfig,
+	overrides: Partial<TaskplaneConfig>,
+): void {
 	if (overrides.taskRunner) {
-		deepMerge(config.taskRunner as Record<string, any>, overrides.taskRunner as Record<string, any>);
+		deepMerge(
+			config.taskRunner as Record<string, any>,
+			overrides.taskRunner as Record<string, any>,
+		);
 	}
 	if (overrides.orchestrator) {
-		deepMerge(config.orchestrator as Record<string, any>, overrides.orchestrator as Record<string, any>);
+		deepMerge(
+			config.orchestrator as Record<string, any>,
+			overrides.orchestrator as Record<string, any>,
+		);
 	}
 	if (overrides.workspace) {
 		if (!config.workspace || typeof config.workspace !== "object") {
 			config.workspace = {} as TaskplaneConfig["workspace"];
 		}
-		deepMerge(config.workspace as Record<string, any>, overrides.workspace as Record<string, any>);
+		deepMerge(
+			config.workspace as Record<string, any>,
+			overrides.workspace as Record<string, any>,
+		);
 	}
 }
 
-function migrateProjectOverrides(overrides: Partial<TaskplaneConfig>, configRoot: string): boolean {
+function migrateProjectOverrides(
+	overrides: Partial<TaskplaneConfig>,
+	configRoot: string,
+): boolean {
 	if (_projectMigrationDone) return false;
 
 	let migrated = false;
-	const orchestratorCore = overrides.orchestrator?.orchestrator as Record<string, unknown> | undefined;
+	const orchestratorCore = overrides.orchestrator?.orchestrator as
+		| Record<string, unknown>
+		| undefined;
 	if (orchestratorCore && hasOwn(orchestratorCore, "tmuxPrefix")) {
 		const currentPrefix = orchestratorCore.sessionPrefix;
 		const isDefault = currentPrefix === undefined || currentPrefix === "orch";
@@ -964,31 +1151,43 @@ function migrateProjectOverrides(overrides: Partial<TaskplaneConfig>, configRoot
 			(orchestratorCore as any).sessionPrefix = orchestratorCore.tmuxPrefix;
 		}
 		delete orchestratorCore.tmuxPrefix;
-		console.error(`[taskplane] Auto-migrated: orchestrator.orchestrator.tmuxPrefix → sessionPrefix`);
+		console.error(
+			`[taskplane] Auto-migrated: orchestrator.orchestrator.tmuxPrefix → sessionPrefix`,
+		);
 		migrated = true;
 	}
 	if (orchestratorCore?.spawnMode === "tmux") {
 		(orchestratorCore as any).spawnMode = "subprocess";
-		console.error(`[taskplane] Auto-migrated: orchestrator.orchestrator.spawnMode "tmux" → "subprocess"`);
+		console.error(
+			`[taskplane] Auto-migrated: orchestrator.orchestrator.spawnMode "tmux" → "subprocess"`,
+		);
 		migrated = true;
 	}
 
-	const workerConfig = overrides.taskRunner?.worker as Record<string, unknown> | undefined;
+	const workerConfig = overrides.taskRunner?.worker as
+		| Record<string, unknown>
+		| undefined;
 	if (workerConfig?.spawnMode === "tmux") {
 		(workerConfig as any).spawnMode = "subprocess";
-		console.error(`[taskplane] Auto-migrated: taskRunner.worker.spawnMode "tmux" → "subprocess"`);
+		console.error(
+			`[taskplane] Auto-migrated: taskRunner.worker.spawnMode "tmux" → "subprocess"`,
+		);
 		migrated = true;
 	}
 
 	if (migrated) {
 		try {
-			const jsonPath = resolveConfigFilePath(configRoot, PROJECT_CONFIG_FILENAME);
+			const jsonPath = resolveConfigFilePath(
+				configRoot,
+				PROJECT_CONFIG_FILENAME,
+			);
 			if (existsSync(jsonPath)) {
 				const raw = JSON.parse(readFileSync(jsonPath, "utf-8"));
 				if (raw.orchestrator?.orchestrator?.tmuxPrefix !== undefined) {
 					const rawPrefix = raw.orchestrator.orchestrator.sessionPrefix;
 					if (rawPrefix === undefined || rawPrefix === "orch") {
-						raw.orchestrator.orchestrator.sessionPrefix = raw.orchestrator.orchestrator.tmuxPrefix;
+						raw.orchestrator.orchestrator.sessionPrefix =
+							raw.orchestrator.orchestrator.tmuxPrefix;
 					}
 					delete raw.orchestrator.orchestrator.tmuxPrefix;
 				}
@@ -1005,7 +1204,9 @@ function migrateProjectOverrides(overrides: Partial<TaskplaneConfig>, configRoot
 				console.error(`[taskplane] Config file updated: ${jsonPath}`);
 			}
 		} catch (err) {
-			console.error(`[taskplane] Warning: could not persist config migration to disk: ${err instanceof Error ? err.message : err}`);
+			console.error(
+				`[taskplane] Warning: could not persist config migration to disk: ${err instanceof Error ? err.message : err}`,
+			);
 		}
 	}
 
@@ -1013,7 +1214,9 @@ function migrateProjectOverrides(overrides: Partial<TaskplaneConfig>, configRoot
 	return migrated;
 }
 
-export function loadProjectOverrides(configRoot: string): Partial<TaskplaneConfig> {
+export function loadProjectOverrides(
+	configRoot: string,
+): Partial<TaskplaneConfig> {
 	const jsonOverrides = loadJsonConfig(configRoot);
 	if (jsonOverrides !== null) {
 		return jsonOverrides;
@@ -1025,7 +1228,8 @@ export function loadProjectOverrides(configRoot: string): Partial<TaskplaneConfi
 
 	const overrides: Partial<TaskplaneConfig> = {};
 	if (Object.keys(taskRunner).length > 0) overrides.taskRunner = taskRunner;
-	if (Object.keys(orchestrator).length > 0) overrides.orchestrator = orchestrator;
+	if (Object.keys(orchestrator).length > 0)
+		overrides.orchestrator = orchestrator;
 	if (workspace) overrides.workspace = workspace;
 	return overrides;
 }
@@ -1041,7 +1245,10 @@ export function loadProjectOverrides(configRoot: string): Partial<TaskplaneConfi
  * Project config is treated as sparse overrides. Missing fields in project
  * config fall through to global preferences, then schema defaults.
  */
-export function loadProjectConfig(cwd: string, pointerConfigRoot?: string): TaskplaneConfig {
+export function loadProjectConfig(
+	cwd: string,
+	pointerConfigRoot?: string,
+): TaskplaneConfig {
 	const configRoot = resolveConfigRoot(cwd, pointerConfigRoot);
 	const config = deepClone(DEFAULT_PROJECT_CONFIG);
 
@@ -1064,7 +1271,10 @@ export function loadProjectConfig(cwd: string, pointerConfigRoot?: string): Task
  * global preferences. Used by settings write-back code paths that must
  * avoid embedding global baseline values into project config.
  */
-export function loadLayer1Config(cwd: string, pointerConfigRoot?: string): TaskplaneConfig {
+export function loadLayer1Config(
+	cwd: string,
+	pointerConfigRoot?: string,
+): TaskplaneConfig {
 	const configRoot = resolveConfigRoot(cwd, pointerConfigRoot);
 	const config = deepClone(DEFAULT_PROJECT_CONFIG);
 	const overrides = loadProjectOverrides(configRoot);
@@ -1076,7 +1286,6 @@ export function loadLayer1Config(cwd: string, pointerConfigRoot?: string): Taskp
 	normalizeInheritanceAliases(config);
 	return config;
 }
-
 
 // ── Backward-Compatible Adapters ─────────────────────────────────────
 
@@ -1090,7 +1299,9 @@ export function loadLayer1Config(cwd: string, pointerConfigRoot?: string): Taskp
  * to preserve record/dictionary keys verbatim (e.g., sizeWeights S/M/L,
  * preWarm.commands keys, etc.).
  */
-export function toOrchestratorConfig(config: TaskplaneConfig): import("./types.ts").OrchestratorConfig {
+export function toOrchestratorConfig(
+	config: TaskplaneConfig,
+): import("./types.ts").OrchestratorConfig {
 	const o = config.orchestrator;
 	return {
 		orchestrator: {
@@ -1154,7 +1365,9 @@ export function toOrchestratorConfig(config: TaskplaneConfig): import("./types.t
  * Special handling for `repoId`: whitespace-only values are treated as undefined,
  * and non-empty values are trimmed — matching the original YAML loader behavior.
  */
-export function toTaskRunnerConfig(config: TaskplaneConfig): import("./types.ts").TaskRunnerConfig {
+export function toTaskRunnerConfig(
+	config: TaskplaneConfig,
+): import("./types.ts").TaskRunnerConfig {
 	// task_areas needs snake_case keys inside each area too (repoId → repo_id)
 	const taskAreas: Record<string, import("./types.ts").TaskArea> = {};
 	for (const [name, area] of Object.entries(config.taskRunner.taskAreas)) {
@@ -1173,20 +1386,33 @@ export function toTaskRunnerConfig(config: TaskplaneConfig): import("./types.ts"
 	// Include testing_commands for baseline fingerprinting (TP-032).
 	// Only set the field when there are actual commands configured.
 	const testingCommands = config.taskRunner.testing?.commands;
-	const hasTestingCommands = testingCommands && Object.keys(testingCommands).length > 0;
+	const hasTestingCommands =
+		testingCommands && Object.keys(testingCommands).length > 0;
 
 	return {
 		task_areas: taskAreas,
 		reference_docs: { ...config.taskRunner.referenceDocs },
 		...(hasTestingCommands ? { testing_commands: { ...testingCommands } } : {}),
 		model_fallback: config.taskRunner.modelFallback ?? "inherit",
+		worker: {
+			model: config.taskRunner.worker.model,
+			thinking: config.taskRunner.worker.thinking,
+			tools: config.taskRunner.worker.tools,
+			excludeExtensions: [
+				...(config.taskRunner.worker.excludeExtensions ?? []),
+			],
+		},
 		reviewer: {
 			model: config.taskRunner.reviewer.model,
 			thinking: config.taskRunner.reviewer.thinking,
 			tools: config.taskRunner.reviewer.tools,
-			excludeExtensions: [...(config.taskRunner.reviewer.excludeExtensions ?? [])],
+			excludeExtensions: [
+				...(config.taskRunner.reviewer.excludeExtensions ?? []),
+			],
 		},
-		workerExcludeExtensions: [...(config.taskRunner.worker.excludeExtensions ?? [])],
+		workerExcludeExtensions: [
+			...(config.taskRunner.worker.excludeExtensions ?? []),
+		],
 	};
 }
 
@@ -1203,7 +1429,12 @@ export function toTaskConfig(config: TaskplaneConfig): {
 	standards: { docs: string[]; rules: string[] };
 	standards_overrides: Record<string, { docs?: string[]; rules?: string[] }>;
 	task_areas: Record<string, { path: string; [key: string]: any }>;
-	worker: { model: string; tools: string; thinking: string; spawn_mode?: "subprocess" };
+	worker: {
+		model: string;
+		tools: string;
+		thinking: string;
+		spawn_mode?: "subprocess";
+	};
 	reviewer: { model: string; tools: string; thinking: string };
 	context: {
 		worker_context_window: number;
@@ -1225,7 +1456,8 @@ export function toTaskConfig(config: TaskplaneConfig): {
 	const tr = config.taskRunner;
 
 	// Build standards_overrides with snake_case outer structure
-	const stdOverrides: Record<string, { docs?: string[]; rules?: string[] }> = {};
+	const stdOverrides: Record<string, { docs?: string[]; rules?: string[] }> =
+		{};
 	for (const [key, val] of Object.entries(tr.standardsOverrides)) {
 		stdOverrides[key] = { docs: val.docs, rules: val.rules };
 	}
@@ -1233,7 +1465,11 @@ export function toTaskConfig(config: TaskplaneConfig): {
 	// Build task_areas
 	const taskAreas: Record<string, { path: string; [key: string]: any }> = {};
 	for (const [key, val] of Object.entries(tr.taskAreas)) {
-		taskAreas[key] = { path: val.path, prefix: val.prefix, context: val.context };
+		taskAreas[key] = {
+			path: val.path,
+			prefix: val.prefix,
+			context: val.context,
+		};
 		if (val.repoId) (taskAreas[key] as any).repo_id = val.repoId;
 	}
 
@@ -1250,7 +1486,11 @@ export function toTaskConfig(config: TaskplaneConfig): {
 			thinking: tr.worker.thinking,
 			spawn_mode: tr.worker.spawnMode,
 		},
-		reviewer: { model: tr.reviewer.model, tools: tr.reviewer.tools, thinking: tr.reviewer.thinking },
+		reviewer: {
+			model: tr.reviewer.model,
+			tools: tr.reviewer.tools,
+			thinking: tr.reviewer.thinking,
+		},
 		context: {
 			worker_context_window: tr.context.workerContextWindow,
 			warn_percent: tr.context.warnPercent,

--- a/extensions/taskplane/engine.ts
+++ b/extensions/taskplane/engine.ts
@@ -2,28 +2,139 @@
  * Main batch execution engine
  * @module orch/engine
  */
-import { existsSync, readdirSync, readFileSync, renameSync, unlinkSync } from "fs";
+import {
+	existsSync,
+	readdirSync,
+	readFileSync,
+	renameSync,
+	unlinkSync,
+} from "fs";
 import { join, resolve } from "path";
-
+import {
+	cleanupPriorBatchArtifacts,
+	enforceTelemetrySizeCap,
+	formatPreflightCleanup,
+	formatPriorBatchCleanup,
+	formatSizeCap,
+	runPreflightCleanup,
+} from "./cleanup.ts";
+import {
+	assembleDiagnosticInput,
+	emitDiagnosticReports,
+} from "./diagnostic-reports.ts";
 import { formatDiscoveryResults, runDiscovery } from "./discovery.ts";
-import { buildReviewerEnv, buildWorkerExcludeEnv, computeTransitiveDependents, execLog, executeLaneV2, executeWave, killV2LaneAgents, resolveCanonicalTaskPaths } from "./execution.ts";
-import type { RuntimeBackend } from "./execution.ts";
-import type { MonitorUpdateCallback } from "./execution.ts";
+import type { MonitorUpdateCallback, RuntimeBackend } from "./execution.ts";
+import {
+	buildReviewerEnv,
+	buildWorkerEnv,
+	buildWorkerExcludeEnv,
+	computeTransitiveDependents,
+	execLog,
+	executeLaneV2,
+	executeWave,
+	killV2LaneAgents,
+	resolveCanonicalTaskPaths,
+} from "./execution.ts";
 // classifyExit no longer called directly — Tier 0 uses exitDiagnostic.classification
 // from the diagnostic-reports pipeline (populated by assembleDiagnosticInput).
 import { getCurrentBranch, runGit } from "./git.ts";
-import { killAllMergeAgentsV2, mergeWaveByRepo, MergeHealthMonitor } from "./merge.ts";
-import { applyMergeRetryLoop, computeCleanupGatePolicy, computeMergeFailurePolicy, extractFailedRepoId, formatRepoMergeSummary, ORCH_MESSAGES } from "./messages.ts";
+import {
+	killAllMergeAgentsV2,
+	MergeHealthMonitor,
+	mergeWaveByRepo,
+} from "./merge.ts";
 import type { CleanupGateRepoFailure } from "./messages.ts";
-import { assembleDiagnosticInput, emitDiagnosticReports } from "./diagnostic-reports.ts";
+import {
+	applyMergeRetryLoop,
+	computeCleanupGatePolicy,
+	computeMergeFailurePolicy,
+	extractFailedRepoId,
+	formatRepoMergeSummary,
+	ORCH_MESSAGES,
+} from "./messages.ts";
 import { resolveOperatorId } from "./naming.ts";
-import { applyPartialProgressToOutcomes, buildTier0EventBase, deleteBatchState, emitEngineEvent, emitTier0Event, loadBatchHistory, loadBatchState, persistRuntimeState, saveBatchHistory, seedPendingOutcomesForAllocatedLanes, syncTaskOutcomesFromMonitor, upsertTaskOutcome } from "./persistence.ts";
-import { readRegistrySnapshot, isTerminalStatus, isProcessAlive as registryIsProcessAlive } from "./process-registry.ts";
-import { buildBatchProgressSnapshot, buildEngineEventBase, buildSegmentId, buildSupervisorSegmentFrontierSnapshot, defaultResilienceState, FATAL_DISCOVERY_CODES, generateBatchId, TIER0_RETRYABLE_CLASSIFICATIONS, TIER0_RETRY_BUDGETS, tier0ScopeKey, tier0WaveScopeKey } from "./types.ts";
-import type { AllocatedLane, AllocatedTask, BatchHistorySummary, BatchTaskSummary, BatchWaveSummary, DiscoveryResult, EngineEventCallback, EscalationContext, LaneExecutionResult, LaneTaskOutcome, MergeWaveResult, OrchBatchPhase, OrchBatchRuntimeState, OrchestratorConfig, ParsedTask, PersistedSegmentRecord, SegmentExpansionRequest, SupervisorAlert, SupervisorAlertCallback, TaskRunnerConfig, TaskSegmentPlan, TaskSegmentPlanMap, TaskSegmentNode, Tier0EscalationPattern, Tier0RecoveryPattern, TokenCounts, WaveExecutionResult, WorkspaceConfig } from "./types.ts";
-import { buildDependencyGraph, computeWaveAssignments, resolveBaseBranch, resolveRepoRoot, validateGraph } from "./waves.ts";
-import { deleteBranchBestEffort, forceCleanupWorktree, formatPreflightResults, listWorktrees, preserveFailedLaneProgress, preserveSkippedLaneProgress, removeAllWorktrees, removeWorktree, runPreflight, safeResetWorktree, sleepSync } from "./worktree.ts";
-import { runPreflightCleanup, formatPreflightCleanup, enforceTelemetrySizeCap, formatSizeCap, cleanupPriorBatchArtifacts, formatPriorBatchCleanup } from "./cleanup.ts";
+import {
+	applyPartialProgressToOutcomes,
+	buildTier0EventBase,
+	deleteBatchState,
+	emitEngineEvent,
+	emitTier0Event,
+	loadBatchHistory,
+	loadBatchState,
+	persistRuntimeState,
+	saveBatchHistory,
+	seedPendingOutcomesForAllocatedLanes,
+	syncTaskOutcomesFromMonitor,
+	upsertTaskOutcome,
+} from "./persistence.ts";
+import {
+	isTerminalStatus,
+	readRegistrySnapshot,
+	isProcessAlive as registryIsProcessAlive,
+} from "./process-registry.ts";
+import type {
+	AllocatedLane,
+	AllocatedTask,
+	BatchHistorySummary,
+	BatchTaskSummary,
+	BatchWaveSummary,
+	DiscoveryResult,
+	EngineEventCallback,
+	EscalationContext,
+	LaneExecutionResult,
+	LaneTaskOutcome,
+	MergeWaveResult,
+	OrchBatchPhase,
+	OrchBatchRuntimeState,
+	OrchestratorConfig,
+	ParsedTask,
+	PersistedSegmentRecord,
+	SegmentExpansionRequest,
+	SupervisorAlert,
+	SupervisorAlertCallback,
+	TaskRunnerConfig,
+	TaskSegmentNode,
+	TaskSegmentPlan,
+	TaskSegmentPlanMap,
+	Tier0EscalationPattern,
+	Tier0RecoveryPattern,
+	TokenCounts,
+	WaveExecutionResult,
+	WorkspaceConfig,
+} from "./types.ts";
+import {
+	buildBatchProgressSnapshot,
+	buildEngineEventBase,
+	buildSegmentId,
+	buildSupervisorSegmentFrontierSnapshot,
+	defaultResilienceState,
+	FATAL_DISCOVERY_CODES,
+	generateBatchId,
+	TIER0_RETRY_BUDGETS,
+	TIER0_RETRYABLE_CLASSIFICATIONS,
+	tier0ScopeKey,
+	tier0WaveScopeKey,
+} from "./types.ts";
+import {
+	buildDependencyGraph,
+	computeWaveAssignments,
+	resolveBaseBranch,
+	resolveRepoRoot,
+	validateGraph,
+} from "./waves.ts";
+import {
+	deleteBranchBestEffort,
+	forceCleanupWorktree,
+	formatPreflightResults,
+	listWorktrees,
+	preserveFailedLaneProgress,
+	preserveSkippedLaneProgress,
+	removeAllWorktrees,
+	removeWorktree,
+	runPreflight,
+	safeResetWorktree,
+	sleepSync,
+} from "./worktree.ts";
 
 // ── Tier 0: Automatic Recovery Helpers (TP-039) ─────────────────────
 
@@ -47,7 +158,12 @@ function emitTier0Escalation(
 	lastError: string,
 	affectedTasks: string[],
 	suggestion: string,
-	extra?: Partial<Pick<import("./persistence.ts").Tier0Event, "taskId" | "laneNumber" | "repoId" | "classification" | "scopeKey">>,
+	extra?: Partial<
+		Pick<
+			import("./persistence.ts").Tier0Event,
+			"taskId" | "laneNumber" | "repoId" | "classification" | "scopeKey"
+		>
+	>,
 ): void {
 	const escalation: EscalationContext = {
 		pattern,
@@ -58,17 +174,32 @@ function emitTier0Escalation(
 		suggestion,
 	};
 	emitTier0Event(stateRoot, {
-		...buildTier0EventBase("tier0_escalation", batchId, waveIndex, pattern, attempts, maxAttempts),
+		...buildTier0EventBase(
+			"tier0_escalation",
+			batchId,
+			waveIndex,
+			pattern,
+			attempts,
+			maxAttempts,
+		),
 		...extra,
 		escalation,
 	});
 }
 
 /** Zero-token sentinel used for task/wave/batch aggregation. */
-const ZERO_TOKENS: TokenCounts = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, costUsd: 0 };
+const ZERO_TOKENS: TokenCounts = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	costUsd: 0,
+};
 
 /** Map embedded outcome telemetry to the batch-history TokenCounts shape. */
-export function taskTokensFromOutcomeTelemetry(outcome: LaneTaskOutcome): TokenCounts {
+export function taskTokensFromOutcomeTelemetry(
+	outcome: LaneTaskOutcome,
+): TokenCounts {
 	const telemetry = outcome.telemetry;
 	if (!telemetry) return { ...ZERO_TOKENS };
 	return {
@@ -107,8 +238,11 @@ export function resolveBatchHistoryTaskTokens(
 		if (v2) return v2;
 	}
 
-	const bySession = legacyLaneTokensByKey.get(outcome.sessionName)
-		|| legacyLaneTokensByKey.get(outcome.sessionName?.replace(/-(?:worker|reviewer)$/, ""));
+	const bySession =
+		legacyLaneTokensByKey.get(outcome.sessionName) ||
+		legacyLaneTokensByKey.get(
+			outcome.sessionName?.replace(/-(?:worker|reviewer)$/, ""),
+		);
 	if (bySession) return bySession;
 
 	if (laneNumber > 0) {
@@ -121,7 +255,12 @@ export function resolveBatchHistoryTaskTokens(
 
 // ── Segment Frontier Helpers (TP-133) ───────────────────────────────
 
-type SegmentLifecycleStatus = "pending" | "running" | "succeeded" | "failed" | "skipped";
+type SegmentLifecycleStatus =
+	| "pending"
+	| "running"
+	| "succeeded"
+	| "failed"
+	| "skipped";
 
 interface SegmentFrontierTaskState {
 	taskId: string;
@@ -132,7 +271,9 @@ interface SegmentFrontierTaskState {
 	terminalStatus: "pending" | "succeeded" | "failed" | "skipped";
 }
 
-function buildSegmentDependencyMap(plan: TaskSegmentPlan): Map<string, string[]> {
+function buildSegmentDependencyMap(
+	plan: TaskSegmentPlan,
+): Map<string, string[]> {
 	const depsBySegmentId = new Map<string, string[]>();
 	for (const segment of plan.segments) {
 		depsBySegmentId.set(segment.segmentId, []);
@@ -142,7 +283,10 @@ function buildSegmentDependencyMap(plan: TaskSegmentPlan): Map<string, string[]>
 		depsBySegmentId.get(edge.toSegmentId)!.push(edge.fromSegmentId);
 	}
 	for (const [segmentId, deps] of depsBySegmentId.entries()) {
-		depsBySegmentId.set(segmentId, [...new Set(deps)].sort((a, b) => a.localeCompare(b)));
+		depsBySegmentId.set(
+			segmentId,
+			[...new Set(deps)].sort((a, b) => a.localeCompare(b)),
+		);
 	}
 	return depsBySegmentId;
 }
@@ -153,7 +297,9 @@ export function resolveTaskWorkerAgentId(
 	laneByTaskId: Map<string, AllocatedLane>,
 	agentIdPrefix?: string,
 ): string | null {
-	const outcome = allTaskOutcomes.find((candidate) => candidate.taskId === taskId);
+	const outcome = allTaskOutcomes.find(
+		(candidate) => candidate.taskId === taskId,
+	);
 	if (outcome?.sessionName) {
 		return outcome.sessionName;
 	}
@@ -174,8 +320,19 @@ export function resolveTaskWorkerAgentId(
 	return `${lane.laneSessionId}-worker`;
 }
 
-function listPendingSegmentExpansionRequestFiles(stateRoot: string, batchId: string, agentId: string): string[] {
-	const outboxDir = join(stateRoot, ".pi", "mailbox", batchId, agentId, "outbox");
+function listPendingSegmentExpansionRequestFiles(
+	stateRoot: string,
+	batchId: string,
+	agentId: string,
+): string[] {
+	const outboxDir = join(
+		stateRoot,
+		".pi",
+		"mailbox",
+		batchId,
+		agentId,
+		"outbox",
+	);
 	if (!existsSync(outboxDir)) return [];
 	let entries: string[] = [];
 	try {
@@ -199,27 +356,49 @@ interface SegmentExpansionParseFailure {
 	reason: string;
 }
 
-function parseSegmentExpansionRequestPayload(payload: unknown): SegmentExpansionRequest | null {
+function parseSegmentExpansionRequestPayload(
+	payload: unknown,
+): SegmentExpansionRequest | null {
 	if (!payload || typeof payload !== "object") return null;
 	const candidate = payload as Record<string, unknown>;
-	if (typeof candidate.requestId !== "string" || !candidate.requestId.trim()) return null;
-	if (typeof candidate.taskId !== "string" || !candidate.taskId.trim()) return null;
-	if (typeof candidate.fromSegmentId !== "string" || !candidate.fromSegmentId.trim()) return null;
-	if (!Array.isArray(candidate.requestedRepoIds) || candidate.requestedRepoIds.length === 0 || candidate.requestedRepoIds.some((repoId) => typeof repoId !== "string" || !repoId.trim())) return null;
+	if (typeof candidate.requestId !== "string" || !candidate.requestId.trim())
+		return null;
+	if (typeof candidate.taskId !== "string" || !candidate.taskId.trim())
+		return null;
+	if (
+		typeof candidate.fromSegmentId !== "string" ||
+		!candidate.fromSegmentId.trim()
+	)
+		return null;
+	if (
+		!Array.isArray(candidate.requestedRepoIds) ||
+		candidate.requestedRepoIds.length === 0 ||
+		candidate.requestedRepoIds.some(
+			(repoId) => typeof repoId !== "string" || !repoId.trim(),
+		)
+	)
+		return null;
 	if (typeof candidate.rationale !== "string") return null;
-	if (candidate.placement !== "after-current" && candidate.placement !== "end") return null;
+	if (candidate.placement !== "after-current" && candidate.placement !== "end")
+		return null;
 	if (!Array.isArray(candidate.edges)) return null;
 	for (const edge of candidate.edges) {
 		if (!edge || typeof edge !== "object") return null;
 		const typedEdge = edge as Record<string, unknown>;
-		if (typeof typedEdge.from !== "string" || !typedEdge.from.trim()) return null;
+		if (typeof typedEdge.from !== "string" || !typedEdge.from.trim())
+			return null;
 		if (typeof typedEdge.to !== "string" || !typedEdge.to.trim()) return null;
 	}
-	if (typeof candidate.timestamp !== "number" || !Number.isFinite(candidate.timestamp)) return null;
+	if (
+		typeof candidate.timestamp !== "number" ||
+		!Number.isFinite(candidate.timestamp)
+	)
+		return null;
 	return {
 		requestId: candidate.requestId,
 		taskId: candidate.taskId,
-		fromSegmentId: candidate.fromSegmentId as SegmentExpansionRequest["fromSegmentId"],
+		fromSegmentId:
+			candidate.fromSegmentId as SegmentExpansionRequest["fromSegmentId"],
 		requestedRepoIds: candidate.requestedRepoIds as string[],
 		rationale: candidate.rationale,
 		placement: candidate.placement,
@@ -276,7 +455,10 @@ function parseSegmentExpansionRequests(filePaths: string[]): {
 	return { valid, malformed };
 }
 
-function markSegmentExpansionRequestFile(filePath: string, stateSuffix: "invalid" | "discarded" | "rejected" | "processed"): boolean {
+function markSegmentExpansionRequestFile(
+	filePath: string,
+	stateSuffix: "invalid" | "discarded" | "rejected" | "processed",
+): boolean {
 	try {
 		renameSync(filePath, `${filePath}.${stateSuffix}`);
 		return true;
@@ -285,7 +467,9 @@ function markSegmentExpansionRequestFile(filePath: string, stateSuffix: "invalid
 	}
 }
 
-export function expansionRequestHasCycle(request: SegmentExpansionRequest): boolean {
+export function expansionRequestHasCycle(
+	request: SegmentExpansionRequest,
+): boolean {
 	const requestedRepoIds = [...new Set(request.requestedRepoIds)];
 	const indegree = new Map<string, number>();
 	const outgoing = new Map<string, string[]>();
@@ -335,23 +519,23 @@ export function validateSegmentExpansionRequestAtBoundary(
 		return "task is already in terminal state";
 	}
 	if (request.placement !== "after-current" && request.placement !== "end") {
-		return `unsupported placement \"${request.placement}\"`;
+		return `unsupported placement "${request.placement}"`;
 	}
 
 	if (knownRequestIds.has(request.requestId)) {
-		return `requestId \"${request.requestId}\" already processed`;
+		return `requestId "${request.requestId}" already processed`;
 	}
 
 	if (workspaceConfig) {
 		for (const repoId of request.requestedRepoIds) {
 			if (!workspaceConfig.repos.has(repoId)) {
-				return `unknown repoId \"${repoId}\"`;
+				return `unknown repoId "${repoId}"`;
 			}
 		}
 	} else {
 		for (const repoId of request.requestedRepoIds) {
 			if (repoId !== "default") {
-				return `repo expansion requires workspace mode (unknown repoId \"${repoId}\")`;
+				return `repo expansion requires workspace mode (unknown repoId "${repoId}")`;
 			}
 		}
 	}
@@ -368,7 +552,9 @@ export function validateSegmentExpansionRequestAtBoundary(
 	// which is valid — the dependency is implicit for after-current placement.
 	const knownEdgeRepoIds = new Set(requestedRepoSet);
 	const orderedSegments = segmentState.orderedSegments ?? [];
-	const anchorSegment = orderedSegments.find((seg) => seg.segmentId === segmentId);
+	const anchorSegment = orderedSegments.find(
+		(seg) => seg.segmentId === segmentId,
+	);
 	if (anchorSegment) {
 		knownEdgeRepoIds.add(anchorSegment.repoId);
 	}
@@ -415,19 +601,26 @@ export function processSegmentExpansionRequestAtBoundary(
 	}
 
 	knownRequestIds.add(requestFile.request.requestId);
-	execLog("batch", batchId, "segment expansion request handed off for graph mutation", {
-		taskId,
-		segmentId,
-		agentId,
-		requestId: requestFile.request.requestId,
-		placement: requestFile.request.placement,
-		requestedRepoIds: requestFile.request.requestedRepoIds.join(","),
-		requestFile: requestFile.filePath,
-	});
+	execLog(
+		"batch",
+		batchId,
+		"segment expansion request handed off for graph mutation",
+		{
+			taskId,
+			segmentId,
+			agentId,
+			requestId: requestFile.request.requestId,
+			placement: requestFile.request.placement,
+			requestedRepoIds: requestFile.request.requestedRepoIds.join(","),
+			requestFile: requestFile.filePath,
+		},
+	);
 	return { ok: true };
 }
 
-function buildOutgoingBySegmentId(dependsOnBySegmentId: Map<string, string[]>): Map<string, string[]> {
+function buildOutgoingBySegmentId(
+	dependsOnBySegmentId: Map<string, string[]>,
+): Map<string, string[]> {
 	const outgoingBySegmentId = new Map<string, string[]>();
 	for (const segmentId of dependsOnBySegmentId.keys()) {
 		outgoingBySegmentId.set(segmentId, []);
@@ -440,12 +633,19 @@ function buildOutgoingBySegmentId(dependsOnBySegmentId: Map<string, string[]>): 
 		}
 	}
 	for (const [segmentId, outgoing] of outgoingBySegmentId.entries()) {
-		outgoingBySegmentId.set(segmentId, [...new Set(outgoing)].sort((a, b) => a.localeCompare(b)));
+		outgoingBySegmentId.set(
+			segmentId,
+			[...new Set(outgoing)].sort((a, b) => a.localeCompare(b)),
+		);
 	}
 	return outgoingBySegmentId;
 }
 
-function addDependency(dependencyMap: Map<string, string[]>, segmentId: string, depSegmentId: string): void {
+function addDependency(
+	dependencyMap: Map<string, string[]>,
+	segmentId: string,
+	depSegmentId: string,
+): void {
 	const deps = dependencyMap.get(segmentId) ?? [];
 	if (!deps.includes(depSegmentId)) {
 		deps.push(depSegmentId);
@@ -454,22 +654,33 @@ function addDependency(dependencyMap: Map<string, string[]>, segmentId: string, 
 	}
 }
 
-function removeDependency(dependencyMap: Map<string, string[]>, segmentId: string, depSegmentId: string): void {
+function removeDependency(
+	dependencyMap: Map<string, string[]>,
+	segmentId: string,
+	depSegmentId: string,
+): void {
 	const deps = dependencyMap.get(segmentId) ?? [];
 	const filtered = deps.filter((dep) => dep !== depSegmentId);
 	dependencyMap.set(segmentId, filtered);
 }
 
-function recomputeNextPendingSegmentIndex(segmentState: SegmentFrontierTaskState): void {
+function recomputeNextPendingSegmentIndex(
+	segmentState: SegmentFrontierTaskState,
+): void {
 	const nextPendingIndex = segmentState.orderedSegments.findIndex((segment) => {
 		return segmentState.statusBySegmentId.get(segment.segmentId) === "pending";
 	});
-	segmentState.nextSegmentIndex = nextPendingIndex >= 0
-		? nextPendingIndex
-		: segmentState.orderedSegments.length;
+	segmentState.nextSegmentIndex =
+		nextPendingIndex >= 0
+			? nextPendingIndex
+			: segmentState.orderedSegments.length;
 }
 
-function hasTaskInFutureSegmentRounds(segmentRounds: string[][], fromIndex: number, taskId: string): boolean {
+function hasTaskInFutureSegmentRounds(
+	segmentRounds: string[][],
+	fromIndex: number,
+	taskId: string,
+): boolean {
 	for (let idx = fromIndex; idx < segmentRounds.length; idx++) {
 		if (segmentRounds[idx]?.includes(taskId)) {
 			return true;
@@ -487,7 +698,9 @@ export function scheduleContinuationSegmentRound(
 	currentWaveIndex: number,
 	taskIds: Iterable<string>,
 ): string[] {
-	const continuationWave = [...new Set(taskIds)].sort((a, b) => a.localeCompare(b));
+	const continuationWave = [...new Set(taskIds)].sort((a, b) =>
+		a.localeCompare(b),
+	);
 	if (continuationWave.length === 0) {
 		return [];
 	}
@@ -535,7 +748,10 @@ export function applySegmentExpansionMutation(
 
 	const dependencyMap = new Map<string, string[]>();
 	for (const [segmentId, deps] of segmentState.dependsOnBySegmentId.entries()) {
-		dependencyMap.set(segmentId, [...new Set(deps)].sort((a, b) => a.localeCompare(b)));
+		dependencyMap.set(
+			segmentId,
+			[...new Set(deps)].sort((a, b) => a.localeCompare(b)),
+		);
 	}
 	for (const segmentId of existingNodeById.keys()) {
 		if (!dependencyMap.has(segmentId)) {
@@ -550,8 +766,14 @@ export function applySegmentExpansionMutation(
 
 	const outgoingBeforeMutation = buildOutgoingBySegmentId(dependencyMap);
 	const anchorSuccessors = outgoingBeforeMutation.get(anchorSegmentId) ?? [];
-	const maxOrder = segmentState.orderedSegments.reduce((max, segment) => Math.max(max, segment.order), -1);
-	const repoMaxSequenceByRepo = buildRepoMaxSequenceByRepo(segmentState.orderedSegments, request.taskId);
+	const maxOrder = segmentState.orderedSegments.reduce(
+		(max, segment) => Math.max(max, segment.order),
+		-1,
+	);
+	const repoMaxSequenceByRepo = buildRepoMaxSequenceByRepo(
+		segmentState.orderedSegments,
+		request.taskId,
+	);
 
 	const newNodes: TaskSegmentNode[] = [];
 	const segmentIdByRequestedRepoId = new Map<string, string>();
@@ -588,8 +810,14 @@ export function applySegmentExpansionMutation(
 		const fromSegmentId = segmentIdByRequestedRepoId.get(edge.from);
 		const toSegmentId = segmentIdByRequestedRepoId.get(edge.to);
 		if (!fromSegmentId || !toSegmentId) continue;
-		internalOutgoingCounts.set(fromSegmentId, (internalOutgoingCounts.get(fromSegmentId) ?? 0) + 1);
-		internalIncomingCounts.set(toSegmentId, (internalIncomingCounts.get(toSegmentId) ?? 0) + 1);
+		internalOutgoingCounts.set(
+			fromSegmentId,
+			(internalOutgoingCounts.get(fromSegmentId) ?? 0) + 1,
+		);
+		internalIncomingCounts.set(
+			toSegmentId,
+			(internalIncomingCounts.get(toSegmentId) ?? 0) + 1,
+		);
 	}
 
 	const roots = newNodes
@@ -614,7 +842,10 @@ export function applySegmentExpansionMutation(
 	} else {
 		const terminals = segmentState.orderedSegments
 			.map((segment) => segment.segmentId)
-			.filter((segmentId) => (outgoingBeforeMutation.get(segmentId) ?? []).length === 0)
+			.filter(
+				(segmentId) =>
+					(outgoingBeforeMutation.get(segmentId) ?? []).length === 0,
+			)
 			.sort((a, b) => a.localeCompare(b));
 		for (const root of roots) {
 			for (const terminal of terminals) {
@@ -629,7 +860,10 @@ export function applySegmentExpansionMutation(
 		priorityBySegmentId.set(segment.segmentId, idx);
 	}
 	for (const [idx, node] of newNodes.entries()) {
-		priorityBySegmentId.set(node.segmentId, segmentState.orderedSegments.length + idx);
+		priorityBySegmentId.set(
+			node.segmentId,
+			segmentState.orderedSegments.length + idx,
+		);
 	}
 
 	const outgoing = buildOutgoingBySegmentId(dependencyMap);
@@ -656,8 +890,10 @@ export function applySegmentExpansionMutation(
 			if (count === 0) {
 				ready.push(depSegmentId);
 				ready.sort((a, b) => {
-					const aPriority = priorityBySegmentId.get(a) ?? Number.MAX_SAFE_INTEGER;
-					const bPriority = priorityBySegmentId.get(b) ?? Number.MAX_SAFE_INTEGER;
+					const aPriority =
+						priorityBySegmentId.get(a) ?? Number.MAX_SAFE_INTEGER;
+					const bPriority =
+						priorityBySegmentId.get(b) ?? Number.MAX_SAFE_INTEGER;
 					if (aPriority !== bPriority) return aPriority - bPriority;
 					return a.localeCompare(b);
 				});
@@ -668,10 +904,15 @@ export function applySegmentExpansionMutation(
 	if (nextOrderedSegmentIds.length !== dependencyMap.size) {
 		// Topological sort failed to cover all nodes — likely a cycle introduced
 		// by the expansion. Reject the mutation entirely and restore original state.
-		execLog("batch", request.taskId, "segment expansion rejected: topological sort failed (possible cycle)", {
-			expected: dependencyMap.size,
-			covered: nextOrderedSegmentIds.length,
-		});
+		execLog(
+			"batch",
+			request.taskId,
+			"segment expansion rejected: topological sort failed (possible cycle)",
+			{
+				expected: dependencyMap.size,
+				covered: nextOrderedSegmentIds.length,
+			},
+		);
 		// Full rollback to pre-mutation state
 		for (const node of newNodes) {
 			segmentState.statusBySegmentId.delete(node.segmentId);
@@ -713,20 +954,31 @@ function handoffSegmentExpansionToMutation(
 	requestFile: PendingSegmentExpansionRequest,
 	segmentState: SegmentFrontierTaskState,
 ): { insertedSegmentIds: string[] } {
-	const mutation = applySegmentExpansionMutation(segmentState, requestFile.request, segmentId);
-	execLog("batch", batchId, "segment expansion request accepted for mutation path", {
-		taskId,
+	const mutation = applySegmentExpansionMutation(
+		segmentState,
+		requestFile.request,
 		segmentId,
-		agentId,
-		requestId: requestFile.request.requestId,
-		placement: requestFile.request.placement,
-		requestedRepoIds: requestFile.request.requestedRepoIds.join(","),
-		insertedSegments: mutation.insertedSegmentIds.join(","),
-	});
+	);
+	execLog(
+		"batch",
+		batchId,
+		"segment expansion request accepted for mutation path",
+		{
+			taskId,
+			segmentId,
+			agentId,
+			requestId: requestFile.request.requestId,
+			placement: requestFile.request.placement,
+			requestedRepoIds: requestFile.request.requestedRepoIds.join(","),
+			insertedSegments: mutation.insertedSegmentIds.join(","),
+		},
+	);
 	return mutation;
 }
 
-function ensureSegmentRecords(batchState: OrchBatchRuntimeState): PersistedSegmentRecord[] {
+function ensureSegmentRecords(
+	batchState: OrchBatchRuntimeState,
+): PersistedSegmentRecord[] {
 	if (!batchState.segments) {
 		batchState.segments = [];
 	}
@@ -748,7 +1000,10 @@ export function upsertPendingExpandedSegmentRecords(
 ): boolean {
 	const insertedSegmentIdSet = new Set(insertedSegmentIds);
 	const pendingSegmentIds = segmentState.orderedSegments
-		.filter((segment) => segmentState.statusBySegmentId.get(segment.segmentId) === "pending")
+		.filter(
+			(segment) =>
+				segmentState.statusBySegmentId.get(segment.segmentId) === "pending",
+		)
 		.map((segment) => segment.segmentId);
 	if (pendingSegmentIds.length === 0) return false;
 
@@ -756,14 +1011,19 @@ export function upsertPendingExpandedSegmentRecords(
 	let changed = false;
 
 	for (const segmentId of pendingSegmentIds) {
-		const segment = segmentState.orderedSegments.find((candidate) => candidate.segmentId === segmentId);
+		const segment = segmentState.orderedSegments.find(
+			(candidate) => candidate.segmentId === segmentId,
+		);
 		if (!segment) continue;
-		const existing = segmentRecords.find((record) => record.segmentId === segmentId);
+		const existing = segmentRecords.find(
+			(record) => record.segmentId === segmentId,
+		);
 		if (!existing && !insertedSegmentIdSet.has(segmentId)) {
 			continue;
 		}
 
-		const dependsOnSegmentIds = segmentState.dependsOnBySegmentId.get(segmentId) ?? [];
+		const dependsOnSegmentIds =
+			segmentState.dependsOnBySegmentId.get(segmentId) ?? [];
 		const nextExpandedFrom = insertedSegmentIdSet.has(segmentId)
 			? expandedFrom
 			: existing?.expandedFrom;
@@ -795,21 +1055,23 @@ export function upsertPendingExpandedSegmentRecords(
 		}
 
 		const recordChanged =
-			existing.taskId !== next.taskId
-			|| existing.repoId !== next.repoId
-			|| existing.status !== next.status
-			|| existing.laneId !== next.laneId
-			|| existing.sessionName !== next.sessionName
-			|| existing.worktreePath !== next.worktreePath
-			|| existing.branch !== next.branch
-			|| existing.startedAt !== next.startedAt
-			|| existing.endedAt !== next.endedAt
-			|| existing.retries !== next.retries
-			|| existing.exitReason !== next.exitReason
-			|| existing.dependsOnSegmentIds.length !== next.dependsOnSegmentIds.length
-			|| existing.dependsOnSegmentIds.some((depSegmentId, idx) => depSegmentId !== next.dependsOnSegmentIds[idx])
-			|| existing.expandedFrom !== next.expandedFrom
-			|| existing.expansionRequestId !== next.expansionRequestId;
+			existing.taskId !== next.taskId ||
+			existing.repoId !== next.repoId ||
+			existing.status !== next.status ||
+			existing.laneId !== next.laneId ||
+			existing.sessionName !== next.sessionName ||
+			existing.worktreePath !== next.worktreePath ||
+			existing.branch !== next.branch ||
+			existing.startedAt !== next.startedAt ||
+			existing.endedAt !== next.endedAt ||
+			existing.retries !== next.retries ||
+			existing.exitReason !== next.exitReason ||
+			existing.dependsOnSegmentIds.length !== next.dependsOnSegmentIds.length ||
+			existing.dependsOnSegmentIds.some(
+				(depSegmentId, idx) => depSegmentId !== next.dependsOnSegmentIds[idx],
+			) ||
+			existing.expandedFrom !== next.expandedFrom ||
+			existing.expansionRequestId !== next.expansionRequestId;
 
 		if (recordChanged) {
 			Object.assign(existing, next);
@@ -843,7 +1105,13 @@ function recordProcessedSegmentExpansionRequestId(
 		batchState.resilience = defaultResilienceState();
 	}
 	const history = batchState.resilience.repairHistory;
-	if (history.some((entry) => entry.strategy === "segment-expansion-request" && entry.id === requestId)) {
+	if (
+		history.some(
+			(entry) =>
+				entry.strategy === "segment-expansion-request" &&
+				entry.id === requestId,
+		)
+	) {
 		return false;
 	}
 	const now = Date.now();
@@ -866,17 +1134,21 @@ function upsertRunningSegmentRecord(
 	const activeSegmentId = task.activeSegmentId;
 	if (!activeSegmentId) return false;
 
-	const activeSegment = segmentState.orderedSegments.find((segment) => segment.segmentId === activeSegmentId);
+	const activeSegment = segmentState.orderedSegments.find(
+		(segment) => segment.segmentId === activeSegmentId,
+	);
 	if (!activeSegment) return false;
 
 	const segmentRecords = ensureSegmentRecords(batchState);
-	const dependsOnSegmentIds = segmentState.dependsOnBySegmentId.get(activeSegmentId) ?? [];
-	const existing = segmentRecords.find((record) => record.segmentId === activeSegmentId);
+	const dependsOnSegmentIds =
+		segmentState.dependsOnBySegmentId.get(activeSegmentId) ?? [];
+	const existing = segmentRecords.find(
+		(record) => record.segmentId === activeSegmentId,
+	);
 	const now = Date.now();
 
-	const restarted = !!existing
-		&& existing.status !== "running"
-		&& existing.startedAt !== null;
+	const restarted =
+		!!existing && existing.status !== "running" && existing.startedAt !== null;
 
 	const next: PersistedSegmentRecord = {
 		segmentId: activeSegmentId,
@@ -887,20 +1159,17 @@ function upsertRunningSegmentRecord(
 		sessionName: lane.laneSessionId,
 		worktreePath: lane.worktreePath,
 		branch: lane.branch,
-		startedAt: existing?.status === "running"
-			? existing.startedAt
-			: (existing?.startedAt ?? now),
+		startedAt:
+			existing?.status === "running"
+				? existing.startedAt
+				: (existing?.startedAt ?? now),
 		endedAt: null,
-		retries: existing
-			? existing.retries + (restarted ? 1 : 0)
-			: 0,
-		exitReason: existing?.status === "running"
-			? existing.exitReason
-			: "Segment running",
+		retries: existing ? existing.retries + (restarted ? 1 : 0) : 0,
+		exitReason:
+			existing?.status === "running" ? existing.exitReason : "Segment running",
 		dependsOnSegmentIds,
-		exitDiagnostic: existing?.status === "running"
-			? existing.exitDiagnostic
-			: undefined,
+		exitDiagnostic:
+			existing?.status === "running" ? existing.exitDiagnostic : undefined,
 		expandedFrom: existing?.expandedFrom,
 		expansionRequestId: existing?.expansionRequestId,
 	};
@@ -911,22 +1180,24 @@ function upsertRunningSegmentRecord(
 	}
 
 	const changed =
-		existing.taskId !== next.taskId
-		|| existing.repoId !== next.repoId
-		|| existing.status !== next.status
-		|| existing.laneId !== next.laneId
-		|| existing.sessionName !== next.sessionName
-		|| existing.worktreePath !== next.worktreePath
-		|| existing.branch !== next.branch
-		|| existing.startedAt !== next.startedAt
-		|| existing.endedAt !== next.endedAt
-		|| existing.retries !== next.retries
-		|| existing.exitReason !== next.exitReason
-		|| existing.dependsOnSegmentIds.length !== next.dependsOnSegmentIds.length
-		|| existing.dependsOnSegmentIds.some((segmentId, idx) => segmentId !== next.dependsOnSegmentIds[idx])
-		|| existing.exitDiagnostic !== next.exitDiagnostic
-		|| existing.expandedFrom !== next.expandedFrom
-		|| existing.expansionRequestId !== next.expansionRequestId;
+		existing.taskId !== next.taskId ||
+		existing.repoId !== next.repoId ||
+		existing.status !== next.status ||
+		existing.laneId !== next.laneId ||
+		existing.sessionName !== next.sessionName ||
+		existing.worktreePath !== next.worktreePath ||
+		existing.branch !== next.branch ||
+		existing.startedAt !== next.startedAt ||
+		existing.endedAt !== next.endedAt ||
+		existing.retries !== next.retries ||
+		existing.exitReason !== next.exitReason ||
+		existing.dependsOnSegmentIds.length !== next.dependsOnSegmentIds.length ||
+		existing.dependsOnSegmentIds.some(
+			(segmentId, idx) => segmentId !== next.dependsOnSegmentIds[idx],
+		) ||
+		existing.exitDiagnostic !== next.exitDiagnostic ||
+		existing.expandedFrom !== next.expandedFrom ||
+		existing.expansionRequestId !== next.expansionRequestId;
 
 	if (changed) {
 		Object.assign(existing, next);
@@ -943,16 +1214,22 @@ function upsertTerminalSegmentRecord(
 	outcome: LaneTaskOutcome | undefined,
 	lane: AllocatedLane | undefined,
 ): boolean {
-	const segment = segmentState.orderedSegments.find((candidate) => candidate.segmentId === segmentId);
+	const segment = segmentState.orderedSegments.find(
+		(candidate) => candidate.segmentId === segmentId,
+	);
 	if (!segment) return false;
 
 	const segmentRecords = ensureSegmentRecords(batchState);
-	const existing = segmentRecords.find((record) => record.segmentId === segmentId);
+	const existing = segmentRecords.find(
+		(record) => record.segmentId === segmentId,
+	);
 	const now = Date.now();
-	const dependsOnSegmentIds = segmentState.dependsOnBySegmentId.get(segmentId) ?? [];
-	const nextExitDiagnostic = status === "failed"
-		? (outcome?.exitDiagnostic ?? existing?.exitDiagnostic)
-		: undefined;
+	const dependsOnSegmentIds =
+		segmentState.dependsOnBySegmentId.get(segmentId) ?? [];
+	const nextExitDiagnostic =
+		status === "failed"
+			? (outcome?.exitDiagnostic ?? existing?.exitDiagnostic)
+			: undefined;
 
 	const next: PersistedSegmentRecord = {
 		segmentId,
@@ -966,11 +1243,13 @@ function upsertTerminalSegmentRecord(
 		startedAt: existing?.startedAt ?? outcome?.startTime ?? now,
 		endedAt: outcome?.endTime ?? now,
 		retries: existing?.retries ?? 0,
-		exitReason: outcome?.exitReason ?? (status === "succeeded"
-			? "Segment completed"
-			: status === "failed"
-			? "Segment failed"
-			: "Segment skipped"),
+		exitReason:
+			outcome?.exitReason ??
+			(status === "succeeded"
+				? "Segment completed"
+				: status === "failed"
+					? "Segment failed"
+					: "Segment skipped"),
 		dependsOnSegmentIds,
 		exitDiagnostic: nextExitDiagnostic,
 		expandedFrom: existing?.expandedFrom,
@@ -983,22 +1262,24 @@ function upsertTerminalSegmentRecord(
 	}
 
 	const changed =
-		existing.taskId !== next.taskId
-		|| existing.repoId !== next.repoId
-		|| existing.status !== next.status
-		|| existing.laneId !== next.laneId
-		|| existing.sessionName !== next.sessionName
-		|| existing.worktreePath !== next.worktreePath
-		|| existing.branch !== next.branch
-		|| existing.startedAt !== next.startedAt
-		|| existing.endedAt !== next.endedAt
-		|| existing.retries !== next.retries
-		|| existing.exitReason !== next.exitReason
-		|| existing.dependsOnSegmentIds.length !== next.dependsOnSegmentIds.length
-		|| existing.dependsOnSegmentIds.some((depSegmentId, idx) => depSegmentId !== next.dependsOnSegmentIds[idx])
-		|| existing.exitDiagnostic !== next.exitDiagnostic
-		|| existing.expandedFrom !== next.expandedFrom
-		|| existing.expansionRequestId !== next.expansionRequestId;
+		existing.taskId !== next.taskId ||
+		existing.repoId !== next.repoId ||
+		existing.status !== next.status ||
+		existing.laneId !== next.laneId ||
+		existing.sessionName !== next.sessionName ||
+		existing.worktreePath !== next.worktreePath ||
+		existing.branch !== next.branch ||
+		existing.startedAt !== next.startedAt ||
+		existing.endedAt !== next.endedAt ||
+		existing.retries !== next.retries ||
+		existing.exitReason !== next.exitReason ||
+		existing.dependsOnSegmentIds.length !== next.dependsOnSegmentIds.length ||
+		existing.dependsOnSegmentIds.some(
+			(depSegmentId, idx) => depSegmentId !== next.dependsOnSegmentIds[idx],
+		) ||
+		existing.exitDiagnostic !== next.exitDiagnostic ||
+		existing.expandedFrom !== next.expandedFrom ||
+		existing.expansionRequestId !== next.expansionRequestId;
 
 	if (changed) {
 		Object.assign(existing, next);
@@ -1006,8 +1287,12 @@ function upsertTerminalSegmentRecord(
 	return changed;
 }
 
-function buildFallbackSegmentPlan(taskId: string, task: ParsedTask): TaskSegmentPlan {
-	const repoId = (task.resolvedRepoId && task.resolvedRepoId.trim()) || "default";
+function buildFallbackSegmentPlan(
+	taskId: string,
+	task: ParsedTask,
+): TaskSegmentPlan {
+	const repoId =
+		(task.resolvedRepoId && task.resolvedRepoId.trim()) || "default";
 	return {
 		taskId,
 		mode: "repo-singleton",
@@ -1029,7 +1314,9 @@ function buildFallbackSegmentPlan(taskId: string, task: ParsedTask): TaskSegment
  * Runtime V2 executes one segment per task at a time, so even explicit DAGs
  * are consumed through a deterministic topological order.
  */
-export function linearizeTaskSegmentPlan(plan: TaskSegmentPlan): TaskSegmentNode[] {
+export function linearizeTaskSegmentPlan(
+	plan: TaskSegmentPlan,
+): TaskSegmentNode[] {
 	const nodeById = new Map<string, TaskSegmentNode>();
 	for (const segment of plan.segments) {
 		nodeById.set(segment.segmentId, segment);
@@ -1056,7 +1343,9 @@ export function linearizeTaskSegmentPlan(plan: TaskSegmentPlan): TaskSegmentNode
 
 	const ready: TaskSegmentNode[] = plan.segments
 		.filter((segment) => (indegree.get(segment.segmentId) ?? 0) === 0)
-		.sort((a, b) => (a.order - b.order) || a.segmentId.localeCompare(b.segmentId));
+		.sort(
+			(a, b) => a.order - b.order || a.segmentId.localeCompare(b.segmentId),
+		);
 
 	const ordered: TaskSegmentNode[] = [];
 	while (ready.length > 0) {
@@ -1069,7 +1358,10 @@ export function linearizeTaskSegmentPlan(plan: TaskSegmentPlan): TaskSegmentNode
 				const depNode = nodeById.get(dep);
 				if (depNode) {
 					ready.push(depNode);
-					ready.sort((a, b) => (a.order - b.order) || a.segmentId.localeCompare(b.segmentId));
+					ready.sort(
+						(a, b) =>
+							a.order - b.order || a.segmentId.localeCompare(b.segmentId),
+					);
 				}
 			}
 		}
@@ -1077,7 +1369,9 @@ export function linearizeTaskSegmentPlan(plan: TaskSegmentPlan): TaskSegmentNode
 
 	// Defensive fallback: malformed/cyclic plans retain deterministic segment order.
 	if (ordered.length !== plan.segments.length) {
-		return [...plan.segments].sort((a, b) => (a.order - b.order) || a.segmentId.localeCompare(b.segmentId));
+		return [...plan.segments].sort(
+			(a, b) => a.order - b.order || a.segmentId.localeCompare(b.segmentId),
+		);
 	}
 
 	return ordered;
@@ -1127,8 +1421,8 @@ export function resolveDisplayWaveNumber(
 	fallbackTotal?: number,
 ): { displayWave: number; displayTotal: number } {
 	const taskWaveIdx = roundToTaskWave?.[roundIdx];
-	const displayWave = (taskWaveIdx != null) ? taskWaveIdx + 1 : roundIdx + 1;
-	const displayTotal = taskLevelWaveCount ?? fallbackTotal ?? (roundIdx + 1);
+	const displayWave = taskWaveIdx != null ? taskWaveIdx + 1 : roundIdx + 1;
+	const displayTotal = taskLevelWaveCount ?? fallbackTotal ?? roundIdx + 1;
 	return { displayWave, displayTotal };
 }
 
@@ -1153,7 +1447,8 @@ export function buildSegmentFrontierWaves(
 	const taskStateById = new Map<string, SegmentFrontierTaskState>();
 
 	for (const [taskId, task] of pending.entries()) {
-		const plan = segmentPlans?.get(taskId) ?? buildFallbackSegmentPlan(taskId, task);
+		const plan =
+			segmentPlans?.get(taskId) ?? buildFallbackSegmentPlan(taskId, task);
 		const orderedSegments = linearizeTaskSegmentPlan(plan);
 		const dependsOnBySegmentId = buildSegmentDependencyMap(plan);
 		task.segmentIds = orderedSegments.map((segment) => segment.segmentId);
@@ -1172,7 +1467,12 @@ export function buildSegmentFrontierWaves(
 			taskId,
 			orderedSegments,
 			nextSegmentIndex: 0,
-			statusBySegmentId: new Map(orderedSegments.map((segment) => [segment.segmentId, "pending" as SegmentLifecycleStatus])),
+			statusBySegmentId: new Map(
+				orderedSegments.map((segment) => [
+					segment.segmentId,
+					"pending" as SegmentLifecycleStatus,
+				]),
+			),
 			dependsOnBySegmentId,
 			terminalStatus: "pending",
 		});
@@ -1188,10 +1488,17 @@ export function buildSegmentFrontierWaves(
 		for (const taskId of waveTasks) {
 			const state = taskStateById.get(taskId);
 			if (!state) continue;
-			maxSegmentsInWave = Math.max(maxSegmentsInWave, state.orderedSegments.length);
+			maxSegmentsInWave = Math.max(
+				maxSegmentsInWave,
+				state.orderedSegments.length,
+			);
 		}
 
-		for (let segmentIndex = 0; segmentIndex < maxSegmentsInWave; segmentIndex++) {
+		for (
+			let segmentIndex = 0;
+			segmentIndex < maxSegmentsInWave;
+			segmentIndex++
+		) {
 			const segmentRound: string[] = [];
 			for (const taskId of waveTasks) {
 				const state = taskStateById.get(taskId);
@@ -1240,7 +1547,11 @@ async function attemptWorkerCrashRetry(
 	stateRoot: string,
 	runnerConfig?: TaskRunnerConfig,
 	runtimeBackend?: RuntimeBackend,
-): Promise<{ retriedCount: number; succeededRetries: string[]; failedRetries: string[] }> {
+): Promise<{
+	retriedCount: number;
+	succeededRetries: string[];
+	failedRetries: string[];
+}> {
 	if (!batchState.resilience) {
 		batchState.resilience = defaultResilienceState();
 	}
@@ -1264,7 +1575,7 @@ async function attemptWorkerCrashRetry(
 		if (!lane) continue;
 
 		// Find the task outcome to get exit info
-		const outcome = allTaskOutcomes.find(o => o.taskId === taskId);
+		const outcome = allTaskOutcomes.find((o) => o.taskId === taskId);
 		if (!outcome) continue;
 
 		// Use the canonical exit diagnostic classification when available.
@@ -1275,7 +1586,9 @@ async function attemptWorkerCrashRetry(
 		const classification = outcome.exitDiagnostic?.classification;
 
 		if (!classification) {
-			execLog("batch", batchState.batchId,
+			execLog(
+				"batch",
+				batchState.batchId,
 				`tier0: task ${taskId} has no exit diagnostic classification — skipping auto-retry (conservative)`,
 			);
 			continue;
@@ -1283,7 +1596,9 @@ async function attemptWorkerCrashRetry(
 
 		// Check if retryable
 		if (!TIER0_RETRYABLE_CLASSIFICATIONS.has(classification)) {
-			execLog("batch", batchState.batchId,
+			execLog(
+				"batch",
+				batchState.batchId,
 				`tier0: task ${taskId} exit classification "${classification}" is not retryable — skipping`,
 			);
 			continue;
@@ -1291,7 +1606,9 @@ async function attemptWorkerCrashRetry(
 
 		// model_access_error is handled by attemptModelFallbackRetry() — skip here
 		if (classification === "model_access_error") {
-			execLog("batch", batchState.batchId,
+			execLog(
+				"batch",
+				batchState.batchId,
 				`tier0: task ${taskId} classified as model_access_error — deferring to model fallback handler`,
 			);
 			continue;
@@ -1301,13 +1618,22 @@ async function attemptWorkerCrashRetry(
 		const scopeKey = tier0ScopeKey("worker_crash", taskId, waveIdx);
 		const currentCount = batchState.resilience.retryCountByScope[scopeKey] ?? 0;
 		if (currentCount >= budget.maxRetries) {
-			execLog("batch", batchState.batchId,
+			execLog(
+				"batch",
+				batchState.batchId,
 				`tier0: task ${taskId} retry budget exhausted (${currentCount}/${budget.maxRetries}) — skipping`,
 				{ scopeKey },
 			);
 			// Emit exhausted event
 			emitTier0Event(stateRoot, {
-				...buildTier0EventBase("tier0_recovery_exhausted", batchState.batchId, waveIdx, "worker_crash", currentCount, budget.maxRetries),
+				...buildTier0EventBase(
+					"tier0_recovery_exhausted",
+					batchState.batchId,
+					waveIdx,
+					"worker_crash",
+					currentCount,
+					budget.maxRetries,
+				),
 				taskId,
 				laneNumber: lane.laneNumber,
 				repoId: lane.repoId ?? null,
@@ -1317,10 +1643,23 @@ async function attemptWorkerCrashRetry(
 				affectedTaskIds: [taskId],
 				suggestion: `Task ${taskId} failed with ${classification} and exhausted ${budget.maxRetries} retry attempt(s). Consider investigating the root cause or manually re-running the task.`,
 			});
-			emitTier0Escalation(stateRoot, batchState.batchId, waveIdx, "worker_crash", currentCount, budget.maxRetries,
-				`Retry budget exhausted for task ${taskId} (${classification})`, [taskId],
+			emitTier0Escalation(
+				stateRoot,
+				batchState.batchId,
+				waveIdx,
+				"worker_crash",
+				currentCount,
+				budget.maxRetries,
+				`Retry budget exhausted for task ${taskId} (${classification})`,
+				[taskId],
 				`Task ${taskId} failed with ${classification} and exhausted ${budget.maxRetries} retry attempt(s). Consider investigating the root cause or manually re-running the task.`,
-				{ taskId, laneNumber: lane.laneNumber, repoId: lane.repoId ?? null, classification, scopeKey },
+				{
+					taskId,
+					laneNumber: lane.laneNumber,
+					repoId: lane.repoId ?? null,
+					classification,
+					scopeKey,
+				},
 			);
 			continue;
 		}
@@ -1329,7 +1668,9 @@ async function attemptWorkerCrashRetry(
 		batchState.resilience.retryCountByScope[scopeKey] = currentCount + 1;
 		retriedCount++;
 
-		execLog("batch", batchState.batchId,
+		execLog(
+			"batch",
+			batchState.batchId,
 			`tier0: retrying task ${taskId} (worker_crash, attempt ${currentCount + 1}/${budget.maxRetries}, classification=${classification})`,
 			{ scopeKey, classification },
 		);
@@ -1340,7 +1681,14 @@ async function attemptWorkerCrashRetry(
 
 		// Emit attempt event
 		emitTier0Event(stateRoot, {
-			...buildTier0EventBase("tier0_recovery_attempt", batchState.batchId, waveIdx, "worker_crash", currentCount + 1, budget.maxRetries),
+			...buildTier0EventBase(
+				"tier0_recovery_attempt",
+				batchState.batchId,
+				waveIdx,
+				"worker_crash",
+				currentCount + 1,
+				budget.maxRetries,
+			),
 			taskId,
 			laneNumber: lane.laneNumber,
 			repoId: lane.repoId ?? null,
@@ -1355,7 +1703,7 @@ async function attemptWorkerCrashRetry(
 		}
 
 		// Find the specific AllocatedTask
-		const allocatedTask = lane.tasks.find(t => t.taskId === taskId);
+		const allocatedTask = lane.tasks.find((t) => t.taskId === taskId);
 		if (!allocatedTask) continue;
 
 		// Re-execute: create a single-task lane config for executeLane
@@ -1381,7 +1729,12 @@ async function attemptWorkerCrashRetry(
 				retryPauseSignal,
 				wsRoot,
 				isWsMode,
-				{ ORCH_BATCH_ID: batchState.batchId, ...buildReviewerEnv(runnerConfig?.reviewer), ...buildWorkerExcludeEnv(runnerConfig?.workerExcludeExtensions) }, // TP-089: ensure mailbox works for retries
+				{
+					ORCH_BATCH_ID: batchState.batchId,
+					...buildWorkerEnv(runnerConfig?.worker),
+					...buildReviewerEnv(runnerConfig?.reviewer),
+					...buildWorkerExcludeEnv(runnerConfig?.workerExcludeExtensions),
+				}, // TP-089: ensure mailbox works for retries
 			);
 
 			const retryOutcome = retryResult.tasks[0];
@@ -1395,7 +1748,7 @@ async function attemptWorkerCrashRetry(
 
 				// Update lane results — replace the failed task outcome
 				for (const lr of waveResult.laneResults) {
-					const taskIdx = lr.tasks.findIndex(t => t.taskId === taskId);
+					const taskIdx = lr.tasks.findIndex((t) => t.taskId === taskId);
 					if (taskIdx !== -1) {
 						lr.tasks[taskIdx] = retryOutcome;
 						break;
@@ -1405,18 +1758,24 @@ async function attemptWorkerCrashRetry(
 				// Update allTaskOutcomes
 				upsertTaskOutcome(allTaskOutcomes, retryOutcome);
 
-				execLog("batch", batchState.batchId,
+				execLog(
+					"batch",
+					batchState.batchId,
 					`tier0: task ${taskId} retry succeeded`,
 					{ scopeKey },
 				);
-				onNotify(
-					`✅ Tier 0: Task ${taskId} retry succeeded`,
-					"info",
-				);
+				onNotify(`✅ Tier 0: Task ${taskId} retry succeeded`, "info");
 
 				// Emit success event
 				emitTier0Event(stateRoot, {
-					...buildTier0EventBase("tier0_recovery_success", batchState.batchId, waveIdx, "worker_crash", currentCount + 1, budget.maxRetries),
+					...buildTier0EventBase(
+						"tier0_recovery_success",
+						batchState.batchId,
+						waveIdx,
+						"worker_crash",
+						currentCount + 1,
+						budget.maxRetries,
+					),
 					taskId,
 					laneNumber: lane.laneNumber,
 					repoId: lane.repoId ?? null,
@@ -1429,16 +1788,26 @@ async function attemptWorkerCrashRetry(
 				if (retryOutcome) {
 					upsertTaskOutcome(allTaskOutcomes, retryOutcome);
 				}
-				execLog("batch", batchState.batchId,
+				execLog(
+					"batch",
+					batchState.batchId,
 					`tier0: task ${taskId} retry failed again`,
 					{ scopeKey, exitReason: retryOutcome?.exitReason },
 				);
 
 				// Emit exhausted event (retry failed and budget now consumed)
-				const retryFailError = retryOutcome?.exitReason ?? `Task ${taskId} retry failed again`;
+				const retryFailError =
+					retryOutcome?.exitReason ?? `Task ${taskId} retry failed again`;
 				const retryFailSuggestion = `Task ${taskId} failed again after retry (${classification}). The failure may be persistent — investigate task logs.`;
 				emitTier0Event(stateRoot, {
-					...buildTier0EventBase("tier0_recovery_exhausted", batchState.batchId, waveIdx, "worker_crash", currentCount + 1, budget.maxRetries),
+					...buildTier0EventBase(
+						"tier0_recovery_exhausted",
+						batchState.batchId,
+						waveIdx,
+						"worker_crash",
+						currentCount + 1,
+						budget.maxRetries,
+					),
 					taskId,
 					laneNumber: lane.laneNumber,
 					repoId: lane.repoId ?? null,
@@ -1448,15 +1817,31 @@ async function attemptWorkerCrashRetry(
 					affectedTaskIds: [taskId],
 					suggestion: retryFailSuggestion,
 				});
-				emitTier0Escalation(stateRoot, batchState.batchId, waveIdx, "worker_crash", currentCount + 1, budget.maxRetries,
-					retryFailError, [taskId], retryFailSuggestion,
-					{ taskId, laneNumber: lane.laneNumber, repoId: lane.repoId ?? null, classification, scopeKey },
+				emitTier0Escalation(
+					stateRoot,
+					batchState.batchId,
+					waveIdx,
+					"worker_crash",
+					currentCount + 1,
+					budget.maxRetries,
+					retryFailError,
+					[taskId],
+					retryFailSuggestion,
+					{
+						taskId,
+						laneNumber: lane.laneNumber,
+						repoId: lane.repoId ?? null,
+						classification,
+						scopeKey,
+					},
 				);
 			}
 		} catch (err: unknown) {
 			failedRetries.push(taskId);
 			const errMsg = err instanceof Error ? err.message : String(err);
-			execLog("batch", batchState.batchId,
+			execLog(
+				"batch",
+				batchState.batchId,
 				`tier0: task ${taskId} retry threw error: ${errMsg}`,
 				{ scopeKey },
 			);
@@ -1464,7 +1849,14 @@ async function attemptWorkerCrashRetry(
 			// Emit exhausted event for exception during retry
 			const exceptionSuggestion = `Task ${taskId} retry threw an exception: ${errMsg}. Investigate the execution environment.`;
 			emitTier0Event(stateRoot, {
-				...buildTier0EventBase("tier0_recovery_exhausted", batchState.batchId, waveIdx, "worker_crash", currentCount + 1, budget.maxRetries),
+				...buildTier0EventBase(
+					"tier0_recovery_exhausted",
+					batchState.batchId,
+					waveIdx,
+					"worker_crash",
+					currentCount + 1,
+					budget.maxRetries,
+				),
 				taskId,
 				laneNumber: lane.laneNumber,
 				repoId: lane.repoId ?? null,
@@ -1474,9 +1866,23 @@ async function attemptWorkerCrashRetry(
 				affectedTaskIds: [taskId],
 				suggestion: exceptionSuggestion,
 			});
-			emitTier0Escalation(stateRoot, batchState.batchId, waveIdx, "worker_crash", currentCount + 1, budget.maxRetries,
-				errMsg, [taskId], exceptionSuggestion,
-				{ taskId, laneNumber: lane.laneNumber, repoId: lane.repoId ?? null, classification, scopeKey },
+			emitTier0Escalation(
+				stateRoot,
+				batchState.batchId,
+				waveIdx,
+				"worker_crash",
+				currentCount + 1,
+				budget.maxRetries,
+				errMsg,
+				[taskId],
+				exceptionSuggestion,
+				{
+					taskId,
+					laneNumber: lane.laneNumber,
+					repoId: lane.repoId ?? null,
+					classification,
+					scopeKey,
+				},
 			);
 		}
 	}
@@ -1528,7 +1934,11 @@ async function attemptModelFallbackRetry(
 	stateRoot: string,
 	runnerConfig?: TaskRunnerConfig,
 	runtimeBackend?: RuntimeBackend,
-): Promise<{ retriedCount: number; succeededRetries: string[]; failedRetries: string[] }> {
+): Promise<{
+	retriedCount: number;
+	succeededRetries: string[];
+	failedRetries: string[];
+}> {
 	// Short-circuit: if model fallback is disabled, skip entirely
 	const modelFallbackMode = runnerConfig?.model_fallback ?? "inherit";
 	if (modelFallbackMode !== "inherit") {
@@ -1557,7 +1967,7 @@ async function attemptModelFallbackRetry(
 		const lane = taskToLane.get(taskId);
 		if (!lane) continue;
 
-		const outcome = allTaskOutcomes.find(o => o.taskId === taskId);
+		const outcome = allTaskOutcomes.find((o) => o.taskId === taskId);
 		if (!outcome) continue;
 
 		const classification = outcome.exitDiagnostic?.classification;
@@ -1567,12 +1977,21 @@ async function attemptModelFallbackRetry(
 		const scopeKey = tier0ScopeKey("model_fallback", taskId, waveIdx);
 		const currentCount = batchState.resilience.retryCountByScope[scopeKey] ?? 0;
 		if (currentCount >= budget.maxRetries) {
-			execLog("batch", batchState.batchId,
+			execLog(
+				"batch",
+				batchState.batchId,
 				`tier0: task ${taskId} model fallback retry budget exhausted (${currentCount}/${budget.maxRetries})`,
 				{ scopeKey },
 			);
 			emitTier0Event(stateRoot, {
-				...buildTier0EventBase("tier0_recovery_exhausted", batchState.batchId, waveIdx, "model_fallback", currentCount, budget.maxRetries),
+				...buildTier0EventBase(
+					"tier0_recovery_exhausted",
+					batchState.batchId,
+					waveIdx,
+					"model_fallback",
+					currentCount,
+					budget.maxRetries,
+				),
 				taskId,
 				laneNumber: lane.laneNumber,
 				repoId: lane.repoId ?? null,
@@ -1582,10 +2001,23 @@ async function attemptModelFallbackRetry(
 				affectedTaskIds: [taskId],
 				suggestion: `Task ${taskId} failed with model_access_error and model fallback retry exhausted. Check API key validity and model availability.`,
 			});
-			emitTier0Escalation(stateRoot, batchState.batchId, waveIdx, "model_fallback", currentCount, budget.maxRetries,
-				`Model fallback retry budget exhausted for task ${taskId}`, [taskId],
+			emitTier0Escalation(
+				stateRoot,
+				batchState.batchId,
+				waveIdx,
+				"model_fallback",
+				currentCount,
+				budget.maxRetries,
+				`Model fallback retry budget exhausted for task ${taskId}`,
+				[taskId],
 				`Task ${taskId} failed with model_access_error and model fallback retry exhausted. Check API key validity and model availability.`,
-				{ taskId, laneNumber: lane.laneNumber, repoId: lane.repoId ?? null, classification, scopeKey },
+				{
+					taskId,
+					laneNumber: lane.laneNumber,
+					repoId: lane.repoId ?? null,
+					classification,
+					scopeKey,
+				},
 			);
 			continue;
 		}
@@ -1594,8 +2026,11 @@ async function attemptModelFallbackRetry(
 		batchState.resilience.retryCountByScope[scopeKey] = currentCount + 1;
 		retriedCount++;
 
-		const failedModel = outcome.exitDiagnostic?.errorMessage || "configured model";
-		execLog("batch", batchState.batchId,
+		const failedModel =
+			outcome.exitDiagnostic?.errorMessage || "configured model";
+		execLog(
+			"batch",
+			batchState.batchId,
 			`tier0: model fallback — retrying task ${taskId} without explicit model (${failedModel} unavailable)`,
 			{ scopeKey, classification },
 		);
@@ -1606,7 +2041,14 @@ async function attemptModelFallbackRetry(
 
 		// Emit attempt event
 		emitTier0Event(stateRoot, {
-			...buildTier0EventBase("tier0_recovery_attempt", batchState.batchId, waveIdx, "model_fallback", currentCount + 1, budget.maxRetries),
+			...buildTier0EventBase(
+				"tier0_recovery_attempt",
+				batchState.batchId,
+				waveIdx,
+				"model_fallback",
+				currentCount + 1,
+				budget.maxRetries,
+			),
 			taskId,
 			laneNumber: lane.laneNumber,
 			repoId: lane.repoId ?? null,
@@ -1621,7 +2063,7 @@ async function attemptModelFallbackRetry(
 		}
 
 		// Find the specific AllocatedTask
-		const allocatedTask = lane.tasks.find(t => t.taskId === taskId);
+		const allocatedTask = lane.tasks.find((t) => t.taskId === taskId);
 		if (!allocatedTask) continue;
 
 		// Re-execute with model fallback env var
@@ -1640,7 +2082,13 @@ async function attemptModelFallbackRetry(
 			// Pass TASKPLANE_MODEL_FALLBACK=1 as extra env var to signal
 			// the task-runner to use the session model instead of configured model.
 			// TP-089: Also include ORCH_BATCH_ID so mailbox steering works for retries.
-			const modelFallbackEnv = { TASKPLANE_MODEL_FALLBACK: "1", ORCH_BATCH_ID: batchState.batchId, ...buildReviewerEnv(runnerConfig?.reviewer), ...buildWorkerExcludeEnv(runnerConfig?.workerExcludeExtensions) };
+			const modelFallbackEnv = {
+				TASKPLANE_MODEL_FALLBACK: "1",
+				ORCH_BATCH_ID: batchState.batchId,
+				...buildWorkerEnv(runnerConfig?.worker),
+				...buildReviewerEnv(runnerConfig?.reviewer),
+				...buildWorkerExcludeEnv(runnerConfig?.workerExcludeExtensions),
+			};
 			const retryResult = await executeLaneV2(
 				retryLane,
 				orchConfig,
@@ -1662,7 +2110,7 @@ async function attemptModelFallbackRetry(
 
 				// Update lane results
 				for (const lr of waveResult.laneResults) {
-					const taskIdx = lr.tasks.findIndex(t => t.taskId === taskId);
+					const taskIdx = lr.tasks.findIndex((t) => t.taskId === taskId);
 					if (taskIdx !== -1) {
 						lr.tasks[taskIdx] = retryOutcome;
 						break;
@@ -1671,7 +2119,9 @@ async function attemptModelFallbackRetry(
 
 				upsertTaskOutcome(allTaskOutcomes, retryOutcome);
 
-				execLog("batch", batchState.batchId,
+				execLog(
+					"batch",
+					batchState.batchId,
 					`tier0: task ${taskId} model fallback retry succeeded`,
 					{ scopeKey },
 				);
@@ -1681,7 +2131,14 @@ async function attemptModelFallbackRetry(
 				);
 
 				emitTier0Event(stateRoot, {
-					...buildTier0EventBase("tier0_recovery_success", batchState.batchId, waveIdx, "model_fallback", currentCount + 1, budget.maxRetries),
+					...buildTier0EventBase(
+						"tier0_recovery_success",
+						batchState.batchId,
+						waveIdx,
+						"model_fallback",
+						currentCount + 1,
+						budget.maxRetries,
+					),
 					taskId,
 					laneNumber: lane.laneNumber,
 					repoId: lane.repoId ?? null,
@@ -1694,14 +2151,25 @@ async function attemptModelFallbackRetry(
 				if (retryOutcome) {
 					upsertTaskOutcome(allTaskOutcomes, retryOutcome);
 				}
-				execLog("batch", batchState.batchId,
+				execLog(
+					"batch",
+					batchState.batchId,
 					`tier0: task ${taskId} model fallback retry failed`,
 					{ scopeKey, exitReason: retryOutcome?.exitReason },
 				);
 
-				const retryFailError = retryOutcome?.exitReason ?? `Task ${taskId} model fallback retry failed`;
+				const retryFailError =
+					retryOutcome?.exitReason ??
+					`Task ${taskId} model fallback retry failed`;
 				emitTier0Event(stateRoot, {
-					...buildTier0EventBase("tier0_recovery_exhausted", batchState.batchId, waveIdx, "model_fallback", currentCount + 1, budget.maxRetries),
+					...buildTier0EventBase(
+						"tier0_recovery_exhausted",
+						batchState.batchId,
+						waveIdx,
+						"model_fallback",
+						currentCount + 1,
+						budget.maxRetries,
+					),
 					taskId,
 					laneNumber: lane.laneNumber,
 					repoId: lane.repoId ?? null,
@@ -1711,21 +2179,43 @@ async function attemptModelFallbackRetry(
 					affectedTaskIds: [taskId],
 					suggestion: `Task ${taskId} failed even with session model fallback. Investigate task logs.`,
 				});
-				emitTier0Escalation(stateRoot, batchState.batchId, waveIdx, "model_fallback", currentCount + 1, budget.maxRetries,
-					retryFailError, [taskId],
+				emitTier0Escalation(
+					stateRoot,
+					batchState.batchId,
+					waveIdx,
+					"model_fallback",
+					currentCount + 1,
+					budget.maxRetries,
+					retryFailError,
+					[taskId],
 					`Task ${taskId} failed even with session model fallback. Investigate task logs.`,
-					{ taskId, laneNumber: lane.laneNumber, repoId: lane.repoId ?? null, classification, scopeKey },
+					{
+						taskId,
+						laneNumber: lane.laneNumber,
+						repoId: lane.repoId ?? null,
+						classification,
+						scopeKey,
+					},
 				);
 			}
 		} catch (err: unknown) {
 			failedRetries.push(taskId);
 			const errMsg = err instanceof Error ? err.message : String(err);
-			execLog("batch", batchState.batchId,
+			execLog(
+				"batch",
+				batchState.batchId,
 				`tier0: task ${taskId} model fallback retry threw error: ${errMsg}`,
 				{ scopeKey },
 			);
 			emitTier0Event(stateRoot, {
-				...buildTier0EventBase("tier0_recovery_exhausted", batchState.batchId, waveIdx, "model_fallback", currentCount + 1, budget.maxRetries),
+				...buildTier0EventBase(
+					"tier0_recovery_exhausted",
+					batchState.batchId,
+					waveIdx,
+					"model_fallback",
+					currentCount + 1,
+					budget.maxRetries,
+				),
 				taskId,
 				laneNumber: lane.laneNumber,
 				repoId: lane.repoId ?? null,
@@ -1735,10 +2225,23 @@ async function attemptModelFallbackRetry(
 				affectedTaskIds: [taskId],
 				suggestion: `Model fallback retry for task ${taskId} threw an exception: ${errMsg}`,
 			});
-			emitTier0Escalation(stateRoot, batchState.batchId, waveIdx, "model_fallback", currentCount + 1, budget.maxRetries,
-				errMsg, [taskId],
+			emitTier0Escalation(
+				stateRoot,
+				batchState.batchId,
+				waveIdx,
+				"model_fallback",
+				currentCount + 1,
+				budget.maxRetries,
+				errMsg,
+				[taskId],
 				`Model fallback retry for task ${taskId} threw an exception: ${errMsg}`,
-				{ taskId, laneNumber: lane.laneNumber, repoId: lane.repoId ?? null, classification, scopeKey },
+				{
+					taskId,
+					laneNumber: lane.laneNumber,
+					repoId: lane.repoId ?? null,
+					classification,
+					scopeKey,
+				},
 			);
 		}
 	}
@@ -1779,11 +2282,17 @@ async function attemptStaleWorktreeRecovery(
 	stateRoot: string,
 	runtimeBackend?: RuntimeBackend,
 	onSupervisorAlert?: SupervisorAlertCallback,
-	supervisorAutonomy: "interactive" | "supervised" | "autonomous" = "autonomous",
+	supervisorAutonomy:
+		| "interactive"
+		| "supervised"
+		| "autonomous" = "autonomous",
 	runnerConfig?: TaskRunnerConfig,
 ): Promise<WaveExecutionResult | null> {
 	// Only attempt recovery for ALLOC_WORKTREE_FAILED
-	if (!waveResult.allocationError || waveResult.allocationError.code !== "ALLOC_WORKTREE_FAILED") {
+	if (
+		!waveResult.allocationError ||
+		waveResult.allocationError.code !== "ALLOC_WORKTREE_FAILED"
+	) {
 		return null;
 	}
 
@@ -1796,22 +2305,39 @@ async function attemptStaleWorktreeRecovery(
 	const currentCount = batchState.resilience.retryCountByScope[scopeKey] ?? 0;
 
 	if (currentCount >= budget.maxRetries) {
-		execLog("batch", batchState.batchId,
+		execLog(
+			"batch",
+			batchState.batchId,
 			`tier0: stale worktree retry budget exhausted (${currentCount}/${budget.maxRetries})`,
 			{ scopeKey },
 		);
 		const staleExhaustedError = waveResult.allocationError.message;
 		const staleExhaustedSuggestion = `Stale worktree cleanup exhausted ${budget.maxRetries} retry(s). Manually remove worktrees and prune git state.`;
 		emitTier0Event(stateRoot, {
-			...buildTier0EventBase("tier0_recovery_exhausted", batchState.batchId, waveIdx, "stale_worktree", currentCount, budget.maxRetries),
+			...buildTier0EventBase(
+				"tier0_recovery_exhausted",
+				batchState.batchId,
+				waveIdx,
+				"stale_worktree",
+				currentCount,
+				budget.maxRetries,
+			),
 			repoId: null, // wave-scoped
 			error: staleExhaustedError,
 			scopeKey,
 			affectedTaskIds: waveTasks,
 			suggestion: staleExhaustedSuggestion,
 		});
-		emitTier0Escalation(stateRoot, batchState.batchId, waveIdx, "stale_worktree", currentCount, budget.maxRetries,
-			staleExhaustedError, waveTasks, staleExhaustedSuggestion,
+		emitTier0Escalation(
+			stateRoot,
+			batchState.batchId,
+			waveIdx,
+			"stale_worktree",
+			currentCount,
+			budget.maxRetries,
+			staleExhaustedError,
+			waveTasks,
+			staleExhaustedSuggestion,
 			{ repoId: null, scopeKey },
 		);
 		return null;
@@ -1819,14 +2345,23 @@ async function attemptStaleWorktreeRecovery(
 
 	batchState.resilience.retryCountByScope[scopeKey] = currentCount + 1;
 
-	execLog("batch", batchState.batchId,
+	execLog(
+		"batch",
+		batchState.batchId,
 		`tier0: attempting stale worktree recovery (attempt ${currentCount + 1}/${budget.maxRetries})`,
 		{ scopeKey, allocationError: waveResult.allocationError.message },
 	);
 
 	// Emit attempt event
 	emitTier0Event(stateRoot, {
-		...buildTier0EventBase("tier0_recovery_attempt", batchState.batchId, waveIdx, "stale_worktree", currentCount + 1, budget.maxRetries),
+		...buildTier0EventBase(
+			"tier0_recovery_attempt",
+			batchState.batchId,
+			waveIdx,
+			"stale_worktree",
+			currentCount + 1,
+			budget.maxRetries,
+		),
 		repoId: null, // wave-scoped: allocation failure may span multiple repos
 		classification: waveResult.allocationError.code,
 		cooldownMs: budget.cooldownMs,
@@ -1842,14 +2377,22 @@ async function attemptStaleWorktreeRecovery(
 	const repoRootsToClean: string[] = [repoRoot];
 	if (workspaceConfig) {
 		for (const [, repoConf] of workspaceConfig.repos) {
-			if (repoConf.path !== repoRoot && !repoRootsToClean.includes(repoConf.path)) {
+			if (
+				repoConf.path !== repoRoot &&
+				!repoRootsToClean.includes(repoConf.path)
+			) {
 				repoRootsToClean.push(repoConf.path);
 			}
 		}
 	}
 
 	for (const cleanRoot of repoRootsToClean) {
-		const existingWorktrees = listWorktrees(prefix, cleanRoot, opId, batchState.batchId);
+		const existingWorktrees = listWorktrees(
+			prefix,
+			cleanRoot,
+			opId,
+			batchState.batchId,
+		);
 		for (const wt of existingWorktrees) {
 			forceCleanupWorktree(wt, cleanRoot, batchState.batchId);
 		}
@@ -1863,7 +2406,9 @@ async function attemptStaleWorktreeRecovery(
 	}
 
 	// Retry the wave execution
-	execLog("batch", batchState.batchId,
+	execLog(
+		"batch",
+		batchState.batchId,
 		`tier0: retrying wave ${waveIdx + 1} after stale worktree cleanup`,
 	);
 
@@ -1889,12 +2434,19 @@ async function attemptStaleWorktreeRecovery(
 			tools: runnerConfig?.reviewer?.tools || "",
 			excludeExtensions: runnerConfig?.reviewer?.excludeExtensions ?? [],
 		},
+		runnerConfig?.worker
+			? {
+					model: runnerConfig.worker.model || "",
+					thinking: runnerConfig.worker.thinking || "",
+					tools: runnerConfig.worker.tools || "",
+					excludeExtensions: runnerConfig.worker.excludeExtensions ?? [],
+				}
+			: undefined,
 		runnerConfig?.workerExcludeExtensions ?? [],
 	);
 
 	return retryResult;
 }
-
 
 export interface RuntimeBackendSelection {
 	backend: RuntimeBackend;
@@ -1966,7 +2518,10 @@ export async function executeOrchBatch(
 	agentRoot?: string,
 	onEngineEvent?: EngineEventCallback | null,
 	onSupervisorAlert?: SupervisorAlertCallback | null,
-	supervisorAutonomy: "interactive" | "supervised" | "autonomous" = "autonomous",
+	supervisorAutonomy:
+		| "interactive"
+		| "supervised"
+		| "autonomous" = "autonomous",
 ): Promise<void> {
 	const repoRoot = cwd;
 	// State files (.pi/batch-state.json, lane-state, etc.) belong in the workspace root,
@@ -1976,7 +2531,8 @@ export async function executeOrchBatch(
 	// ── TP-040: Engine event emission helper ─────────────────────
 	// Closure over stateRoot and onEngineEvent to keep emit calls terse.
 	// batchState.batchId is read at call time (it's set in Phase 1).
-	const emitEvent: typeof emitEngineEvent = (sr, event, cb) => emitEngineEvent(sr, event, cb);
+	const emitEvent: typeof emitEngineEvent = (sr, event, cb) =>
+		emitEngineEvent(sr, event, cb);
 
 	// ── TP-076: Supervisor alert emission helper ─────────────────
 	// Wraps the optional callback with a null guard for terse call sites.
@@ -1986,9 +2542,14 @@ export async function executeOrchBatch(
 				onSupervisorAlert(alert);
 			} catch (err: unknown) {
 				const msg = err instanceof Error ? err.message : String(err);
-				execLog("batch", batchState.batchId, `supervisor alert callback failed: ${msg}`, {
-					alertCategory: alert.category,
-				});
+				execLog(
+					"batch",
+					batchState.batchId,
+					`supervisor alert callback failed: ${msg}`,
+					{
+						alertCategory: alert.category,
+					},
+				);
 			}
 		}
 	};
@@ -2004,20 +2565,47 @@ export async function executeOrchBatch(
 		if (terminalEventEmitted) return;
 		terminalEventEmitted = true;
 		if (batchState.phase === "completed" || batchState.phase === "failed") {
-			emitEvent(stateRoot, {
-				...buildEngineEventBase("batch_complete", batchState.batchId, batchState.currentWaveIndex, batchState.phase),
-				succeededTasks: batchState.succeededTasks,
-				failedTasks: batchState.failedTasks,
-				skippedTasks: batchState.skippedTasks,
-				blockedTasks: batchState.blockedTasks,
-				batchDurationMs: batchState.endedAt ? batchState.endedAt - batchState.startedAt : undefined,
-			}, onEngineEvent);
-		} else if (batchState.phase === "paused" || batchState.phase === "stopped") {
-			emitEvent(stateRoot, {
-				...buildEngineEventBase("batch_paused", batchState.batchId, batchState.currentWaveIndex, batchState.phase),
-				reason: reason || (batchState.errors.length > 0 ? batchState.errors[batchState.errors.length - 1] : "paused"),
-				failedTasks: batchState.failedTasks,
-			}, onEngineEvent);
+			emitEvent(
+				stateRoot,
+				{
+					...buildEngineEventBase(
+						"batch_complete",
+						batchState.batchId,
+						batchState.currentWaveIndex,
+						batchState.phase,
+					),
+					succeededTasks: batchState.succeededTasks,
+					failedTasks: batchState.failedTasks,
+					skippedTasks: batchState.skippedTasks,
+					blockedTasks: batchState.blockedTasks,
+					batchDurationMs: batchState.endedAt
+						? batchState.endedAt - batchState.startedAt
+						: undefined,
+				},
+				onEngineEvent,
+			);
+		} else if (
+			batchState.phase === "paused" ||
+			batchState.phase === "stopped"
+		) {
+			emitEvent(
+				stateRoot,
+				{
+					...buildEngineEventBase(
+						"batch_paused",
+						batchState.batchId,
+						batchState.currentWaveIndex,
+						batchState.phase,
+					),
+					reason:
+						reason ||
+						(batchState.errors.length > 0
+							? batchState.errors[batchState.errors.length - 1]
+							: "paused"),
+					failedTasks: batchState.failedTasks,
+				},
+				onEngineEvent,
+			);
 		}
 	};
 
@@ -2028,7 +2616,8 @@ export async function executeOrchBatch(
 	if (!batchState.startedAt) batchState.startedAt = Date.now();
 	// Preserve pauseSignal if already set during "launching" phase (TP-040)
 	// — e.g., /orch-pause issued between /orch return and engine start
-	if (!batchState.pauseSignal?.paused) batchState.pauseSignal = { paused: false };
+	if (!batchState.pauseSignal?.paused)
+		batchState.pauseSignal = { paused: false };
 	batchState.mergeResults = [];
 	batchState.mode = workspaceConfig ? "workspace" : "repo";
 
@@ -2037,8 +2626,13 @@ export async function executeOrchBatch(
 	if (!detectedBranch) {
 		batchState.phase = "failed";
 		batchState.endedAt = Date.now();
-		batchState.errors.push("Cannot determine current branch (detached HEAD or not a git repo)");
-		onNotify("❌ Cannot determine current branch. Ensure HEAD is on a branch (not detached).", "error");
+		batchState.errors.push(
+			"Cannot determine current branch (detached HEAD or not a git repo)",
+		);
+		onNotify(
+			"❌ Cannot determine current branch. Ensure HEAD is on a branch (not detached).",
+			"error",
+		);
 		emitTerminalEvent();
 		return;
 	}
@@ -2050,7 +2644,7 @@ export async function executeOrchBatch(
 
 	// ── State persistence tracking (TS-009 Step 2) ───────────────
 	// Accumulated task outcomes across all waves for state serialization.
-	let allTaskOutcomes: LaneTaskOutcome[] = [];
+	const allTaskOutcomes: LaneTaskOutcome[] = [];
 	// Merge results accumulated across waves (for branch cleanup after worktree removal).
 	const allMergeResults: MergeWaveResult[] = [];
 	// Latest allocated lanes (updated each wave for serialization).
@@ -2060,7 +2654,8 @@ export async function executeOrchBatch(
 	// Segment frontier runtime state keyed by parent task ID.
 	let segmentStateByTask = new Map<string, SegmentFrontierTaskState>();
 	// Processed segment-expansion request IDs (idempotency guard).
-	const processedSegmentExpansionRequestIds = collectProcessedSegmentExpansionRequestIds(batchState);
+	const processedSegmentExpansionRequestIds =
+		collectProcessedSegmentExpansionRequestIds(batchState);
 	// Tasks that have reached terminal status at segment frontier level.
 	const terminalSegmentTasks = new Set<string>();
 	// Reference to discovery result for enriching taskFolder paths.
@@ -2076,7 +2671,10 @@ export async function executeOrchBatch(
 
 	// Preflight
 	const preflight = runPreflight(orchConfig, repoRoot);
-	onNotify(formatPreflightResults(preflight), preflight.passed ? "info" : "error");
+	onNotify(
+		formatPreflightResults(preflight),
+		preflight.passed ? "info" : "error",
+	);
 	if (!preflight.passed) {
 		batchState.phase = "failed";
 		batchState.endedAt = Date.now();
@@ -2096,10 +2694,17 @@ export async function executeOrchBatch(
 				// Check persisted state — a prior batch may still be active
 				try {
 					const state = loadBatchState(stateRoot);
-					if (state && state.phase !== "completed" && state.phase !== "failed" && state.phase !== "stopped") {
+					if (
+						state &&
+						state.phase !== "completed" &&
+						state.phase !== "failed" &&
+						state.phase !== "stopped"
+					) {
 						return true;
 					}
-				} catch { /* state unreadable — safe to sweep */ }
+				} catch {
+					/* state unreadable — safe to sweep */
+				}
 				return false;
 			},
 			now: () => Date.now(),
@@ -2124,7 +2729,10 @@ export async function executeOrchBatch(
 
 		// Layer 5: Clean up prior batch artifacts (TP-168)
 		if (batchState.batchId) {
-			const priorCleanup = cleanupPriorBatchArtifacts(stateRoot, batchState.batchId);
+			const priorCleanup = cleanupPriorBatchArtifacts(
+				stateRoot,
+				batchState.batchId,
+			);
 			const priorMsg = formatPriorBatchCleanup(priorCleanup);
 			if (priorMsg) {
 				onNotify(priorMsg, "info");
@@ -2143,7 +2751,10 @@ export async function executeOrchBatch(
 		useDependencyCache: orchConfig.dependencies.cache,
 		workspaceConfig: workspaceConfig ?? null,
 	});
-	onNotify(formatDiscoveryResults(discovery), discovery.errors.length > 0 ? "warning" : "info");
+	onNotify(
+		formatDiscoveryResults(discovery),
+		discovery.errors.length > 0 ? "warning" : "info",
+	);
 
 	// Check for fatal errors
 	const fatalCodes = new Set<string>(FATAL_DISCOVERY_CODES);
@@ -2154,7 +2765,8 @@ export async function executeOrchBatch(
 		batchState.errors.push("Discovery had fatal errors — cannot proceed");
 		onNotify("❌ Cannot execute due to discovery errors above.", "error");
 		const hasRoutingErrors = fatalErrors.some(
-			(e) => e.code === "TASK_REPO_UNRESOLVED" || e.code === "TASK_REPO_UNKNOWN",
+			(e) =>
+				e.code === "TASK_REPO_UNRESOLVED" || e.code === "TASK_REPO_UNKNOWN",
 		);
 		if (hasRoutingErrors) {
 			onNotify(
@@ -2168,8 +2780,8 @@ export async function executeOrchBatch(
 		if (hasStrictErrors) {
 			onNotify(
 				"💡 Strict routing is enabled (routing.strict: true). Every task must declare an explicit execution target.\n" +
-				"   Add a `## Execution Target` section with `Repo: <id>` to each task's PROMPT.md.\n" +
-				"   To disable strict routing, set `routing.strict: false` in workspace config.",
+					"   Add a `## Execution Target` section with `Repo: <id>` to each task's PROMPT.md.\n" +
+					"   To disable strict routing, set `routing.strict: false` in workspace config.",
 				"info",
 			);
 		}
@@ -2190,11 +2802,17 @@ export async function executeOrchBatch(
 	batchState.dependencyGraph = depGraph;
 
 	// Validate graph
-	const validation = validateGraph(depGraph, discovery.pending, discovery.completed);
+	const validation = validateGraph(
+		depGraph,
+		discovery.pending,
+		discovery.completed,
+	);
 	if (!validation.valid) {
 		batchState.phase = "failed";
 		batchState.endedAt = Date.now();
-		const errMsgs = validation.errors.map(e => `[${e.code}] ${e.message}`).join("\n");
+		const errMsgs = validation.errors
+			.map((e) => `[${e.code}] ${e.message}`)
+			.join("\n");
 		batchState.errors.push(`Graph validation failed:\n${errMsgs}`);
 		onNotify(`❌ Dependency graph errors:\n${errMsgs}`, "error");
 		emitTerminalEvent();
@@ -2207,20 +2825,26 @@ export async function executeOrchBatch(
 		discovery.completed,
 		orchConfig,
 		{
-			workspaceRepoIds: workspaceConfig ? workspaceConfig.repos.keys() : undefined,
+			workspaceRepoIds: workspaceConfig
+				? workspaceConfig.repos.keys()
+				: undefined,
 		},
 	);
 	if (waveComputation.errors.length > 0) {
 		batchState.phase = "failed";
 		batchState.endedAt = Date.now();
-		const errMsgs = waveComputation.errors.map(e => `[${e.code}] ${e.message}`).join("\n");
+		const errMsgs = waveComputation.errors
+			.map((e) => `[${e.code}] ${e.message}`)
+			.join("\n");
 		batchState.errors.push(`Wave computation failed:\n${errMsgs}`);
 		onNotify(`❌ Wave computation errors:\n${errMsgs}`, "error");
 		emitTerminalEvent();
 		return;
 	}
 
-	const taskWaves = waveComputation.waves.map((wave) => wave.tasks.map((assignment) => assignment.taskId));
+	const taskWaves = waveComputation.waves.map((wave) =>
+		wave.tasks.map((assignment) => assignment.taskId),
+	);
 	const packetRepoId = workspaceConfig?.routing?.taskPacketRepo;
 	const frontier = buildSegmentFrontierWaves(
 		taskWaves,
@@ -2234,7 +2858,7 @@ export async function executeOrchBatch(
 
 	// TP-166: Track task-level wave metadata for correct display.
 	// roundToTaskWave maps each segment round index to its parent task-level wave.
-	let roundToTaskWave = frontier.roundToTaskWave;
+	const roundToTaskWave = frontier.roundToTaskWave;
 	const taskLevelWaveCount = frontier.taskLevelWaveCount;
 
 	batchState.totalWaves = rawWaves.length;
@@ -2266,37 +2890,70 @@ export async function executeOrchBatch(
 			const repoBranch = getCurrentBranch(rRoot) || "HEAD";
 			const result = runGit(["branch", orchBranch, repoBranch], rRoot);
 			if (result.ok) {
-				execLog("batch", batchState.batchId, `created orch branch in ${repoId}`, { orchBranch, base: repoBranch });
+				execLog(
+					"batch",
+					batchState.batchId,
+					`created orch branch in ${repoId}`,
+					{ orchBranch, base: repoBranch },
+				);
 			} else {
 				const errDetail = result.stderr || result.stdout || "unknown error";
-				execLog("batch", batchState.batchId, `failed to create orch branch in ${repoId}: ${errDetail}`);
+				execLog(
+					"batch",
+					batchState.batchId,
+					`failed to create orch branch in ${repoId}: ${errDetail}`,
+				);
 				batchState.phase = "failed";
 				batchState.endedAt = Date.now();
-				batchState.errors.push(`Failed to create orch branch '${orchBranch}' in ${repoId}: ${errDetail}`);
-				onNotify(`❌ Failed to create orch branch '${orchBranch}' in ${repoId}: ${errDetail}`, "error");
+				batchState.errors.push(
+					`Failed to create orch branch '${orchBranch}' in ${repoId}: ${errDetail}`,
+				);
+				onNotify(
+					`❌ Failed to create orch branch '${orchBranch}' in ${repoId}: ${errDetail}`,
+					"error",
+				);
 				orchBranchFailed = true;
 				break;
 			}
 		}
-		if (orchBranchFailed) { emitTerminalEvent(); return; }
-	} else {
-		const branchResult = runGit(["branch", orchBranch, batchState.baseBranch], repoRoot);
-		if (!branchResult.ok) {
-			batchState.phase = "failed";
-			batchState.endedAt = Date.now();
-			const errDetail = branchResult.stderr || branchResult.stdout || "unknown error";
-			batchState.errors.push(`Failed to create orch branch '${orchBranch}': ${errDetail}`);
-			onNotify(`❌ Failed to create orch branch '${orchBranch}': ${errDetail}`, "error");
+		if (orchBranchFailed) {
 			emitTerminalEvent();
 			return;
 		}
-		execLog("batch", batchState.batchId, "created orch branch", { orchBranch, baseBranch: batchState.baseBranch });
+	} else {
+		const branchResult = runGit(
+			["branch", orchBranch, batchState.baseBranch],
+			repoRoot,
+		);
+		if (!branchResult.ok) {
+			batchState.phase = "failed";
+			batchState.endedAt = Date.now();
+			const errDetail =
+				branchResult.stderr || branchResult.stdout || "unknown error";
+			batchState.errors.push(
+				`Failed to create orch branch '${orchBranch}': ${errDetail}`,
+			);
+			onNotify(
+				`❌ Failed to create orch branch '${orchBranch}': ${errDetail}`,
+				"error",
+			);
+			emitTerminalEvent();
+			return;
+		}
+		execLog("batch", batchState.batchId, "created orch branch", {
+			orchBranch,
+			baseBranch: batchState.baseBranch,
+		});
 	}
 	batchState.orchBranch = orchBranch;
 
 	// TP-166: Report task-level wave count, not segment round count
 	onNotify(
-		ORCH_MESSAGES.orchStarting(batchState.batchId, taskLevelWaveCount, batchState.totalTasks),
+		ORCH_MESSAGES.orchStarting(
+			batchState.batchId,
+			taskLevelWaveCount,
+			batchState.totalTasks,
+		),
 		"info",
 	);
 
@@ -2304,7 +2961,15 @@ export async function executeOrchBatch(
 	batchState.phase = "executing";
 
 	// ── TS-009: Persist state on batch start (after wave computation) ──
-	persistRuntimeState("batch-start", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+	persistRuntimeState(
+		"batch-start",
+		batchState,
+		wavePlan,
+		latestAllocatedLanes,
+		allTaskOutcomes,
+		discoveryRef,
+		stateRoot,
+	);
 
 	// ── TP-105: Runtime V2 backend selection ────────────────────
 	// Use Runtime V2 (no-TMUX lane-runner) when ALL conditions are met:
@@ -2312,7 +2977,11 @@ export async function executeOrchBatch(
 	//   2. Repo mode (not workspace mode — workspace deferred to TP-109)
 	//   3. The user target is a single direct PROMPT.md path
 	// Otherwise, fall back to the legacy TMUX-backed path.
-	const backendSelection = selectRuntimeBackend(args, rawWaves, workspaceConfig);
+	const backendSelection = selectRuntimeBackend(
+		args,
+		rawWaves,
+		workspaceConfig,
+	);
 	const selectedBackend = backendSelection.backend;
 	const runtimeSegmentRounds = rawWaves.map((waveTasks) => [...waveTasks]);
 
@@ -2325,13 +2994,32 @@ export async function executeOrchBatch(
 		// Check pause signal before starting each wave
 		if (batchState.pauseSignal.paused) {
 			batchState.phase = "paused";
-			execLog("batch", batchState.batchId, `batch paused before wave ${waveIdx + 1}`);
+			execLog(
+				"batch",
+				batchState.batchId,
+				`batch paused before wave ${waveIdx + 1}`,
+			);
 			{
-				const { displayWave } = resolveDisplayWaveNumber(waveIdx, roundToTaskWave, taskLevelWaveCount);
-				onNotify(`⏸️  Batch paused before wave ${displayWave}. Resume not yet implemented (TS-009).`, "warning");
+				const { displayWave } = resolveDisplayWaveNumber(
+					waveIdx,
+					roundToTaskWave,
+					taskLevelWaveCount,
+				);
+				onNotify(
+					`⏸️  Batch paused before wave ${displayWave}. Resume not yet implemented (TS-009).`,
+					"warning",
+				);
 			}
 			// ── TS-009: Persist state on pause ──
-			persistRuntimeState("pause-before-wave", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+			persistRuntimeState(
+				"pause-before-wave",
+				batchState,
+				wavePlan,
+				latestAllocatedLanes,
+				allTaskOutcomes,
+				discoveryRef,
+				stateRoot,
+			);
 			// TP-040: Emit batch_paused event (via terminal helper for dedup)
 			emitTerminalEvent(`Paused before wave ${waveIdx + 1}`);
 			break;
@@ -2340,14 +3028,22 @@ export async function executeOrchBatch(
 		batchState.currentWaveIndex = waveIdx;
 
 		// ── TS-009: Persist state on wave index change ──
-		persistRuntimeState("wave-index-change", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+		persistRuntimeState(
+			"wave-index-change",
+			batchState,
+			wavePlan,
+			latestAllocatedLanes,
+			allTaskOutcomes,
+			discoveryRef,
+			stateRoot,
+		);
 
 		// Filter wave tasks against blocked + terminal task sets, then bind the
 		// next active segment for each surviving task.
 		const scheduledWaveTasks = runtimeSegmentRounds[waveIdx];
 		const blockedInWave: string[] = [];
 		const terminalInWave: string[] = [];
-		let waveTasks: string[] = [];
+		const waveTasks: string[] = [];
 		for (const taskId of scheduledWaveTasks) {
 			if (batchState.blockedTaskIds.has(taskId)) {
 				blockedInWave.push(taskId);
@@ -2364,8 +3060,11 @@ export async function executeOrchBatch(
 				continue;
 			}
 
-			task.segmentIds = segmentState.orderedSegments.map((segment) => segment.segmentId);
-			const activeSegment = segmentState.orderedSegments[segmentState.nextSegmentIndex] ?? null;
+			task.segmentIds = segmentState.orderedSegments.map(
+				(segment) => segment.segmentId,
+			);
+			const activeSegment =
+				segmentState.orderedSegments[segmentState.nextSegmentIndex] ?? null;
 			if (!activeSegment) {
 				segmentState.terminalStatus = "succeeded";
 				task.activeSegmentId = null;
@@ -2378,33 +3077,61 @@ export async function executeOrchBatch(
 			if (workspaceConfig) {
 				task.resolvedRepoId = activeSegment.repoId;
 			}
-			if (segmentState.statusBySegmentId.get(activeSegment.segmentId) === "pending") {
+			if (
+				segmentState.statusBySegmentId.get(activeSegment.segmentId) ===
+				"pending"
+			) {
 				segmentState.statusBySegmentId.set(activeSegment.segmentId, "running");
 			}
 			waveTasks.push(taskId);
 		}
 
 		if (blockedInWave.length > 0) {
-			execLog("batch", batchState.batchId, `wave ${waveIdx + 1}: skipping ${blockedInWave.length} blocked task(s)`, {
-				blocked: blockedInWave.join(","),
-			});
+			execLog(
+				"batch",
+				batchState.batchId,
+				`wave ${waveIdx + 1}: skipping ${blockedInWave.length} blocked task(s)`,
+				{
+					blocked: blockedInWave.join(","),
+				},
+			);
 			batchState.blockedTasks += blockedInWave.length;
 		}
 		if (terminalInWave.length > 0) {
-			execLog("batch", batchState.batchId, `wave ${waveIdx + 1}: skipping ${terminalInWave.length} terminal task(s)`, {
-				terminal: terminalInWave.join(","),
-			});
+			execLog(
+				"batch",
+				batchState.batchId,
+				`wave ${waveIdx + 1}: skipping ${terminalInWave.length} terminal task(s)`,
+				{
+					terminal: terminalInWave.join(","),
+				},
+			);
 		}
 
 		if (waveTasks.length === 0) {
-			execLog("batch", batchState.batchId, `wave ${waveIdx + 1}: no tasks to execute (all blocked or terminal)`);
+			execLog(
+				"batch",
+				batchState.batchId,
+				`wave ${waveIdx + 1}: no tasks to execute (all blocked or terminal)`,
+			);
 			continue;
 		}
 
 		const handleWaveMonitorUpdate: MonitorUpdateCallback = (monitorState) => {
-			const changed = syncTaskOutcomesFromMonitor(monitorState, allTaskOutcomes);
+			const changed = syncTaskOutcomesFromMonitor(
+				monitorState,
+				allTaskOutcomes,
+			);
 			if (changed) {
-				persistRuntimeState("task-transition", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+				persistRuntimeState(
+					"task-transition",
+					batchState,
+					wavePlan,
+					latestAllocatedLanes,
+					allTaskOutcomes,
+					discoveryRef,
+					stateRoot,
+				);
 			}
 			onMonitorUpdate?.(monitorState);
 		};
@@ -2415,13 +3142,28 @@ export async function executeOrchBatch(
 			batchState.currentLanes = lanes;
 
 			// TP-166: Use task-level wave number for operator display
-			const { displayWave, displayTotal } = resolveDisplayWaveNumber(waveIdx, roundToTaskWave, taskLevelWaveCount);
+			const { displayWave, displayTotal } = resolveDisplayWaveNumber(
+				waveIdx,
+				roundToTaskWave,
+				taskLevelWaveCount,
+			);
 			onNotify(
-				ORCH_MESSAGES.orchWaveStart(displayWave, displayTotal, waveTasks.length, lanes.length),
+				ORCH_MESSAGES.orchWaveStart(
+					displayWave,
+					displayTotal,
+					waveTasks.length,
+					lanes.length,
+				),
 				"info",
 			);
 			// TP-148: Build per-task segment context for the wave_start event
-			const waveSegmentContext: Array<{ taskId: string; segmentIndex: number; totalSegments: number; repoId: string; segmentId: string }> = [];
+			const waveSegmentContext: Array<{
+				taskId: string;
+				segmentIndex: number;
+				totalSegments: number;
+				repoId: string;
+				segmentId: string;
+			}> = [];
 			for (const taskId of waveTasks) {
 				const segState = segmentStateByTask.get(taskId);
 				if (segState && segState.orderedSegments.length > 1) {
@@ -2438,25 +3180,45 @@ export async function executeOrchBatch(
 					}
 				}
 			}
-			emitEvent(stateRoot, {
-				...buildEngineEventBase("wave_start", batchState.batchId, waveIdx, batchState.phase),
-				taskIds: waveTasks,
-				laneCount: lanes.length,
-				...(waveSegmentContext.length > 0 ? { segmentContext: waveSegmentContext } : {}),
-			}, onEngineEvent);
+			emitEvent(
+				stateRoot,
+				{
+					...buildEngineEventBase(
+						"wave_start",
+						batchState.batchId,
+						waveIdx,
+						batchState.phase,
+					),
+					taskIds: waveTasks,
+					laneCount: lanes.length,
+					...(waveSegmentContext.length > 0
+						? { segmentContext: waveSegmentContext }
+						: {}),
+				},
+				onEngineEvent,
+			);
 			// TP-029: Track repos from newly allocated lanes for cleanup coverage
 			for (const lane of lanes) {
-				const laneRepoRoot = resolveRepoRoot(lane.repoId, repoRoot, workspaceConfig);
+				const laneRepoRoot = resolveRepoRoot(
+					lane.repoId,
+					repoRoot,
+					workspaceConfig,
+				);
 				encounteredRepoRoots.set(laneRepoRoot, lane.repoId);
 			}
-			const seededPendingOutcomes = seedPendingOutcomesForAllocatedLanes(lanes, allTaskOutcomes);
+			const seededPendingOutcomes = seedPendingOutcomesForAllocatedLanes(
+				lanes,
+				allTaskOutcomes,
+			);
 			let startedSegments = false;
 			for (const lane of lanes) {
 				for (const laneTask of lane.tasks) {
 					const task = discovery.pending.get(laneTask.taskId);
 					const segmentState = segmentStateByTask.get(laneTask.taskId);
 					if (!task || !segmentState) continue;
-					startedSegments = upsertRunningSegmentRecord(batchState, task, segmentState, lane) || startedSegments;
+					startedSegments =
+						upsertRunningSegmentRecord(batchState, task, segmentState, lane) ||
+						startedSegments;
 				}
 			}
 			if (seededPendingOutcomes || startedSegments) {
@@ -2494,6 +3256,14 @@ export async function executeOrchBatch(
 				tools: runnerConfig?.reviewer?.tools || "",
 				excludeExtensions: runnerConfig?.reviewer?.excludeExtensions ?? [],
 			},
+			runnerConfig?.worker
+				? {
+						model: runnerConfig.worker.model || "",
+						thinking: runnerConfig.worker.thinking || "",
+						tools: runnerConfig.worker.tools || "",
+						excludeExtensions: runnerConfig.worker.excludeExtensions ?? [],
+					}
+				: undefined,
 			runnerConfig?.workerExcludeExtensions ?? [],
 		);
 
@@ -2528,27 +3298,53 @@ export async function executeOrchBatch(
 
 				// Emit success or exhausted event based on retry result
 				const staleScopeKey = tier0WaveScopeKey("stale_worktree", waveIdx);
-				const staleCount = batchState.resilience?.retryCountByScope[staleScopeKey] ?? 1;
+				const staleCount =
+					batchState.resilience?.retryCountByScope[staleScopeKey] ?? 1;
 				if (staleRecovered) {
 					emitTier0Event(stateRoot, {
-						...buildTier0EventBase("tier0_recovery_success", batchState.batchId, waveIdx, "stale_worktree", staleCount, TIER0_RETRY_BUDGETS.stale_worktree.maxRetries),
+						...buildTier0EventBase(
+							"tier0_recovery_success",
+							batchState.batchId,
+							waveIdx,
+							"stale_worktree",
+							staleCount,
+							TIER0_RETRY_BUDGETS.stale_worktree.maxRetries,
+						),
 						repoId: null, // wave-scoped
 						resolution: `Stale worktree cleanup succeeded — wave ${waveIdx + 1} re-executed successfully`,
 						scopeKey: staleScopeKey,
 					});
 				} else {
-					const staleRetryError = retryResult.allocationError?.message ?? "Allocation failed again after cleanup";
-					const staleRetrySuggestion = "Stale worktree cleanup did not resolve the allocation failure. Manually inspect and remove worktrees.";
+					const staleRetryError =
+						retryResult.allocationError?.message ??
+						"Allocation failed again after cleanup";
+					const staleRetrySuggestion =
+						"Stale worktree cleanup did not resolve the allocation failure. Manually inspect and remove worktrees.";
 					emitTier0Event(stateRoot, {
-						...buildTier0EventBase("tier0_recovery_exhausted", batchState.batchId, waveIdx, "stale_worktree", staleCount, TIER0_RETRY_BUDGETS.stale_worktree.maxRetries),
+						...buildTier0EventBase(
+							"tier0_recovery_exhausted",
+							batchState.batchId,
+							waveIdx,
+							"stale_worktree",
+							staleCount,
+							TIER0_RETRY_BUDGETS.stale_worktree.maxRetries,
+						),
 						repoId: null, // wave-scoped
 						error: staleRetryError,
 						scopeKey: staleScopeKey,
 						affectedTaskIds: waveTasks,
 						suggestion: staleRetrySuggestion,
 					});
-					emitTier0Escalation(stateRoot, batchState.batchId, waveIdx, "stale_worktree", staleCount, TIER0_RETRY_BUDGETS.stale_worktree.maxRetries,
-						staleRetryError, waveTasks, staleRetrySuggestion,
+					emitTier0Escalation(
+						stateRoot,
+						batchState.batchId,
+						waveIdx,
+						"stale_worktree",
+						staleCount,
+						TIER0_RETRY_BUDGETS.stale_worktree.maxRetries,
+						staleRetryError,
+						waveTasks,
+						staleRetrySuggestion,
 						{ repoId: null, scopeKey: staleScopeKey },
 					);
 				}
@@ -2588,7 +3384,10 @@ export async function executeOrchBatch(
 			);
 			if (modelFallbackOutcome.succeededRetries.length > 0) {
 				// Recompute blocked tasks after model fallback successes
-				if (waveResult.policyApplied === "skip-dependents" && waveResult.failedTaskIds.length > 0) {
+				if (
+					waveResult.policyApplied === "skip-dependents" &&
+					waveResult.failedTaskIds.length > 0
+				) {
 					const recomputed = computeTransitiveDependents(
 						new Set(waveResult.failedTaskIds),
 						depGraph,
@@ -2599,7 +3398,15 @@ export async function executeOrchBatch(
 				}
 			}
 			if (modelFallbackOutcome.retriedCount > 0) {
-				persistRuntimeState("tier0-model-fallback", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+				persistRuntimeState(
+					"tier0-model-fallback",
+					batchState,
+					wavePlan,
+					latestAllocatedLanes,
+					allTaskOutcomes,
+					discoveryRef,
+					stateRoot,
+				);
 			}
 		}
 
@@ -2625,7 +3432,10 @@ export async function executeOrchBatch(
 				// Recompute blockedTaskIds from remaining failures (R002-2).
 				// attemptWorkerCrashRetry already updated waveResult.failedTaskIds
 				// and waveResult.succeededTaskIds in-place.
-				if (waveResult.policyApplied === "skip-dependents" && waveResult.failedTaskIds.length > 0) {
+				if (
+					waveResult.policyApplied === "skip-dependents" &&
+					waveResult.failedTaskIds.length > 0
+				) {
 					const recomputed = computeTransitiveDependents(
 						new Set(waveResult.failedTaskIds),
 						depGraph,
@@ -2638,7 +3448,15 @@ export async function executeOrchBatch(
 			}
 			if (retryOutcome.retriedCount > 0) {
 				// Persist updated state after retries
-				persistRuntimeState("tier0-worker-retry", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+				persistRuntimeState(
+					"tier0-worker-retry",
+					batchState,
+					wavePlan,
+					latestAllocatedLanes,
+					allTaskOutcomes,
+					discoveryRef,
+					stateRoot,
+				);
 			}
 
 			// If stop-wave had paused the batch but Tier 0 retry recovered all
@@ -2646,12 +3464,14 @@ export async function executeOrchBatch(
 			// proceed. attemptWorkerCrashRetry already set stoppedEarly=false
 			// and overallStatus="succeeded" on the waveResult (R002-4 fix).
 			if (
-				waveResult.failedTaskIds.length === 0
-				&& batchState.pauseSignal.paused
-				&& waveResult.policyApplied === "stop-wave"
+				waveResult.failedTaskIds.length === 0 &&
+				batchState.pauseSignal.paused &&
+				waveResult.policyApplied === "stop-wave"
 			) {
 				batchState.pauseSignal.paused = false;
-				execLog("batch", batchState.batchId,
+				execLog(
+					"batch",
+					batchState.batchId,
 					`tier0: all failed tasks recovered — clearing stop-wave pause`,
 				);
 				onNotify(
@@ -2681,32 +3501,64 @@ export async function executeOrchBatch(
 
 			// Use the completing segment ID from the task outcome, not task.activeSegmentId
 			// which may already be null (advanced by pre-wave loop for next wave).
-			const outcome = allTaskOutcomes.find((candidate) => candidate.taskId === taskId);
+			const outcome = allTaskOutcomes.find(
+				(candidate) => candidate.taskId === taskId,
+			);
 			const activeSegmentId = outcome?.segmentId ?? task.activeSegmentId;
 			if (activeSegmentId) {
 				segmentState.statusBySegmentId.set(activeSegmentId, "succeeded");
-				upsertTerminalSegmentRecord(batchState, task, segmentState, activeSegmentId, "succeeded", outcome, laneByTaskId.get(taskId));
+				upsertTerminalSegmentRecord(
+					batchState,
+					task,
+					segmentState,
+					activeSegmentId,
+					"succeeded",
+					outcome,
+					laneByTaskId.get(taskId),
+				);
 
-				const workerAgentId = resolveTaskWorkerAgentId(taskId, allTaskOutcomes, laneByTaskId, agentIdPrefix);
+				const workerAgentId = resolveTaskWorkerAgentId(
+					taskId,
+					allTaskOutcomes,
+					laneByTaskId,
+					agentIdPrefix,
+				);
 				if (workerAgentId) {
-					const pendingExpansionFiles = listPendingSegmentExpansionRequestFiles(stateRoot, batchState.batchId, workerAgentId);
+					const pendingExpansionFiles = listPendingSegmentExpansionRequestFiles(
+						stateRoot,
+						batchState.batchId,
+						workerAgentId,
+					);
 					if (pendingExpansionFiles.length > 0) {
-						const parsedRequests = parseSegmentExpansionRequests(pendingExpansionFiles);
+						const parsedRequests = parseSegmentExpansionRequests(
+							pendingExpansionFiles,
+						);
 						for (const malformed of parsedRequests.malformed) {
-							const renamed = markSegmentExpansionRequestFile(malformed.filePath, "invalid");
-							execLog("batch", batchState.batchId, `segment expansion request malformed (${renamed ? "renamed to .invalid" : "rename failed"})`, {
-								taskId,
-								agentId: workerAgentId,
-								segmentId: activeSegmentId,
-								filePath: malformed.filePath,
-								reason: malformed.reason,
-							});
+							const renamed = markSegmentExpansionRequestFile(
+								malformed.filePath,
+								"invalid",
+							);
+							execLog(
+								"batch",
+								batchState.batchId,
+								`segment expansion request malformed (${renamed ? "renamed to .invalid" : "rename failed"})`,
+								{
+									taskId,
+									agentId: workerAgentId,
+									segmentId: activeSegmentId,
+									filePath: malformed.filePath,
+									reason: malformed.reason,
+								},
+							);
 						}
-						const orderedRequests = [...parsedRequests.valid].sort((a, b) => a.request.requestId.localeCompare(b.request.requestId));
-						const scopedRequests = orderedRequests.filter((pendingRequest) => (
-							pendingRequest.request.taskId === taskId
-							&& pendingRequest.request.fromSegmentId === activeSegmentId
-						));
+						const orderedRequests = [...parsedRequests.valid].sort((a, b) =>
+							a.request.requestId.localeCompare(b.request.requestId),
+						);
+						const scopedRequests = orderedRequests.filter(
+							(pendingRequest) =>
+								pendingRequest.request.taskId === taskId &&
+								pendingRequest.request.fromSegmentId === activeSegmentId,
+						);
 						let rejectedCount = 0;
 						let acceptedCount = 0;
 						for (const pendingRequest of scopedRequests) {
@@ -2724,11 +3576,27 @@ export async function executeOrchBatch(
 							if (!processingResult.ok) {
 								rejectedCount += 1;
 								processedSegmentExpansionRequestIds.add(requestId);
-								const recordedRequestId = recordProcessedSegmentExpansionRequestId(batchState, requestId, "failed");
+								const recordedRequestId =
+									recordProcessedSegmentExpansionRequestId(
+										batchState,
+										requestId,
+										"failed",
+									);
 								if (recordedRequestId) {
-									persistRuntimeState("segment-expansion-rejected", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+									persistRuntimeState(
+										"segment-expansion-rejected",
+										batchState,
+										wavePlan,
+										latestAllocatedLanes,
+										allTaskOutcomes,
+										discoveryRef,
+										stateRoot,
+									);
 								}
-								const renamedRejected = markSegmentExpansionRequestFile(pendingRequest.filePath, "rejected");
+								const renamedRejected = markSegmentExpansionRequestFile(
+									pendingRequest.filePath,
+									"rejected",
+								);
 								emitAlert({
 									category: "segment-expansion-rejected",
 									summary:
@@ -2749,7 +3617,9 @@ export async function executeOrchBatch(
 								continue;
 							}
 
-							const beforeSegmentIds = segmentState.orderedSegments.map((segment) => segment.segmentId);
+							const beforeSegmentIds = segmentState.orderedSegments.map(
+								(segment) => segment.segmentId,
+							);
 							const mutation = handoffSegmentExpansionToMutation(
 								batchState.batchId,
 								taskId,
@@ -2758,18 +3628,26 @@ export async function executeOrchBatch(
 								pendingRequest,
 								segmentState,
 							);
-							task.segmentIds = segmentState.orderedSegments.map((segment) => segment.segmentId);
-							const afterSegmentIds = [...task.segmentIds];
-							const persistedInsertedSegments = upsertPendingExpandedSegmentRecords(
-								batchState,
-								task,
-								segmentState,
-								mutation.insertedSegmentIds,
-								activeSegmentId,
-								requestId,
-								batchState.orchBranch,
+							task.segmentIds = segmentState.orderedSegments.map(
+								(segment) => segment.segmentId,
 							);
-							const recordedRequestId = recordProcessedSegmentExpansionRequestId(batchState, requestId, "succeeded");
+							const afterSegmentIds = [...task.segmentIds];
+							const persistedInsertedSegments =
+								upsertPendingExpandedSegmentRecords(
+									batchState,
+									task,
+									segmentState,
+									mutation.insertedSegmentIds,
+									activeSegmentId,
+									requestId,
+									batchState.orchBranch,
+								);
+							const recordedRequestId =
+								recordProcessedSegmentExpansionRequestId(
+									batchState,
+									requestId,
+									"succeeded",
+								);
 
 							// TP-145 hardening: if .DONE was prematurely created by the
 							// completing segment (because it was the last segment at that
@@ -2785,29 +3663,53 @@ export async function executeOrchBatch(
 								const lane = laneByTaskId.get(taskId);
 								const doneDir = lane
 									? resolveCanonicalTaskPaths(
-										task.taskFolder,
-										lane.worktreePath,
-										repoRoot,
-										!!workspaceConfig,
-									).taskFolderResolved
+											task.taskFolder,
+											lane.worktreePath,
+											repoRoot,
+											!!workspaceConfig,
+										).taskFolderResolved
 									: task.packetTaskPath || task.taskFolder;
 								if (doneDir) {
 									const donePath = join(doneDir, ".DONE");
 									if (existsSync(donePath)) {
 										try {
 											unlinkSync(donePath);
-											execLog("batch", batchState.batchId, "removed premature .DONE after segment expansion", {
-												taskId, donePath, requestId,
-											});
-										} catch { /* non-fatal */ }
+											execLog(
+												"batch",
+												batchState.batchId,
+												"removed premature .DONE after segment expansion",
+												{
+													taskId,
+													donePath,
+													requestId,
+												},
+											);
+										} catch {
+											/* non-fatal */
+										}
 									}
 								}
 							}
 
-							if (persistedInsertedSegments || recordedRequestId || mutation.insertedSegmentIds.length > 0) {
-								persistRuntimeState("segment-expansion-approved", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+							if (
+								persistedInsertedSegments ||
+								recordedRequestId ||
+								mutation.insertedSegmentIds.length > 0
+							) {
+								persistRuntimeState(
+									"segment-expansion-approved",
+									batchState,
+									wavePlan,
+									latestAllocatedLanes,
+									allTaskOutcomes,
+									discoveryRef,
+									stateRoot,
+								);
 							}
-							const renamedProcessed = markSegmentExpansionRequestFile(pendingRequest.filePath, "processed");
+							const renamedProcessed = markSegmentExpansionRequestFile(
+								pendingRequest.filePath,
+								"processed",
+							);
 							emitAlert({
 								category: "segment-expansion-approved",
 								summary:
@@ -2828,60 +3730,99 @@ export async function executeOrchBatch(
 							});
 							acceptedCount += 1;
 						}
-						execLog("batch", batchState.batchId, `segment ${activeSegmentId} completed with ${pendingExpansionFiles.length} pending expansion request(s)`, {
-							taskId,
-							agentId: workerAgentId,
-							segmentId: activeSegmentId,
-							acceptedCount,
-							rejectedCount,
-							validRequests: parsedRequests.valid.length,
-							scopedRequests: scopedRequests.length,
-							ignoredRequests: orderedRequests.length - scopedRequests.length,
-							malformedRequests: parsedRequests.malformed.length,
-						});
+						execLog(
+							"batch",
+							batchState.batchId,
+							`segment ${activeSegmentId} completed with ${pendingExpansionFiles.length} pending expansion request(s)`,
+							{
+								taskId,
+								agentId: workerAgentId,
+								segmentId: activeSegmentId,
+								acceptedCount,
+								rejectedCount,
+								validRequests: parsedRequests.valid.length,
+								scopedRequests: scopedRequests.length,
+								ignoredRequests: orderedRequests.length - scopedRequests.length,
+								malformedRequests: parsedRequests.malformed.length,
+							},
+						);
 					}
 				}
 			}
 			recomputeNextPendingSegmentIndex(segmentState);
 			task.activeSegmentId = null;
 
-			if (segmentState.nextSegmentIndex >= segmentState.orderedSegments.length) {
+			if (
+				segmentState.nextSegmentIndex >= segmentState.orderedSegments.length
+			) {
 				segmentState.terminalStatus = "succeeded";
 				terminalSegmentTasks.add(taskId);
 				completedTaskIdsThisWave.push(taskId);
-			} else if (!hasTaskInFutureSegmentRounds(runtimeSegmentRounds, waveIdx + 1, taskId)) {
+			} else if (
+				!hasTaskInFutureSegmentRounds(runtimeSegmentRounds, waveIdx + 1, taskId)
+			) {
 				continuationTaskIds.add(taskId);
 			}
 		}
 		if (continuationTaskIds.size > 0) {
-			const continuationWave = scheduleContinuationSegmentRound(runtimeSegmentRounds, waveIdx, continuationTaskIds);
+			const continuationWave = scheduleContinuationSegmentRound(
+				runtimeSegmentRounds,
+				waveIdx,
+				continuationTaskIds,
+			);
 			// TP-166: Maintain roundToTaskWave mapping for the inserted continuation round.
 			// The continuation belongs to the same task-level wave as the current round.
 			const parentTaskWave = roundToTaskWave[waveIdx] ?? 0;
 			roundToTaskWave.splice(waveIdx + 1, 0, parentTaskWave);
 			batchState.roundToTaskWave = [...roundToTaskWave];
-			execLog("batch", batchState.batchId, "scheduled continuation segment round for expanded task frontier", {
-				waveIndex: waveIdx,
-				taskIds: continuationWave.join(","),
-				runtimeSegmentRoundCount: runtimeSegmentRounds.length,
-			});
+			execLog(
+				"batch",
+				batchState.batchId,
+				"scheduled continuation segment round for expanded task frontier",
+				{
+					waveIndex: waveIdx,
+					taskIds: continuationWave.join(","),
+					runtimeSegmentRoundCount: runtimeSegmentRounds.length,
+				},
+			);
 		}
 
 		for (const taskId of waveResult.failedTaskIds) {
 			const task = discovery.pending.get(taskId);
 			const segmentState = segmentStateByTask.get(taskId);
 			if (!task || !segmentState) continue;
-			const failOutcome = allTaskOutcomes.find((candidate) => candidate.taskId === taskId);
+			const failOutcome = allTaskOutcomes.find(
+				(candidate) => candidate.taskId === taskId,
+			);
 			const activeSegmentId = failOutcome?.segmentId ?? task.activeSegmentId;
 			if (activeSegmentId) {
 				segmentState.statusBySegmentId.set(activeSegmentId, "failed");
-				upsertTerminalSegmentRecord(batchState, task, segmentState, activeSegmentId, "failed", failOutcome, laneByTaskId.get(taskId));
+				upsertTerminalSegmentRecord(
+					batchState,
+					task,
+					segmentState,
+					activeSegmentId,
+					"failed",
+					failOutcome,
+					laneByTaskId.get(taskId),
+				);
 
-				const workerAgentId = resolveTaskWorkerAgentId(taskId, allTaskOutcomes, laneByTaskId, agentIdPrefix);
+				const workerAgentId = resolveTaskWorkerAgentId(
+					taskId,
+					allTaskOutcomes,
+					laneByTaskId,
+					agentIdPrefix,
+				);
 				if (workerAgentId) {
-					const pendingExpansionFiles = listPendingSegmentExpansionRequestFiles(stateRoot, batchState.batchId, workerAgentId);
+					const pendingExpansionFiles = listPendingSegmentExpansionRequestFiles(
+						stateRoot,
+						batchState.batchId,
+						workerAgentId,
+					);
 					if (pendingExpansionFiles.length > 0) {
-						const parsedRequests = parseSegmentExpansionRequests(pendingExpansionFiles);
+						const parsedRequests = parseSegmentExpansionRequests(
+							pendingExpansionFiles,
+						);
 						for (const malformed of parsedRequests.malformed) {
 							markSegmentExpansionRequestFile(malformed.filePath, "invalid");
 						}
@@ -2889,28 +3830,54 @@ export async function executeOrchBatch(
 						let discardedCount = 0;
 						let ignoredCount = 0;
 						for (const requestFile of parsedRequests.valid) {
-							if (requestFile.request.taskId === taskId && requestFile.request.fromSegmentId === activeSegmentId) {
+							if (
+								requestFile.request.taskId === taskId &&
+								requestFile.request.fromSegmentId === activeSegmentId
+							) {
 								const requestId = requestFile.request.requestId;
 								processedSegmentExpansionRequestIds.add(requestId);
-								const recordedRequestId = recordProcessedSegmentExpansionRequestId(batchState, requestId, "skipped");
+								const recordedRequestId =
+									recordProcessedSegmentExpansionRequestId(
+										batchState,
+										requestId,
+										"skipped",
+									);
 								if (recordedRequestId) {
-									persistRuntimeState("segment-expansion-discarded", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+									persistRuntimeState(
+										"segment-expansion-discarded",
+										batchState,
+										wavePlan,
+										latestAllocatedLanes,
+										allTaskOutcomes,
+										discoveryRef,
+										stateRoot,
+									);
 								}
-								if (markSegmentExpansionRequestFile(requestFile.filePath, "discarded")) {
+								if (
+									markSegmentExpansionRequestFile(
+										requestFile.filePath,
+										"discarded",
+									)
+								) {
 									discardedCount += 1;
 								}
 								continue;
 							}
 							ignoredCount += 1;
 						}
-						execLog("batch", batchState.batchId, `segment ${activeSegmentId} failed with ${pendingExpansionFiles.length} pending expansion request(s)`, {
-							taskId,
-							agentId: workerAgentId,
-							segmentId: activeSegmentId,
-							discardedCount,
-							ignoredCount,
-							malformedCount: parsedRequests.malformed.length,
-						});
+						execLog(
+							"batch",
+							batchState.batchId,
+							`segment ${activeSegmentId} failed with ${pendingExpansionFiles.length} pending expansion request(s)`,
+							{
+								taskId,
+								agentId: workerAgentId,
+								segmentId: activeSegmentId,
+								discardedCount,
+								ignoredCount,
+								malformedCount: parsedRequests.malformed.length,
+							},
+						);
 						if (discardedCount > 0) {
 							emitAlert({
 								category: "segment-expansion-rejected",
@@ -2924,7 +3891,8 @@ export async function executeOrchBatch(
 									taskId,
 									segmentId: activeSegmentId,
 									agentId: workerAgentId,
-									exitReason: "segment-expansion-discarded-originating-segment-failed",
+									exitReason:
+										"segment-expansion-discarded-originating-segment-failed",
 								},
 							});
 						}
@@ -2944,8 +3912,18 @@ export async function executeOrchBatch(
 			const activeSegmentId = task.activeSegmentId;
 			if (activeSegmentId) {
 				segmentState.statusBySegmentId.set(activeSegmentId, "skipped");
-				const outcome = allTaskOutcomes.find((candidate) => candidate.taskId === taskId);
-				upsertTerminalSegmentRecord(batchState, task, segmentState, activeSegmentId, "skipped", outcome, laneByTaskId.get(taskId));
+				const outcome = allTaskOutcomes.find(
+					(candidate) => candidate.taskId === taskId,
+				);
+				upsertTerminalSegmentRecord(
+					batchState,
+					task,
+					segmentState,
+					activeSegmentId,
+					"skipped",
+					outcome,
+					laneByTaskId.get(taskId),
+				);
 			}
 			task.activeSegmentId = null;
 			segmentState.terminalStatus = "skipped";
@@ -2971,31 +3949,55 @@ export async function executeOrchBatch(
 		// ── TP-040: Emit task_complete / task_failed events ──────
 		// Emitted after Tier 0 retry so events reflect final status.
 		for (const taskId of waveResult.succeededTaskIds) {
-			const outcome = allTaskOutcomes.find(o => o.taskId === taskId);
-			emitEvent(stateRoot, {
-				...buildEngineEventBase("task_complete", batchState.batchId, waveIdx, batchState.phase),
-				taskId,
-				durationMs: outcome?.startTime && outcome?.endTime
-					? outcome.endTime - outcome.startTime
-					: undefined,
-				outcome: "succeeded",
-			}, onEngineEvent);
+			const outcome = allTaskOutcomes.find((o) => o.taskId === taskId);
+			emitEvent(
+				stateRoot,
+				{
+					...buildEngineEventBase(
+						"task_complete",
+						batchState.batchId,
+						waveIdx,
+						batchState.phase,
+					),
+					taskId,
+					durationMs:
+						outcome?.startTime && outcome?.endTime
+							? outcome.endTime - outcome.startTime
+							: undefined,
+					outcome: "succeeded",
+				},
+				onEngineEvent,
+			);
 		}
 		for (const taskId of waveResult.failedTaskIds) {
-			const outcome = allTaskOutcomes.find(o => o.taskId === taskId);
-			emitEvent(stateRoot, {
-				...buildEngineEventBase("task_failed", batchState.batchId, waveIdx, batchState.phase),
-				taskId,
-				durationMs: outcome?.startTime && outcome?.endTime
-					? outcome.endTime - outcome.startTime
-					: undefined,
-				reason: outcome?.exitReason || "unknown",
-				partialProgress: (outcome?.partialProgressCommits ?? 0) > 0,
-			}, onEngineEvent);
+			const outcome = allTaskOutcomes.find((o) => o.taskId === taskId);
+			emitEvent(
+				stateRoot,
+				{
+					...buildEngineEventBase(
+						"task_failed",
+						batchState.batchId,
+						waveIdx,
+						batchState.phase,
+					),
+					taskId,
+					durationMs:
+						outcome?.startTime && outcome?.endTime
+							? outcome.endTime - outcome.startTime
+							: undefined,
+					reason: outcome?.exitReason || "unknown",
+					partialProgress: (outcome?.partialProgressCommits ?? 0) > 0,
+				},
+				onEngineEvent,
+			);
 
 			// ── TP-076: Emit supervisor alert for task failure ──────
-			const laneForTask = latestAllocatedLanes.find(l => l.tasks.some(t => t.taskId === taskId));
-			const allocatedTask = laneForTask?.tasks.find(t => t.taskId === taskId)?.task;
+			const laneForTask = latestAllocatedLanes.find((l) =>
+				l.tasks.some((t) => t.taskId === taskId),
+			);
+			const allocatedTask = laneForTask?.tasks.find(
+				(t) => t.taskId === taskId,
+			)?.task;
 			const exitReason = outcome?.exitReason || "unknown";
 			const hasPartialProgress = (outcome?.partialProgressCommits ?? 0) > 0;
 			const segmentFrontier = buildSupervisorSegmentFrontierSnapshot(
@@ -3005,12 +4007,15 @@ export async function executeOrchBatch(
 				batchState.segments,
 				outcome?.segmentId,
 			);
-			const segmentId = outcome?.segmentId
-				?? allocatedTask?.activeSegmentId
-				?? segmentFrontier?.activeSegmentId
-				?? undefined;
+			const segmentId =
+				outcome?.segmentId ??
+				allocatedTask?.activeSegmentId ??
+				segmentFrontier?.activeSegmentId ??
+				undefined;
 			const repoId = segmentId
-				? (segmentFrontier?.segments.find((segment) => segment.segmentId === segmentId)?.repoId ?? laneForTask?.repoId)
+				? (segmentFrontier?.segments.find(
+						(segment) => segment.segmentId === segmentId,
+					)?.repoId ?? laneForTask?.repoId)
 				: laneForTask?.repoId;
 			const segmentSummary = segmentId
 				? `  Segment: ${segmentId}${repoId ? ` (repo: ${repoId})` : ""}\n`
@@ -3049,11 +4054,25 @@ export async function executeOrchBatch(
 		}
 
 		// ── TS-009: Persist state after wave execution ──
-		persistRuntimeState("wave-execution-complete", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+		persistRuntimeState(
+			"wave-execution-complete",
+			batchState,
+			wavePlan,
+			latestAllocatedLanes,
+			allTaskOutcomes,
+			discoveryRef,
+			stateRoot,
+		);
 
-		const elapsedSec = Math.round((waveResult.endedAt - waveResult.startedAt) / 1000);
+		const elapsedSec = Math.round(
+			(waveResult.endedAt - waveResult.startedAt) / 1000,
+		);
 		{
-			const { displayWave: completeDisplayWave } = resolveDisplayWaveNumber(waveIdx, roundToTaskWave, taskLevelWaveCount);
+			const { displayWave: completeDisplayWave } = resolveDisplayWaveNumber(
+				waveIdx,
+				roundToTaskWave,
+				taskLevelWaveCount,
+			);
 			onNotify(
 				ORCH_MESSAGES.orchWaveComplete(
 					completeDisplayWave,
@@ -3075,8 +4094,19 @@ export async function executeOrchBatch(
 			if (waveResult.policyApplied === "stop-all") {
 				batchState.phase = "stopped";
 				// ── TS-009: Persist state on stop-all ──
-				persistRuntimeState("stop-all", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
-				onNotify(ORCH_MESSAGES.orchBatchStopped(batchState.batchId, "stop-all"), "error");
+				persistRuntimeState(
+					"stop-all",
+					batchState,
+					wavePlan,
+					latestAllocatedLanes,
+					allTaskOutcomes,
+					discoveryRef,
+					stateRoot,
+				);
+				onNotify(
+					ORCH_MESSAGES.orchBatchStopped(batchState.batchId, "stop-all"),
+					"error",
+				);
 				// TP-040: Emit batch_paused event (via terminal helper for dedup)
 				emitTerminalEvent(`Stopped by stop-all policy at wave ${waveIdx + 1}`);
 				break;
@@ -3084,8 +4114,19 @@ export async function executeOrchBatch(
 			if (waveResult.policyApplied === "stop-wave") {
 				batchState.phase = "stopped";
 				// ── TS-009: Persist state on stop-wave ──
-				persistRuntimeState("stop-wave", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
-				onNotify(ORCH_MESSAGES.orchBatchStopped(batchState.batchId, "stop-wave"), "error");
+				persistRuntimeState(
+					"stop-wave",
+					batchState,
+					wavePlan,
+					latestAllocatedLanes,
+					allTaskOutcomes,
+					discoveryRef,
+					stateRoot,
+				);
+				onNotify(
+					ORCH_MESSAGES.orchBatchStopped(batchState.batchId, "stop-wave"),
+					"error",
+				);
 				// TP-040: Emit batch_paused event (via terminal helper for dedup)
 				emitTerminalEvent(`Stopped by stop-wave policy at wave ${waveIdx + 1}`);
 				break;
@@ -3102,10 +4143,10 @@ export async function executeOrchBatch(
 		for (const lr of waveResult.laneResults) {
 			laneOutcomeByNumber.set(lr.laneNumber, lr);
 		}
-		const mixedOutcomeLanes = waveResult.laneResults.filter(lr => {
-			const hasSucceeded = lr.tasks.some(t => t.status === "succeeded");
+		const mixedOutcomeLanes = waveResult.laneResults.filter((lr) => {
+			const hasSucceeded = lr.tasks.some((t) => t.status === "succeeded");
 			const hasHardFailure = lr.tasks.some(
-				t => t.status === "failed" || t.status === "stalled",
+				(t) => t.status === "failed" || t.status === "stalled",
 			);
 			return hasSucceeded && hasHardFailure;
 		});
@@ -3121,44 +4162,71 @@ export async function executeOrchBatch(
 			if (!lane.worktreePath || !existsSync(lane.worktreePath)) continue;
 			const laneOutcome = laneOutcomeByNumber.get(lane.laneNumber);
 			if (!laneOutcome) continue;
-			const hasSucceeded = laneOutcome.tasks.some(t => t.status === "succeeded");
-			const hasSkipped = laneOutcome.tasks.some(t => t.status === "skipped");
+			const hasSucceeded = laneOutcome.tasks.some(
+				(t) => t.status === "succeeded",
+			);
+			const hasSkipped = laneOutcome.tasks.some((t) => t.status === "skipped");
 			// Auto-commit merge candidates (succeeded) and skipped-task lanes
 			if (!hasSucceeded && !hasSkipped) continue;
 			try {
 				const addResult = runGit(["add", "-A"], lane.worktreePath);
 				if (!addResult.ok) {
-					execLog("merge", batchState.batchId, `safety-net: git add failed in ${lane.laneId}`, { stderr: addResult.stderr });
+					execLog(
+						"merge",
+						batchState.batchId,
+						`safety-net: git add failed in ${lane.laneId}`,
+						{ stderr: addResult.stderr },
+					);
 					continue;
 				}
-				const statusResult = runGit(["status", "--porcelain"], lane.worktreePath);
+				const statusResult = runGit(
+					["status", "--porcelain"],
+					lane.worktreePath,
+				);
 				if (!statusResult.ok || !statusResult.stdout?.trim()) continue;
-				const taskIds = lane.tasks.map(t => t.taskId).join(", ");
+				const taskIds = lane.tasks.map((t) => t.taskId).join(", ");
 				const commitResult = runGit(
 					["commit", "-m", `safety-net: uncommitted artifacts for ${taskIds}`],
 					lane.worktreePath,
 				);
 				if (commitResult.ok) {
-					execLog("merge", batchState.batchId, `safety-net: auto-committed uncommitted files in ${lane.laneId}`, {
-						worktree: lane.worktreePath,
-						taskIds,
-						files: statusResult.stdout.trim(),
-					});
+					execLog(
+						"merge",
+						batchState.batchId,
+						`safety-net: auto-committed uncommitted files in ${lane.laneId}`,
+						{
+							worktree: lane.worktreePath,
+							taskIds,
+							files: statusResult.stdout.trim(),
+						},
+					);
 				} else {
-					execLog("merge", batchState.batchId, `safety-net: commit failed in ${lane.laneId}`, { stderr: commitResult.stderr });
+					execLog(
+						"merge",
+						batchState.batchId,
+						`safety-net: commit failed in ${lane.laneId}`,
+						{ stderr: commitResult.stderr },
+					);
 				}
 			} catch (err: any) {
-				execLog("merge", batchState.batchId, `safety-net: unexpected error in ${lane.laneId}`, { error: err?.message });
+				execLog(
+					"merge",
+					batchState.batchId,
+					`safety-net: unexpected error in ${lane.laneId}`,
+					{ error: err?.message },
+				);
 			}
 		}
 
 		if (succeededSegmentTaskIdsForMerge.length > 0) {
-			const mergeableLaneCount = waveResult.allocatedLanes.filter(lane => {
+			const mergeableLaneCount = waveResult.allocatedLanes.filter((lane) => {
 				const outcome = laneOutcomeByNumber.get(lane.laneNumber);
 				if (!outcome) return false;
-				const hasSucceeded = outcome.tasks.some(t => t.status === "succeeded");
+				const hasSucceeded = outcome.tasks.some(
+					(t) => t.status === "succeeded",
+				);
 				const hasHardFailure = outcome.tasks.some(
-					t => t.status === "failed" || t.status === "stalled",
+					(t) => t.status === "failed" || t.status === "stalled",
 				);
 				return hasSucceeded && !hasHardFailure;
 			}).length;
@@ -3166,13 +4234,40 @@ export async function executeOrchBatch(
 			if (mergeableLaneCount > 0) {
 				batchState.phase = "merging";
 				// ── TS-009: Persist state on executing→merging transition ──
-				persistRuntimeState("merge-start", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
-				onNotify(ORCH_MESSAGES.orchMergeStart(resolveDisplayWaveNumber(waveIdx, roundToTaskWave, taskLevelWaveCount).displayWave, mergeableLaneCount), "info");
+				persistRuntimeState(
+					"merge-start",
+					batchState,
+					wavePlan,
+					latestAllocatedLanes,
+					allTaskOutcomes,
+					discoveryRef,
+					stateRoot,
+				);
+				onNotify(
+					ORCH_MESSAGES.orchMergeStart(
+						resolveDisplayWaveNumber(
+							waveIdx,
+							roundToTaskWave,
+							taskLevelWaveCount,
+						).displayWave,
+						mergeableLaneCount,
+					),
+					"info",
+				);
 				// TP-040: Emit merge_start event
-				emitEvent(stateRoot, {
-					...buildEngineEventBase("merge_start", batchState.batchId, waveIdx, batchState.phase),
-					laneCount: mergeableLaneCount,
-				}, onEngineEvent);
+				emitEvent(
+					stateRoot,
+					{
+						...buildEngineEventBase(
+							"merge_start",
+							batchState.batchId,
+							waveIdx,
+							batchState.phase,
+						),
+						laneCount: mergeableLaneCount,
+					},
+					onEngineEvent,
+				);
 
 				// TP-056: Start merge health monitor during merge phase
 				const mergeHealthMonitor = new MergeHealthMonitor({
@@ -3181,11 +4276,16 @@ export async function executeOrchBatch(
 					waveIndex: waveIdx,
 					phase: batchState.phase,
 					onDeadSession: (sessionName, laneNumber) => {
-						execLog("batch", batchState.batchId, `merge health monitor detected dead session`, {
-							sessionName,
-							laneNumber,
-							waveIndex: waveIdx,
-						});
+						execLog(
+							"batch",
+							batchState.batchId,
+							`merge health monitor detected dead session`,
+							{
+								sessionName,
+								laneNumber,
+								waveIndex: waveIdx,
+							},
+						);
 					},
 				});
 				mergeHealthMonitor.start();
@@ -3215,7 +4315,15 @@ export async function executeOrchBatch(
 				batchState.mergeResults.push(mergeResult);
 
 				// Persist state after merge so dashboard shows wave merge results
-				persistRuntimeState("merge-complete", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+				persistRuntimeState(
+					"merge-complete",
+					batchState,
+					wavePlan,
+					latestAllocatedLanes,
+					allTaskOutcomes,
+					discoveryRef,
+					stateRoot,
+				);
 
 				// Emit per-lane merge notifications
 				for (const lr of mergeResult.laneResults) {
@@ -3223,26 +4331,59 @@ export async function executeOrchBatch(
 					// TP-032 R006-3: Check lr.error first — verification_new_failure lanes
 					// have error set even though lr.result.status may be SUCCESS/CONFLICT_RESOLVED.
 					if (lr.error) {
-						onNotify(ORCH_MESSAGES.orchMergeLaneFailed(lr.laneNumber, lr.error), "error");
+						onNotify(
+							ORCH_MESSAGES.orchMergeLaneFailed(lr.laneNumber, lr.error),
+							"error",
+						);
 					} else if (lr.result?.status === "SUCCESS") {
-						onNotify(ORCH_MESSAGES.orchMergeLaneSuccess(lr.laneNumber, lr.result.merge_commit, durationSec), "info");
+						onNotify(
+							ORCH_MESSAGES.orchMergeLaneSuccess(
+								lr.laneNumber,
+								lr.result.merge_commit,
+								durationSec,
+							),
+							"info",
+						);
 					} else if (lr.result?.status === "CONFLICT_RESOLVED") {
-						onNotify(ORCH_MESSAGES.orchMergeLaneConflictResolved(lr.laneNumber, lr.result.conflicts.length, durationSec), "info");
-					} else if (lr.result?.status === "CONFLICT_UNRESOLVED" || lr.result?.status === "BUILD_FAILURE") {
-						onNotify(ORCH_MESSAGES.orchMergeLaneFailed(lr.laneNumber, lr.result.status), "error");
+						onNotify(
+							ORCH_MESSAGES.orchMergeLaneConflictResolved(
+								lr.laneNumber,
+								lr.result.conflicts.length,
+								durationSec,
+							),
+							"info",
+						);
+					} else if (
+						lr.result?.status === "CONFLICT_UNRESOLVED" ||
+						lr.result?.status === "BUILD_FAILURE"
+					) {
+						onNotify(
+							ORCH_MESSAGES.orchMergeLaneFailed(
+								lr.laneNumber,
+								lr.result.status,
+							),
+							"error",
+						);
 					}
 				}
 
 				// If any lane has mixed outcomes, do not silently discard succeeded work.
 				// Force merge failure handling so state is preserved for manual resolution.
 				if (mixedOutcomeLanes.length > 0) {
-					const mixedIds = mixedOutcomeLanes.map(l => `lane-${l.laneNumber}`).join(", ");
+					const mixedIds = mixedOutcomeLanes
+						.map((l) => `lane-${l.laneNumber}`)
+						.join(", ");
 					const failureReason =
 						`Lane(s) ${mixedIds} contain both succeeded and failed tasks. ` +
 						`Automatic partial-branch merge is disabled to avoid dropping succeeded commits.`;
-					execLog("merge", `W${waveIdx + 1}`, "mixed-outcome lanes detected — escalating to merge failure handling", {
-						mixedLaneIds: mixedIds,
-					});
+					execLog(
+						"merge",
+						`W${waveIdx + 1}`,
+						"mixed-outcome lanes detected — escalating to merge failure handling",
+						{
+							mixedLaneIds: mixedIds,
+						},
+					);
 					mergeResult = {
 						...mergeResult,
 						status: "partial",
@@ -3251,39 +4392,80 @@ export async function executeOrchBatch(
 					};
 					// Update the already-pushed references so persisted state reflects "partial"
 					allMergeResults[allMergeResults.length - 1] = mergeResult;
-					batchState.mergeResults[batchState.mergeResults.length - 1] = mergeResult;
+					batchState.mergeResults[batchState.mergeResults.length - 1] =
+						mergeResult;
 				}
 
 				// Emit overall merge result notification
 				// TP-032 R006-3: Exclude verification_new_failure lanes from success count
 				const mergedCount = mergeResult.laneResults.filter(
-					r => !r.error && (r.result?.status === "SUCCESS" || r.result?.status === "CONFLICT_RESOLVED"),
+					(r) =>
+						!r.error &&
+						(r.result?.status === "SUCCESS" ||
+							r.result?.status === "CONFLICT_RESOLVED"),
 				).length;
 				const mergeTotalSec = Math.round(mergeResult.totalDurationMs / 1000);
 
 				if (mergeResult.status === "succeeded") {
-					const { displayWave: mergeDisplayWave } = resolveDisplayWaveNumber(waveIdx, roundToTaskWave, taskLevelWaveCount);
-					onNotify(ORCH_MESSAGES.orchMergeComplete(mergeDisplayWave, mergedCount, mergeTotalSec), "info");
+					const { displayWave: mergeDisplayWave } = resolveDisplayWaveNumber(
+						waveIdx,
+						roundToTaskWave,
+						taskLevelWaveCount,
+					);
+					onNotify(
+						ORCH_MESSAGES.orchMergeComplete(
+							mergeDisplayWave,
+							mergedCount,
+							mergeTotalSec,
+						),
+						"info",
+					);
 
 					// TP-040: Emit merge_success event
-					emitEvent(stateRoot, {
-						...buildEngineEventBase("merge_success", batchState.batchId, waveIdx, batchState.phase),
-						laneCount: mergedCount,
-						durationMs: mergeResult.totalDurationMs,
-						totalWaves: taskLevelWaveCount,
-					}, onEngineEvent);
+					emitEvent(
+						stateRoot,
+						{
+							...buildEngineEventBase(
+								"merge_success",
+								batchState.batchId,
+								waveIdx,
+								batchState.phase,
+							),
+							laneCount: mergedCount,
+							durationMs: mergeResult.totalDurationMs,
+							totalWaves: taskLevelWaveCount,
+						},
+						onEngineEvent,
+					);
 				} else {
 					onNotify(
-						ORCH_MESSAGES.orchMergeFailed(resolveDisplayWaveNumber(waveIdx, roundToTaskWave, taskLevelWaveCount).displayWave, mergeResult.failedLane ?? 0, mergeResult.failureReason || "unknown"),
+						ORCH_MESSAGES.orchMergeFailed(
+							resolveDisplayWaveNumber(
+								waveIdx,
+								roundToTaskWave,
+								taskLevelWaveCount,
+							).displayWave,
+							mergeResult.failedLane ?? 0,
+							mergeResult.failureReason || "unknown",
+						),
 						"error",
 					);
 
 					// TP-040: Emit merge_failed event
-					emitEvent(stateRoot, {
-						...buildEngineEventBase("merge_failed", batchState.batchId, waveIdx, batchState.phase),
-						laneNumber: mergeResult.failedLane ?? undefined,
-						error: mergeResult.failureReason || "unknown",
-					}, onEngineEvent);
+					emitEvent(
+						stateRoot,
+						{
+							...buildEngineEventBase(
+								"merge_failed",
+								batchState.batchId,
+								waveIdx,
+								batchState.phase,
+							),
+							laneNumber: mergeResult.failedLane ?? undefined,
+							error: mergeResult.failureReason || "unknown",
+						},
+						onEngineEvent,
+					);
 
 					// Emit repo-divergence summary when partial is caused by cross-repo outcome differences
 					if (mergeResult.status === "partial") {
@@ -3297,9 +4479,19 @@ export async function executeOrchBatch(
 				// Restore phase to executing (may be overridden below by failure handling)
 				batchState.phase = "executing";
 				// ── TS-009: Persist state after merge (merging→executing) ──
-				persistRuntimeState("merge-complete", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+				persistRuntimeState(
+					"merge-complete",
+					batchState,
+					wavePlan,
+					latestAllocatedLanes,
+					allTaskOutcomes,
+					discoveryRef,
+					stateRoot,
+				);
 			} else if (mixedOutcomeLanes.length > 0) {
-				const mixedIds = mixedOutcomeLanes.map(l => `lane-${l.laneNumber}`).join(", ");
+				const mixedIds = mixedOutcomeLanes
+					.map((l) => `lane-${l.laneNumber}`)
+					.join(", ");
 				mergeResult = {
 					waveIndex: waveIdx + 1,
 					status: "partial",
@@ -3315,23 +4507,55 @@ export async function executeOrchBatch(
 				allMergeResults.push(mergeResult);
 				batchState.mergeResults.push(mergeResult);
 				onNotify(
-					ORCH_MESSAGES.orchMergeFailed(resolveDisplayWaveNumber(waveIdx, roundToTaskWave, taskLevelWaveCount).displayWave, mergeResult.failedLane, mergeResult.failureReason || "unknown"),
+					ORCH_MESSAGES.orchMergeFailed(
+						resolveDisplayWaveNumber(
+							waveIdx,
+							roundToTaskWave,
+							taskLevelWaveCount,
+						).displayWave,
+						mergeResult.failedLane,
+						mergeResult.failureReason || "unknown",
+					),
 					"error",
 				);
 
 				// TP-040 R002: Emit merge_failed for mixed-outcome/no-mergeable-lane path
-				emitEvent(stateRoot, {
-					...buildEngineEventBase("merge_failed", batchState.batchId, waveIdx, batchState.phase),
-					laneNumber: mergeResult.failedLane,
-					error: mergeResult.failureReason,
-				}, onEngineEvent);
+				emitEvent(
+					stateRoot,
+					{
+						...buildEngineEventBase(
+							"merge_failed",
+							batchState.batchId,
+							waveIdx,
+							batchState.phase,
+						),
+						laneNumber: mergeResult.failedLane,
+						error: mergeResult.failureReason,
+					},
+					onEngineEvent,
+				);
 			} else {
 				// No mergeable lanes and no mixed outcomes (e.g., only skipped tasks)
-				onNotify(ORCH_MESSAGES.orchMergeSkipped(resolveDisplayWaveNumber(waveIdx, roundToTaskWave, taskLevelWaveCount).displayWave), "info");
+				onNotify(
+					ORCH_MESSAGES.orchMergeSkipped(
+						resolveDisplayWaveNumber(
+							waveIdx,
+							roundToTaskWave,
+							taskLevelWaveCount,
+						).displayWave,
+					),
+					"info",
+				);
 			}
 		} else {
 			// No succeeded tasks — skip merge entirely
-			onNotify(ORCH_MESSAGES.orchMergeSkipped(resolveDisplayWaveNumber(waveIdx, roundToTaskWave, taskLevelWaveCount).displayWave), "info");
+			onNotify(
+				ORCH_MESSAGES.orchMergeSkipped(
+					resolveDisplayWaveNumber(waveIdx, roundToTaskWave, taskLevelWaveCount)
+						.displayWave,
+				),
+				"info",
+			);
 		}
 
 		// ── TP-033: Safe-stop on rollback failure ─────────────────
@@ -3341,30 +4565,47 @@ export async function executeOrchBatch(
 		if (mergeResult?.rollbackFailed) {
 			// TP-033 R004-2: Include persistence error warning when transaction
 			// record files may be missing, so operator knows to inspect manually
-			const hasPersistErrors = mergeResult.persistenceErrors && mergeResult.persistenceErrors.length > 0;
+			const hasPersistErrors =
+				mergeResult.persistenceErrors &&
+				mergeResult.persistenceErrors.length > 0;
 			const persistWarning = hasPersistErrors
 				? ` WARNING: ${mergeResult.persistenceErrors!.length} transaction record(s) failed to persist — recovery file(s) may be missing.`
 				: "";
 
-			execLog("batch", batchState.batchId, "SAFE-STOP: verification rollback failed — forcing paused regardless of policy", {
-				waveIndex: waveIdx,
-				configPolicy: orchConfig.failure.on_merge_failure,
-				...(hasPersistErrors ? { persistenceErrors: mergeResult.persistenceErrors } : {}),
-			});
+			execLog(
+				"batch",
+				batchState.batchId,
+				"SAFE-STOP: verification rollback failed — forcing paused regardless of policy",
+				{
+					waveIndex: waveIdx,
+					configPolicy: orchConfig.failure.on_merge_failure,
+					...(hasPersistErrors
+						? { persistenceErrors: mergeResult.persistenceErrors }
+						: {}),
+				},
+			);
 
 			batchState.phase = "paused";
 			batchState.errors.push(
 				`Safe-stop at wave ${waveIdx + 1}: verification rollback failed. ` +
-				`Merge worktree and temp branch preserved for recovery. ` +
-				`Check transaction records in .pi/verification/ for recovery commands.` +
-				persistWarning
+					`Merge worktree and temp branch preserved for recovery. ` +
+					`Check transaction records in .pi/verification/ for recovery commands.` +
+					persistWarning,
 			);
-			persistRuntimeState("merge-rollback-safe-stop", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+			persistRuntimeState(
+				"merge-rollback-safe-stop",
+				batchState,
+				wavePlan,
+				latestAllocatedLanes,
+				allTaskOutcomes,
+				discoveryRef,
+				stateRoot,
+			);
 			onNotify(
 				`🛑 Safe-stop: verification rollback failed at wave ${waveIdx + 1}. ` +
-				`Batch force-paused. Merge worktree preserved for manual recovery. ` +
-				`See .pi/verification/ transaction records for recovery commands.` +
-				persistWarning,
+					`Batch force-paused. Merge worktree preserved for manual recovery. ` +
+					`See .pi/verification/ transaction records for recovery commands.` +
+					persistWarning,
 				"error",
 			);
 
@@ -3398,7 +4639,10 @@ export async function executeOrchBatch(
 		// TP-033 Step 2 (R006): Retry policy matrix via shared applyMergeRetryLoop.
 		// Classifies the failure, loops retries per the matrix (supports maxAttempts>1),
 		// and on exhaustion forces paused regardless of on_merge_failure config.
-		if (mergeResult && (mergeResult.status === "failed" || mergeResult.status === "partial")) {
+		if (
+			mergeResult &&
+			(mergeResult.status === "failed" || mergeResult.status === "partial")
+		) {
 			// Initialize resilience state if not yet present (fresh batch)
 			if (!batchState.resilience) {
 				batchState.resilience = defaultResilienceState();
@@ -3432,20 +4676,38 @@ export async function executeOrchBatch(
 							selectedBackend,
 						);
 					},
-					persist: (trigger) => persistRuntimeState(trigger, batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot),
-					log: (message, details) => execLog("batch", batchState.batchId, message, details),
+					persist: (trigger) =>
+						persistRuntimeState(
+							trigger,
+							batchState,
+							wavePlan,
+							latestAllocatedLanes,
+							allTaskOutcomes,
+							discoveryRef,
+							stateRoot,
+						),
+					log: (message, details) =>
+						execLog("batch", batchState.batchId, message, details),
 					notify: (message, level) => onNotify(message, level),
 					updateMergeResult: (result) => {
 						mergeResult = result;
 						allMergeResults[allMergeResults.length - 1] = result;
-						batchState.mergeResults[batchState.mergeResults.length - 1] = result;
+						batchState.mergeResults[batchState.mergeResults.length - 1] =
+							result;
 					},
 					sleep: sleepSync,
 					// TP-039 R004: Emit attempt event only when retry is actually scheduled,
 					// with accurate classification/attempt data from the retry decision.
 					onRetryAttempt: (decision) => {
 						emitTier0Event(stateRoot, {
-							...buildTier0EventBase("tier0_recovery_attempt", batchState.batchId, waveIdx, "merge_timeout", decision.currentAttempt, decision.maxAttempts),
+							...buildTier0EventBase(
+								"tier0_recovery_attempt",
+								batchState.batchId,
+								waveIdx,
+								"merge_timeout",
+								decision.currentAttempt,
+								decision.maxAttempts,
+							),
 							laneNumber: mergeFailedLane,
 							repoId: mergeRepoId,
 							classification: decision.classification,
@@ -3458,11 +4720,26 @@ export async function executeOrchBatch(
 			if (retryOutcome.kind === "retry_succeeded") {
 				mergeResult = retryOutcome.mergeResult;
 				batchState.phase = "executing";
-				persistRuntimeState("merge-retry-succeeded", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+				persistRuntimeState(
+					"merge-retry-succeeded",
+					batchState,
+					wavePlan,
+					latestAllocatedLanes,
+					allTaskOutcomes,
+					discoveryRef,
+					stateRoot,
+				);
 
 				// Emit merge retry success event
 				emitTier0Event(stateRoot, {
-					...buildTier0EventBase("tier0_recovery_success", batchState.batchId, waveIdx, "merge_timeout", retryOutcome.lastDecision.currentAttempt, retryOutcome.lastDecision.maxAttempts),
+					...buildTier0EventBase(
+						"tier0_recovery_success",
+						batchState.batchId,
+						waveIdx,
+						"merge_timeout",
+						retryOutcome.lastDecision.currentAttempt,
+						retryOutcome.lastDecision.maxAttempts,
+					),
 					laneNumber: mergeFailedLane,
 					repoId: mergeRepoId,
 					classification: retryOutcome.classification ?? undefined,
@@ -3475,7 +4752,15 @@ export async function executeOrchBatch(
 				mergeResult = retryOutcome.mergeResult;
 				batchState.phase = "paused";
 				batchState.errors.push(retryOutcome.errorMessage);
-				persistRuntimeState("merge-rollback-safe-stop", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+				persistRuntimeState(
+					"merge-rollback-safe-stop",
+					batchState,
+					wavePlan,
+					latestAllocatedLanes,
+					allTaskOutcomes,
+					discoveryRef,
+					stateRoot,
+				);
 				onNotify(retryOutcome.notifyMessage, "error");
 
 				// ── TP-076: Emit supervisor alert for merge safe-stop ──
@@ -3500,9 +4785,17 @@ export async function executeOrchBatch(
 				});
 
 				// Emit merge safe-stop event (treated as exhausted — no further automatic recovery possible)
-				const mergeSafeStopSuggestion = "Merge rollback failed — batch force-paused for manual recovery. Check .pi/verification/ for recovery commands.";
+				const mergeSafeStopSuggestion =
+					"Merge rollback failed — batch force-paused for manual recovery. Check .pi/verification/ for recovery commands.";
 				emitTier0Event(stateRoot, {
-					...buildTier0EventBase("tier0_recovery_exhausted", batchState.batchId, waveIdx, "merge_timeout", retryOutcome.lastDecision.currentAttempt, retryOutcome.lastDecision.maxAttempts),
+					...buildTier0EventBase(
+						"tier0_recovery_exhausted",
+						batchState.batchId,
+						waveIdx,
+						"merge_timeout",
+						retryOutcome.lastDecision.currentAttempt,
+						retryOutcome.lastDecision.maxAttempts,
+					),
 					laneNumber: mergeFailedLane,
 					repoId: mergeRepoId,
 					classification: retryOutcome.classification ?? undefined,
@@ -3510,10 +4803,22 @@ export async function executeOrchBatch(
 					scopeKey: retryOutcome.scopeKey,
 					suggestion: mergeSafeStopSuggestion,
 				});
-				emitTier0Escalation(stateRoot, batchState.batchId, waveIdx, "merge_timeout",
-					retryOutcome.lastDecision.currentAttempt, retryOutcome.lastDecision.maxAttempts,
-					retryOutcome.errorMessage, [], mergeSafeStopSuggestion,
-					{ laneNumber: mergeFailedLane, repoId: mergeRepoId, classification: retryOutcome.classification ?? undefined, scopeKey: retryOutcome.scopeKey },
+				emitTier0Escalation(
+					stateRoot,
+					batchState.batchId,
+					waveIdx,
+					"merge_timeout",
+					retryOutcome.lastDecision.currentAttempt,
+					retryOutcome.lastDecision.maxAttempts,
+					retryOutcome.errorMessage,
+					[],
+					mergeSafeStopSuggestion,
+					{
+						laneNumber: mergeFailedLane,
+						repoId: mergeRepoId,
+						classification: retryOutcome.classification ?? undefined,
+						scopeKey: retryOutcome.scopeKey,
+					},
 				);
 
 				preserveWorktreesForResume = true;
@@ -3522,20 +4827,33 @@ export async function executeOrchBatch(
 				// TP-033 R006-2: Force paused regardless of on_merge_failure config.
 				// Retry exhaustion takes precedence over config policy.
 				mergeResult = retryOutcome.mergeResult;
-				const exhaustionMsg = retryOutcome.errorMessage +
+				const exhaustionMsg =
+					retryOutcome.errorMessage +
 					` [${retryOutcome.classification ?? "unknown"} ${retryOutcome.lastDecision.currentAttempt}/${retryOutcome.lastDecision.maxAttempts}, scope=${retryOutcome.scopeKey}]`;
 
-				execLog("batch", batchState.batchId, `merge retry exhausted — forcing paused`, {
-					classification: retryOutcome.classification,
-					scopeKey: retryOutcome.scopeKey,
-					attempts: retryOutcome.lastDecision.currentAttempt,
-					maxAttempts: retryOutcome.lastDecision.maxAttempts,
-				});
+				execLog(
+					"batch",
+					batchState.batchId,
+					`merge retry exhausted — forcing paused`,
+					{
+						classification: retryOutcome.classification,
+						scopeKey: retryOutcome.scopeKey,
+						attempts: retryOutcome.lastDecision.currentAttempt,
+						maxAttempts: retryOutcome.lastDecision.maxAttempts,
+					},
+				);
 
 				// Emit merge retry exhausted event
 				const mergeExhaustedSuggestion = `Merge retry exhausted (${retryOutcome.classification ?? "unknown"}) after ${retryOutcome.lastDecision.currentAttempt} attempt(s). Investigate merge failure and retry manually.`;
 				emitTier0Event(stateRoot, {
-					...buildTier0EventBase("tier0_recovery_exhausted", batchState.batchId, waveIdx, "merge_timeout", retryOutcome.lastDecision.currentAttempt, retryOutcome.lastDecision.maxAttempts),
+					...buildTier0EventBase(
+						"tier0_recovery_exhausted",
+						batchState.batchId,
+						waveIdx,
+						"merge_timeout",
+						retryOutcome.lastDecision.currentAttempt,
+						retryOutcome.lastDecision.maxAttempts,
+					),
 					laneNumber: mergeFailedLane,
 					repoId: mergeRepoId,
 					classification: retryOutcome.classification ?? undefined,
@@ -3543,15 +4861,35 @@ export async function executeOrchBatch(
 					scopeKey: retryOutcome.scopeKey,
 					suggestion: mergeExhaustedSuggestion,
 				});
-				emitTier0Escalation(stateRoot, batchState.batchId, waveIdx, "merge_timeout",
-					retryOutcome.lastDecision.currentAttempt, retryOutcome.lastDecision.maxAttempts,
-					exhaustionMsg, [], mergeExhaustedSuggestion,
-					{ laneNumber: mergeFailedLane, repoId: mergeRepoId, classification: retryOutcome.classification ?? undefined, scopeKey: retryOutcome.scopeKey },
+				emitTier0Escalation(
+					stateRoot,
+					batchState.batchId,
+					waveIdx,
+					"merge_timeout",
+					retryOutcome.lastDecision.currentAttempt,
+					retryOutcome.lastDecision.maxAttempts,
+					exhaustionMsg,
+					[],
+					mergeExhaustedSuggestion,
+					{
+						laneNumber: mergeFailedLane,
+						repoId: mergeRepoId,
+						classification: retryOutcome.classification ?? undefined,
+						scopeKey: retryOutcome.scopeKey,
+					},
 				);
 
 				batchState.phase = "paused";
 				batchState.errors.push(exhaustionMsg);
-				persistRuntimeState("merge-retry-exhausted", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+				persistRuntimeState(
+					"merge-retry-exhausted",
+					batchState,
+					wavePlan,
+					latestAllocatedLanes,
+					allTaskOutcomes,
+					discoveryRef,
+					stateRoot,
+				);
 				onNotify(retryOutcome.notifyMessage, "error");
 
 				// ── TP-076: Emit supervisor alert for merge retry exhausted ──
@@ -3581,17 +4919,37 @@ export async function executeOrchBatch(
 			} else {
 				// kind === "no_retry": fall through to standard on_merge_failure policy
 				mergeResult = retryOutcome.mergeResult;
-				const policyResult = computeMergeFailurePolicy(mergeResult, waveIdx, orchConfig);
+				const policyResult = computeMergeFailurePolicy(
+					mergeResult,
+					waveIdx,
+					orchConfig,
+				);
 				const classNote = retryOutcome.classification
 					? ` [not retriable: ${retryOutcome.classification}, scope=${retryOutcome.scopeKey}]`
 					: "";
 
-				execLog("batch", batchState.batchId, `merge failure — applying ${policyResult.policy} policy${classNote}`, policyResult.logDetails);
+				execLog(
+					"batch",
+					batchState.batchId,
+					`merge failure — applying ${policyResult.policy} policy${classNote}`,
+					policyResult.logDetails,
+				);
 
 				batchState.phase = policyResult.targetPhase;
 				batchState.errors.push(policyResult.errorMessage + classNote);
-				persistRuntimeState(policyResult.persistTrigger, batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
-				onNotify(policyResult.notifyMessage + classNote, policyResult.notifyLevel);
+				persistRuntimeState(
+					policyResult.persistTrigger,
+					batchState,
+					wavePlan,
+					latestAllocatedLanes,
+					allTaskOutcomes,
+					discoveryRef,
+					stateRoot,
+				);
+				onNotify(
+					policyResult.notifyMessage + classNote,
+					policyResult.notifyLevel,
+				);
 
 				// ── TP-076: Emit supervisor alert for merge failure (no-retry policy) ──
 				emitAlert({
@@ -3630,7 +4988,10 @@ export async function executeOrchBatch(
 		// Hoisted outside the if-block so unsafeBranches is accessible to the
 		// reset loop below — both blocks share the same guard condition.
 		let ppUnsafeBranches = new Set<string>();
-		if (waveIdx < runtimeSegmentRounds.length - 1 && !batchState.pauseSignal.paused) {
+		if (
+			waveIdx < runtimeSegmentRounds.length - 1 &&
+			!batchState.pauseSignal.paused
+		) {
 			const ppOpId = resolveOperatorId(orchConfig);
 			const ppResult = preserveFailedLaneProgress(
 				latestAllocatedLanes,
@@ -3638,34 +4999,58 @@ export async function executeOrchBatch(
 				ppOpId,
 				batchState.batchId,
 				(repoId) => {
-					const perRepoRoot = resolveRepoRoot(repoId, repoRoot, workspaceConfig);
+					const perRepoRoot = resolveRepoRoot(
+						repoId,
+						repoRoot,
+						workspaceConfig,
+					);
 					let targetBranch = batchState.orchBranch;
 					if (repoId && perRepoRoot !== repoRoot) {
 						try {
-							targetBranch = resolveBaseBranch(repoId, perRepoRoot, batchState.orchBranch, workspaceConfig);
-						} catch { /* fall back to orchBranch */ }
+							targetBranch = resolveBaseBranch(
+								repoId,
+								perRepoRoot,
+								batchState.orchBranch,
+								workspaceConfig,
+							);
+						} catch {
+							/* fall back to orchBranch */
+						}
 					}
 					return { repoRoot: perRepoRoot, targetBranch };
 				},
 			);
 			ppUnsafeBranches = ppResult.unsafeBranches;
-			if (ppResult.results.some(r => r.saved)) {
-				execLog("batch", batchState.batchId,
-					`preserved partial progress for ${ppResult.results.filter(r => r.saved).length} failed task(s) before inter-wave reset`);
+			if (ppResult.results.some((r) => r.saved)) {
+				execLog(
+					"batch",
+					batchState.batchId,
+					`preserved partial progress for ${ppResult.results.filter((r) => r.saved).length} failed task(s) before inter-wave reset`,
+				);
 			}
 			// Log per-task warnings for failed preservation attempts
 			for (const r of ppResult.results) {
 				if (!r.saved && (r.commitCount > 0 || r.error)) {
-					execLog("batch", batchState.batchId,
+					execLog(
+						"batch",
+						batchState.batchId,
 						`WARNING: Failed to preserve partial progress for task ${r.taskId} ` +
-						`(${r.commitCount} commit(s) at risk on lane branch)`,
-						{ taskId: r.taskId, commitCount: r.commitCount, error: r.error ?? "unknown" });
+							`(${r.commitCount} commit(s) at risk on lane branch)`,
+						{
+							taskId: r.taskId,
+							commitCount: r.commitCount,
+							error: r.error ?? "unknown",
+						},
+					);
 				}
 			}
 			if (ppUnsafeBranches.size > 0) {
-				execLog("batch", batchState.batchId,
+				execLog(
+					"batch",
+					batchState.batchId,
 					`WARNING: ${ppUnsafeBranches.size} lane branch(es) could not be preserved — skipping reset for those lanes to prevent commit loss`,
-					{ unsafeBranches: [...ppUnsafeBranches] });
+					{ unsafeBranches: [...ppUnsafeBranches] },
+				);
 			}
 			// TP-028: Stamp task outcomes with partial progress data for persistence
 			applyPartialProgressToOutcomes(ppResult, allTaskOutcomes);
@@ -3677,12 +5062,23 @@ export async function executeOrchBatch(
 				ppOpId,
 				batchState.batchId,
 				(repoId) => {
-					const perRepoRoot = resolveRepoRoot(repoId, repoRoot, workspaceConfig);
+					const perRepoRoot = resolveRepoRoot(
+						repoId,
+						repoRoot,
+						workspaceConfig,
+					);
 					let targetBranch = batchState.orchBranch;
 					if (repoId && perRepoRoot !== repoRoot) {
 						try {
-							targetBranch = resolveBaseBranch(repoId, perRepoRoot, batchState.orchBranch, workspaceConfig);
-						} catch { /* fall back to orchBranch */ }
+							targetBranch = resolveBaseBranch(
+								repoId,
+								perRepoRoot,
+								batchState.orchBranch,
+								workspaceConfig,
+							);
+						} catch {
+							/* fall back to orchBranch */
+						}
 					}
 					return { repoRoot: perRepoRoot, targetBranch };
 				},
@@ -3691,9 +5087,12 @@ export async function executeOrchBatch(
 			for (const branch of skippedPpResult.unsafeBranches) {
 				ppUnsafeBranches.add(branch);
 			}
-			if (skippedPpResult.results.some(r => r.saved)) {
-				execLog("batch", batchState.batchId,
-					`preserved partial progress for ${skippedPpResult.results.filter(r => r.saved).length} skipped task(s) before inter-wave reset`);
+			if (skippedPpResult.results.some((r) => r.saved)) {
+				execLog(
+					"batch",
+					batchState.batchId,
+					`preserved partial progress for ${skippedPpResult.results.filter((r) => r.saved).length} skipped task(s) before inter-wave reset`,
+				);
 			}
 			// Stamp skipped task outcomes with partial progress data
 			applyPartialProgressToOutcomes(skippedPpResult, allTaskOutcomes);
@@ -3704,17 +5103,28 @@ export async function executeOrchBatch(
 		// TP-029: Iterate ALL encountered repo roots (not just primary repoRoot)
 		// so that repos active in wave N but not in the final wave still get reset.
 		// Follows the resume.ts encounteredRepoRoots pattern for parity.
-		if (waveIdx < runtimeSegmentRounds.length - 1 && !batchState.pauseSignal.paused) {
+		if (
+			waveIdx < runtimeSegmentRounds.length - 1 &&
+			!batchState.pauseSignal.paused
+		) {
 			const resetPrefix = orchConfig.orchestrator.worktree_prefix;
 			const resetOpId = resolveOperatorId(orchConfig);
 			let totalResetWorktrees = 0;
 			// TP-029 R006: Track worktrees that failed reset AND removal
 			// so the cleanup gate only fires on true stale state, not
 			// successfully-reset reusable worktrees.
-			const failedRemovalWorktrees = new Map<string, { repoId: string | undefined; paths: string[] }>();
+			const failedRemovalWorktrees = new Map<
+				string,
+				{ repoId: string | undefined; paths: string[] }
+			>();
 
 			for (const [perRepoRoot, perRepoId] of encounteredRepoRoots) {
-				const existingWorktrees = listWorktrees(resetPrefix, perRepoRoot, resetOpId, batchState.batchId);
+				const existingWorktrees = listWorktrees(
+					resetPrefix,
+					perRepoRoot,
+					resetOpId,
+					batchState.batchId,
+				);
 				if (existingWorktrees.length === 0) continue;
 				totalResetWorktrees += existingWorktrees.length;
 
@@ -3725,7 +5135,12 @@ export async function executeOrchBatch(
 					targetBranch = batchState.orchBranch;
 				} else {
 					try {
-						targetBranch = resolveBaseBranch(perRepoId, perRepoRoot, batchState.orchBranch, workspaceConfig);
+						targetBranch = resolveBaseBranch(
+							perRepoId,
+							perRepoRoot,
+							batchState.orchBranch,
+							workspaceConfig,
+						);
 					} catch {
 						// If resolution fails, fall back to orchBranch (reset will
 						// fail gracefully and trigger worktree removal)
@@ -3737,45 +5152,79 @@ export async function executeOrchBatch(
 					// TP-028: Skip reset for worktrees whose lane branch has
 					// unsaved partial progress (preservation failed with commits)
 					if (ppUnsafeBranches.has(wt.branch)) {
-						execLog("batch", batchState.batchId,
+						execLog(
+							"batch",
+							batchState.batchId,
 							`skipping worktree reset for lane ${wt.laneNumber} — branch "${wt.branch}" has unsaved partial progress`,
-							{ path: wt.path, branch: wt.branch });
+							{ path: wt.path, branch: wt.branch },
+						);
 						continue;
 					}
 
 					const resetResult = safeResetWorktree(wt, targetBranch, perRepoRoot);
 					if (!resetResult.success) {
-						execLog("batch", batchState.batchId, `worktree reset failed for lane ${wt.laneNumber}`, {
-							error: resetResult.error || "unknown",
-							path: wt.path,
-							repoId: perRepoId ?? "(default)",
-						});
+						execLog(
+							"batch",
+							batchState.batchId,
+							`worktree reset failed for lane ${wt.laneNumber}`,
+							{
+								error: resetResult.error || "unknown",
+								path: wt.path,
+								repoId: perRepoId ?? "(default)",
+							},
+						);
 						// If reset fails, remove this worktree so the next wave can recreate it cleanly.
 						try {
 							removeWorktree(wt, perRepoRoot);
-							execLog("batch", batchState.batchId, `removed unrecoverable worktree for lane ${wt.laneNumber}`);
+							execLog(
+								"batch",
+								batchState.batchId,
+								`removed unrecoverable worktree for lane ${wt.laneNumber}`,
+							);
 						} catch (removeErr: unknown) {
-							execLog("batch", batchState.batchId, `removeWorktree failed for lane ${wt.laneNumber}, attempting force cleanup`, {
-								error: removeErr instanceof Error ? removeErr.message : String(removeErr),
-								path: wt.path,
-							});
+							execLog(
+								"batch",
+								batchState.batchId,
+								`removeWorktree failed for lane ${wt.laneNumber}, attempting force cleanup`,
+								{
+									error:
+										removeErr instanceof Error
+											? removeErr.message
+											: String(removeErr),
+									path: wt.path,
+								},
+							);
 							// Last resort: force-remove the directory and prune git worktree state.
 							forceCleanupWorktree(wt, perRepoRoot, batchState.batchId);
 							// Track this worktree for the cleanup gate — it may still be registered
 							if (!failedRemovalWorktrees.has(perRepoRoot)) {
-								failedRemovalWorktrees.set(perRepoRoot, { repoId: perRepoId, paths: [] });
+								failedRemovalWorktrees.set(perRepoRoot, {
+									repoId: perRepoId,
+									paths: [],
+								});
 							}
 							failedRemovalWorktrees.get(perRepoRoot)!.paths.push(wt.path);
 						}
 					} else {
-						execLog("batch", batchState.batchId, `worktree reset OK for lane ${wt.laneNumber}`);
+						execLog(
+							"batch",
+							batchState.batchId,
+							`worktree reset OK for lane ${wt.laneNumber}`,
+						);
 					}
 				}
 			}
 
 			if (totalResetWorktrees > 0) {
 				onNotify(
-					ORCH_MESSAGES.orchWorktreeReset(resolveDisplayWaveNumber(waveIdx, roundToTaskWave, taskLevelWaveCount).displayWave, totalResetWorktrees),
+					ORCH_MESSAGES.orchWorktreeReset(
+						resolveDisplayWaveNumber(
+							waveIdx,
+							roundToTaskWave,
+							taskLevelWaveCount,
+						).displayWave,
+						totalResetWorktrees,
+					),
 					"info",
 				);
 			}
@@ -3788,11 +5237,19 @@ export async function executeOrchBatch(
 			// before classifying it as truly stale.
 			const cleanupGateFailures: CleanupGateRepoFailure[] = [];
 			if (failedRemovalWorktrees.size > 0) {
-				for (const [perRepoRoot, { repoId: perRepoId, paths: failedPaths }] of failedRemovalWorktrees) {
-					const remaining = listWorktrees(resetPrefix, perRepoRoot, resetOpId, batchState.batchId);
-					const remainingPaths = new Set(remaining.map(wt => wt.path));
+				for (const [
+					perRepoRoot,
+					{ repoId: perRepoId, paths: failedPaths },
+				] of failedRemovalWorktrees) {
+					const remaining = listWorktrees(
+						resetPrefix,
+						perRepoRoot,
+						resetOpId,
+						batchState.batchId,
+					);
+					const remainingPaths = new Set(remaining.map((wt) => wt.path));
 					// Only report worktrees that were targeted for removal but are still registered
-					const stale = failedPaths.filter(p => remainingPaths.has(p));
+					const stale = failedPaths.filter((p) => remainingPaths.has(p));
 					if (stale.length > 0) {
 						cleanupGateFailures.push({
 							repoRoot: perRepoRoot,
@@ -3815,20 +5272,40 @@ export async function executeOrchBatch(
 
 				const cleanupBudget = TIER0_RETRY_BUDGETS.cleanup_gate;
 				const cleanupScopeKey = tier0WaveScopeKey("cleanup_gate", waveIdx);
-				const cleanupRetryCount = batchState.resilience.retryCountByScope[cleanupScopeKey] ?? 0;
+				const cleanupRetryCount =
+					batchState.resilience.retryCountByScope[cleanupScopeKey] ?? 0;
 
 				if (cleanupRetryCount < cleanupBudget.maxRetries) {
-					batchState.resilience.retryCountByScope[cleanupScopeKey] = cleanupRetryCount + 1;
+					batchState.resilience.retryCountByScope[cleanupScopeKey] =
+						cleanupRetryCount + 1;
 
-					execLog("batch", batchState.batchId,
+					execLog(
+						"batch",
+						batchState.batchId,
 						`tier0: retrying cleanup gate (attempt ${cleanupRetryCount + 1}/${cleanupBudget.maxRetries})`,
-						{ cleanupScopeKey, staleCount: cleanupGateFailures.reduce((n, f) => n + f.staleWorktrees.length, 0) },
+						{
+							cleanupScopeKey,
+							staleCount: cleanupGateFailures.reduce(
+								(n, f) => n + f.staleWorktrees.length,
+								0,
+							),
+						},
 					);
 
 					// Emit attempt event
-					const staleWorktreeCount = cleanupGateFailures.reduce((n, f) => n + f.staleWorktrees.length, 0);
+					const staleWorktreeCount = cleanupGateFailures.reduce(
+						(n, f) => n + f.staleWorktrees.length,
+						0,
+					);
 					emitTier0Event(stateRoot, {
-						...buildTier0EventBase("tier0_recovery_attempt", batchState.batchId, waveIdx, "cleanup_gate", cleanupRetryCount + 1, cleanupBudget.maxRetries),
+						...buildTier0EventBase(
+							"tier0_recovery_attempt",
+							batchState.batchId,
+							waveIdx,
+							"cleanup_gate",
+							cleanupRetryCount + 1,
+							cleanupBudget.maxRetries,
+						),
 						repoId: null, // wave-scoped: cleanup gate spans all repos
 						classification: `stale_worktrees:${staleWorktreeCount}`,
 						cooldownMs: cleanupBudget.cooldownMs,
@@ -3841,7 +5318,12 @@ export async function executeOrchBatch(
 
 					// Force-cleanup each stale worktree again
 					for (const failure of cleanupGateFailures) {
-						const remaining = listWorktrees(resetPrefix, failure.repoRoot, resetOpId, batchState.batchId);
+						const remaining = listWorktrees(
+							resetPrefix,
+							failure.repoRoot,
+							resetOpId,
+							batchState.batchId,
+						);
 						for (const wt of remaining) {
 							if (failure.staleWorktrees.includes(wt.path)) {
 								forceCleanupWorktree(wt, failure.repoRoot, batchState.batchId);
@@ -3854,9 +5336,16 @@ export async function executeOrchBatch(
 					// Re-check: are any worktrees still stale?
 					const retriedGateFailures: CleanupGateRepoFailure[] = [];
 					for (const failure of cleanupGateFailures) {
-						const remaining = listWorktrees(resetPrefix, failure.repoRoot, resetOpId, batchState.batchId);
-						const remainingPaths = new Set(remaining.map(wt => wt.path));
-						const stillStale = failure.staleWorktrees.filter(p => remainingPaths.has(p));
+						const remaining = listWorktrees(
+							resetPrefix,
+							failure.repoRoot,
+							resetOpId,
+							batchState.batchId,
+						);
+						const remainingPaths = new Set(remaining.map((wt) => wt.path));
+						const stillStale = failure.staleWorktrees.filter((p) =>
+							remainingPaths.has(p),
+						);
 						if (stillStale.length > 0) {
 							retriedGateFailures.push({
 								repoRoot: failure.repoRoot,
@@ -3867,7 +5356,9 @@ export async function executeOrchBatch(
 					}
 
 					if (retriedGateFailures.length === 0) {
-						execLog("batch", batchState.batchId,
+						execLog(
+							"batch",
+							batchState.batchId,
 							`tier0: cleanup gate retry succeeded — all stale worktrees removed`,
 							{ cleanupScopeKey },
 						);
@@ -3878,75 +5369,162 @@ export async function executeOrchBatch(
 
 						// Emit success event
 						emitTier0Event(stateRoot, {
-							...buildTier0EventBase("tier0_recovery_success", batchState.batchId, waveIdx, "cleanup_gate", cleanupRetryCount + 1, cleanupBudget.maxRetries),
+							...buildTier0EventBase(
+								"tier0_recovery_success",
+								batchState.batchId,
+								waveIdx,
+								"cleanup_gate",
+								cleanupRetryCount + 1,
+								cleanupBudget.maxRetries,
+							),
 							repoId: null, // wave-scoped
 							resolution: `Cleanup gate retry succeeded — all stale worktrees removed at wave ${waveIdx + 1}`,
 							scopeKey: cleanupScopeKey,
 						});
 
-						persistRuntimeState("tier0-cleanup-retry-success", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+						persistRuntimeState(
+							"tier0-cleanup-retry-success",
+							batchState,
+							wavePlan,
+							latestAllocatedLanes,
+							allTaskOutcomes,
+							discoveryRef,
+							stateRoot,
+						);
 						// Fall through to continue the wave loop (don't break)
 					} else {
 						// Retry failed — fall through to pausing
-						const gatePolicyResult = computeCleanupGatePolicy(waveIdx, retriedGateFailures);
+						const gatePolicyResult = computeCleanupGatePolicy(
+							waveIdx,
+							retriedGateFailures,
+						);
 
-						execLog("batch", batchState.batchId,
+						execLog(
+							"batch",
+							batchState.batchId,
 							`tier0: cleanup gate retry failed — still ${retriedGateFailures.reduce((n, f) => n + f.staleWorktrees.length, 0)} stale worktree(s), pausing batch`,
 							gatePolicyResult.logDetails,
 						);
 
-						const stillStaleCount = retriedGateFailures.reduce((n, f) => n + f.staleWorktrees.length, 0);
+						const stillStaleCount = retriedGateFailures.reduce(
+							(n, f) => n + f.staleWorktrees.length,
+							0,
+						);
 						const cleanupRetryError = `Cleanup gate retry failed — ${stillStaleCount} stale worktree(s) remain`;
 						const cleanupRetrySuggestion = `Post-merge cleanup retry did not remove all stale worktrees. Manually remove the remaining ${stillStaleCount} worktree(s) and prune git state.`;
-						const cleanupRetryAffected = retriedGateFailures.flatMap(f => f.staleWorktrees);
+						const cleanupRetryAffected = retriedGateFailures.flatMap(
+							(f) => f.staleWorktrees,
+						);
 						// Emit exhausted event (retry attempted but failed)
 						emitTier0Event(stateRoot, {
-							...buildTier0EventBase("tier0_recovery_exhausted", batchState.batchId, waveIdx, "cleanup_gate", cleanupRetryCount + 1, cleanupBudget.maxRetries),
+							...buildTier0EventBase(
+								"tier0_recovery_exhausted",
+								batchState.batchId,
+								waveIdx,
+								"cleanup_gate",
+								cleanupRetryCount + 1,
+								cleanupBudget.maxRetries,
+							),
 							repoId: null, // wave-scoped
 							error: cleanupRetryError,
 							scopeKey: cleanupScopeKey,
 							affectedTaskIds: cleanupRetryAffected,
 							suggestion: cleanupRetrySuggestion,
 						});
-						emitTier0Escalation(stateRoot, batchState.batchId, waveIdx, "cleanup_gate", cleanupRetryCount + 1, cleanupBudget.maxRetries,
-							cleanupRetryError, cleanupRetryAffected, cleanupRetrySuggestion,
+						emitTier0Escalation(
+							stateRoot,
+							batchState.batchId,
+							waveIdx,
+							"cleanup_gate",
+							cleanupRetryCount + 1,
+							cleanupBudget.maxRetries,
+							cleanupRetryError,
+							cleanupRetryAffected,
+							cleanupRetrySuggestion,
 							{ repoId: null, scopeKey: cleanupScopeKey },
 						);
 
 						batchState.phase = gatePolicyResult.targetPhase;
 						batchState.errors.push(gatePolicyResult.errorMessage);
-						persistRuntimeState(gatePolicyResult.persistTrigger, batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
-						onNotify(gatePolicyResult.notifyMessage, gatePolicyResult.notifyLevel);
+						persistRuntimeState(
+							gatePolicyResult.persistTrigger,
+							batchState,
+							wavePlan,
+							latestAllocatedLanes,
+							allTaskOutcomes,
+							discoveryRef,
+							stateRoot,
+						);
+						onNotify(
+							gatePolicyResult.notifyMessage,
+							gatePolicyResult.notifyLevel,
+						);
 						preserveWorktreesForResume = true;
 						break;
 					}
 				} else {
 					// Cleanup retry budget exhausted — pause immediately
-					const gatePolicyResult = computeCleanupGatePolicy(waveIdx, cleanupGateFailures);
+					const gatePolicyResult = computeCleanupGatePolicy(
+						waveIdx,
+						cleanupGateFailures,
+					);
 
-					execLog("batch", batchState.batchId, `cleanup gate failed — pausing batch (retry budget exhausted)`, gatePolicyResult.logDetails);
+					execLog(
+						"batch",
+						batchState.batchId,
+						`cleanup gate failed — pausing batch (retry budget exhausted)`,
+						gatePolicyResult.logDetails,
+					);
 
 					// Emit exhausted event (budget already consumed from prior waves)
 					const cleanupBudgetError = `Cleanup gate retry budget exhausted (${cleanupRetryCount}/${cleanupBudget.maxRetries})`;
 					const cleanupBudgetSuggestion = `Cleanup gate retry budget was already consumed. Manually remove stale worktrees and prune git state.`;
-					const cleanupBudgetAffected = cleanupGateFailures.flatMap(f => f.staleWorktrees);
+					const cleanupBudgetAffected = cleanupGateFailures.flatMap(
+						(f) => f.staleWorktrees,
+					);
 					emitTier0Event(stateRoot, {
-						...buildTier0EventBase("tier0_recovery_exhausted", batchState.batchId, waveIdx, "cleanup_gate", cleanupRetryCount, cleanupBudget.maxRetries),
+						...buildTier0EventBase(
+							"tier0_recovery_exhausted",
+							batchState.batchId,
+							waveIdx,
+							"cleanup_gate",
+							cleanupRetryCount,
+							cleanupBudget.maxRetries,
+						),
 						repoId: null, // wave-scoped
 						error: cleanupBudgetError,
 						scopeKey: cleanupScopeKey,
 						affectedTaskIds: cleanupBudgetAffected,
 						suggestion: cleanupBudgetSuggestion,
 					});
-					emitTier0Escalation(stateRoot, batchState.batchId, waveIdx, "cleanup_gate", cleanupRetryCount, cleanupBudget.maxRetries,
-						cleanupBudgetError, cleanupBudgetAffected, cleanupBudgetSuggestion,
+					emitTier0Escalation(
+						stateRoot,
+						batchState.batchId,
+						waveIdx,
+						"cleanup_gate",
+						cleanupRetryCount,
+						cleanupBudget.maxRetries,
+						cleanupBudgetError,
+						cleanupBudgetAffected,
+						cleanupBudgetSuggestion,
 						{ repoId: null, scopeKey: cleanupScopeKey },
 					);
 
 					batchState.phase = gatePolicyResult.targetPhase;
 					batchState.errors.push(gatePolicyResult.errorMessage);
-					persistRuntimeState(gatePolicyResult.persistTrigger, batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
-					onNotify(gatePolicyResult.notifyMessage, gatePolicyResult.notifyLevel);
+					persistRuntimeState(
+						gatePolicyResult.persistTrigger,
+						batchState,
+						wavePlan,
+						latestAllocatedLanes,
+						allTaskOutcomes,
+						discoveryRef,
+						stateRoot,
+					);
+					onNotify(
+						gatePolicyResult.notifyMessage,
+						gatePolicyResult.notifyLevel,
+					);
 					preserveWorktreesForResume = true;
 					break;
 				}
@@ -3966,11 +5544,14 @@ export async function executeOrchBatch(
 		try {
 			const lanesDir = join(piDir, "runtime", batchState.batchId, "lanes");
 			if (existsSync(lanesDir)) {
-				const files = readdirSync(lanesDir).filter(f => f.startsWith("lane-") && f.endsWith(".json"));
+				const files = readdirSync(lanesDir).filter(
+					(f) => f.startsWith("lane-") && f.endsWith(".json"),
+				);
 				for (const f of files) {
 					try {
 						const snap = JSON.parse(readFileSync(join(lanesDir, f), "utf-8"));
-						const laneNumber = typeof snap.laneNumber === "number" ? snap.laneNumber : 0;
+						const laneNumber =
+							typeof snap.laneNumber === "number" ? snap.laneNumber : 0;
 						if (laneNumber <= 0) continue;
 						const w = snap.worker || {};
 						const r = snap.reviewer || {};
@@ -3981,14 +5562,20 @@ export async function executeOrchBatch(
 							cacheWrite: (w.cacheWriteTokens || 0) + (r.cacheWriteTokens || 0),
 							costUsd: (w.costUsd || 0) + (r.costUsd || 0),
 						});
-					} catch { /* skip invalid files */ }
+					} catch {
+						/* skip invalid files */
+					}
 				}
 			}
-		} catch { /* runtime dir may not exist */ }
+		} catch {
+			/* runtime dir may not exist */
+		}
 
 		// Legacy fallback: lane-state-*.json sidecars (pre-V2).
 		try {
-			const files = readdirSync(piDir).filter(f => f.startsWith("lane-state-") && f.endsWith(".json"));
+			const files = readdirSync(piDir).filter(
+				(f) => f.startsWith("lane-state-") && f.endsWith(".json"),
+			);
 			for (const f of files) {
 				try {
 					const raw = readFileSync(join(piDir, f), "utf-8").trim();
@@ -4003,25 +5590,34 @@ export async function executeOrchBatch(
 							costUsd: data.workerCostUsd || 0,
 						});
 					}
-				} catch { /* skip invalid files */ }
+				} catch {
+					/* skip invalid files */
+				}
 			}
-		} catch { /* .pi dir may not exist */ }
+		} catch {
+			/* .pi dir may not exist */
+		}
 
 		// Build per-task summaries from allTaskOutcomes + wave plan
 		const taskSummaries: BatchTaskSummary[] = allTaskOutcomes.map((to) => {
 			// Find which wave and lane this task ran in
 			let wave = 0;
 			for (let wi = 0; wi < wavePlan.length; wi++) {
-				if (wavePlan[wi].includes(to.taskId)) { wave = wi + 1; break; }
+				if (wavePlan[wi].includes(to.taskId)) {
+					wave = wi + 1;
+					break;
+				}
 			}
-			const lane = to.laneNumber
-				?? (() => {
+			const lane =
+				to.laneNumber ??
+				(() => {
 					const laneMatch = to.sessionName?.match(/lane-(\d+)/);
 					return laneMatch ? parseInt(laneMatch[1], 10) : 0;
 				})();
 
 			// Compute duration from start/end times
-			const durationMs = (to.startTime && to.endTime) ? (to.endTime - to.startTime) : 0;
+			const durationMs =
+				to.startTime && to.endTime ? to.endTime - to.startTime : 0;
 
 			// TP-116: Resolve tokens from outcome telemetry first; only fallback for legacy outcomes.
 			const tokens = resolveBatchHistoryTaskTokens(
@@ -4034,8 +5630,17 @@ export async function executeOrchBatch(
 			// TP-171: Map outcome status to valid BatchTaskSummary status.
 			// Non-terminal statuses ("running", "pending") can appear if batch
 			// was paused/aborted mid-wave. Map them to appropriate history values.
-			const validStatuses: Set<string> = new Set(["succeeded", "failed", "skipped", "blocked", "stalled", "pending"]);
-			const historyStatus: BatchTaskSummary["status"] = validStatuses.has(to.status)
+			const validStatuses: Set<string> = new Set([
+				"succeeded",
+				"failed",
+				"skipped",
+				"blocked",
+				"stalled",
+				"pending",
+			]);
+			const historyStatus: BatchTaskSummary["status"] = validStatuses.has(
+				to.status,
+			)
 				? (to.status as BatchTaskSummary["status"])
 				: "pending"; // "running" or unknown → "pending" in history
 
@@ -4054,13 +5659,15 @@ export async function executeOrchBatch(
 		// TP-147: Ensure ALL tasks from the wave plan are represented in history.
 		// Tasks that never got allocated (blocked by upstream failures, never started)
 		// won't have entries in allTaskOutcomes. Add them with appropriate status.
-		const coveredTaskIds = new Set(taskSummaries.map(t => t.taskId));
+		const coveredTaskIds = new Set(taskSummaries.map((t) => t.taskId));
 		for (let wi = 0; wi < wavePlan.length; wi++) {
 			for (const taskId of wavePlan[wi]) {
 				if (coveredTaskIds.has(taskId)) continue;
 				// Determine the appropriate status for uncovered tasks
 				const isBlocked = batchState.blockedTaskIds.has(taskId);
-				const status: BatchTaskSummary["status"] = isBlocked ? "blocked" : "pending";
+				const status: BatchTaskSummary["status"] = isBlocked
+					? "blocked"
+					: "pending";
 				taskSummaries.push({
 					taskId,
 					taskName: taskId,
@@ -4068,7 +5675,13 @@ export async function executeOrchBatch(
 					wave: wi + 1,
 					lane: 0,
 					durationMs: 0,
-					tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, costUsd: 0 },
+					tokens: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						costUsd: 0,
+					},
 					exitReason: isBlocked ? "Blocked by upstream failure" : null,
 				});
 				coveredTaskIds.add(taskId);
@@ -4077,9 +5690,17 @@ export async function executeOrchBatch(
 
 		// Build per-wave summaries
 		const waveSummaries: BatchWaveSummary[] = wavePlan.map((taskIds, wi) => {
-			const waveTasks = taskSummaries.filter(t => t.wave === wi + 1);
-			const mergeResult = batchState.mergeResults.find(mr => mr.waveIndex === wi + 1);
-			const waveTokens: TokenCounts = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, costUsd: 0 };
+			const waveTasks = taskSummaries.filter((t) => t.wave === wi + 1);
+			const mergeResult = batchState.mergeResults.find(
+				(mr) => mr.waveIndex === wi + 1,
+			);
+			const waveTokens: TokenCounts = {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				costUsd: 0,
+			};
 			for (const t of waveTasks) {
 				waveTokens.input += t.tokens.input;
 				waveTokens.output += t.tokens.output;
@@ -4087,7 +5708,10 @@ export async function executeOrchBatch(
 				waveTokens.cacheWrite += t.tokens.cacheWrite;
 				waveTokens.costUsd += t.tokens.costUsd;
 			}
-			const waveDuration = waveTasks.reduce((sum, t) => Math.max(sum, t.durationMs), 0);
+			const waveDuration = waveTasks.reduce(
+				(sum, t) => Math.max(sum, t.durationMs),
+				0,
+			);
 			return {
 				wave: wi + 1,
 				tasks: taskIds,
@@ -4098,7 +5722,13 @@ export async function executeOrchBatch(
 		});
 
 		// Aggregate batch tokens
-		const batchTokens: TokenCounts = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, costUsd: 0 };
+		const batchTokens: TokenCounts = {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			costUsd: 0,
+		};
 		for (const ws of waveSummaries) {
 			batchTokens.input += ws.tokens.input;
 			batchTokens.output += ws.tokens.output;
@@ -4111,7 +5741,9 @@ export async function executeOrchBatch(
 		// (phase hasn't been set to "completed" yet at this point in the flow).
 		const historyStatus: "completed" | "partial" | "failed" | "aborted" =
 			batchState.failedTasks > 0
-				? (batchState.succeededTasks > 0 ? "partial" : "failed")
+				? batchState.succeededTasks > 0
+					? "partial"
+					: "failed"
 				: batchState.succeededTasks > 0
 					? "completed"
 					: "aborted";
@@ -4121,9 +5753,12 @@ export async function executeOrchBatch(
 		// and log a warning if it diverges from batchState.totalTasks.
 		const actualTotalTasks = taskSummaries.length;
 		if (actualTotalTasks !== batchState.totalTasks) {
-			execLog("batch", batchState.batchId,
+			execLog(
+				"batch",
+				batchState.batchId,
 				`WARNING: totalTasks mismatch — batchState.totalTasks=${batchState.totalTasks}, ` +
-				`taskSummaries.length=${actualTotalTasks}. Using taskSummaries.length for history.`);
+					`taskSummaries.length=${actualTotalTasks}. Using taskSummaries.length for history.`,
+			);
 		}
 
 		const summary: BatchHistorySummary = {
@@ -4145,25 +5780,40 @@ export async function executeOrchBatch(
 
 		saveBatchHistory(stateRoot, summary);
 	} catch (err) {
-		execLog("batch", batchState.batchId, `failed to save batch history: ${err}`);
+		execLog(
+			"batch",
+			batchState.batchId,
+			`failed to save batch history: ${err}`,
+		);
 	}
 
 	// ── Pre-cleanup: Determine if worktrees should be preserved ──
 	// TP-031 (R006): This check MUST run before cleanup so that worktrees
 	// survive when failedTasks > 0. Without this, cleanup deletes worktrees
 	// before the batch is marked "paused", breaking resumability.
-	if (!preserveWorktreesForResume &&
-		((batchState.phase as OrchBatchPhase) === "executing" || (batchState.phase as OrchBatchPhase) === "merging") &&
-		batchState.failedTasks > 0) {
+	if (
+		!preserveWorktreesForResume &&
+		((batchState.phase as OrchBatchPhase) === "executing" ||
+			(batchState.phase as OrchBatchPhase) === "merging") &&
+		batchState.failedTasks > 0
+	) {
 		preserveWorktreesForResume = true;
-		execLog("batch", batchState.batchId, "pre-cleanup: failedTasks > 0 detected, preserving worktrees for resume");
+		execLog(
+			"batch",
+			batchState.batchId,
+			"pre-cleanup: failedTasks > 0 detected, preserving worktrees for resume",
+		);
 	}
 
 	// ── Phase 3: Cleanup ─────────────────────────────────────────
 	const prefix = orchConfig.orchestrator.worktree_prefix;
 
 	if (preserveWorktreesForResume) {
-		execLog("batch", batchState.batchId, "skipping final cleanup to preserve worktrees/branches for resume");
+		execLog(
+			"batch",
+			batchState.batchId,
+			"skipping final cleanup to preserve worktrees/branches for resume",
+		);
 	} else {
 		// Kill lingering Runtime V2 agents BEFORE removing worktrees.
 		// On Windows, lingering processes with cwd inside the worktree can lock
@@ -4172,15 +5822,26 @@ export async function executeOrchBatch(
 		const registry = readRegistrySnapshot(stateRoot, batchState.batchId);
 		if (registry) {
 			for (const manifest of Object.values(registry.agents)) {
-				if (manifest.role !== "worker" && manifest.role !== "reviewer") continue;
-				if (isTerminalStatus(manifest.status) || !registryIsProcessAlive(manifest.pid)) continue;
-				lingeringLaneSessions.add(manifest.agentId.replace(/-(worker|reviewer)$/, ""));
+				if (manifest.role !== "worker" && manifest.role !== "reviewer")
+					continue;
+				if (
+					isTerminalStatus(manifest.status) ||
+					!registryIsProcessAlive(manifest.pid)
+				)
+					continue;
+				lingeringLaneSessions.add(
+					manifest.agentId.replace(/-(worker|reviewer)$/, ""),
+				);
 			}
 		}
 
 		let performedAgentCleanup = false;
 		if (lingeringLaneSessions.size > 0) {
-			execLog("batch", batchState.batchId, `killing ${lingeringLaneSessions.size} lingering lane agent session(s) before cleanup`);
+			execLog(
+				"batch",
+				batchState.batchId,
+				`killing ${lingeringLaneSessions.size} lingering lane agent session(s) before cleanup`,
+			);
 			for (const sessionName of lingeringLaneSessions) {
 				killV2LaneAgents(sessionName, {
 					stateRoot,
@@ -4193,7 +5854,11 @@ export async function executeOrchBatch(
 
 		const killedMergeAgents = killAllMergeAgentsV2();
 		if (killedMergeAgents > 0) {
-			execLog("batch", batchState.batchId, `killed ${killedMergeAgents} lingering merge agent(s) before cleanup`);
+			execLog(
+				"batch",
+				batchState.batchId,
+				`killed ${killedMergeAgents} lingering merge agent(s) before cleanup`,
+			);
 			performedAgentCleanup = true;
 		}
 
@@ -4205,18 +5870,29 @@ export async function executeOrchBatch(
 		const piDir = join(stateRoot, ".pi");
 		try {
 			const sidecarFiles = readdirSync(piDir).filter(
-				f => f.startsWith("lane-state-") ||
+				(f) =>
+					f.startsWith("lane-state-") ||
 					f.startsWith("worker-conversation-") ||
 					f.startsWith("merge-result-") ||
 					f.startsWith("merge-request-"),
 			);
 			for (const f of sidecarFiles) {
-				try { unlinkSync(join(piDir, f)); } catch { /* best effort */ }
+				try {
+					unlinkSync(join(piDir, f));
+				} catch {
+					/* best effort */
+				}
 			}
 			if (sidecarFiles.length > 0) {
-				execLog("batch", batchState.batchId, `cleaned up ${sidecarFiles.length} sidecar file(s)`);
+				execLog(
+					"batch",
+					batchState.batchId,
+					`cleaned up ${sidecarFiles.length} sidecar file(s)`,
+				);
 			}
-		} catch { /* .pi dir may not exist */ }
+		} catch {
+			/* .pi dir may not exist */
+		}
 
 		// ── TP-028: Preserve partial progress before terminal cleanup ──
 		// Save failed task commits as named branches before worktree removal
@@ -4230,29 +5906,50 @@ export async function executeOrchBatch(
 				ppOpId,
 				batchState.batchId,
 				(repoId) => {
-					const perRepoRoot = resolveRepoRoot(repoId, repoRoot, workspaceConfig);
+					const perRepoRoot = resolveRepoRoot(
+						repoId,
+						repoRoot,
+						workspaceConfig,
+					);
 					let targetBranch = batchState.orchBranch;
 					if (repoId && perRepoRoot !== repoRoot) {
 						try {
-							targetBranch = resolveBaseBranch(repoId, perRepoRoot, batchState.orchBranch, workspaceConfig);
-						} catch { /* fall back to orchBranch */ }
+							targetBranch = resolveBaseBranch(
+								repoId,
+								perRepoRoot,
+								batchState.orchBranch,
+								workspaceConfig,
+							);
+						} catch {
+							/* fall back to orchBranch */
+						}
 					}
 					return { repoRoot: perRepoRoot, targetBranch };
 				},
 			);
-			if (ppResult.results.some(r => r.saved)) {
-				execLog("batch", batchState.batchId,
-					`preserved partial progress for ${ppResult.results.filter(r => r.saved).length} failed task(s) before terminal cleanup`);
+			if (ppResult.results.some((r) => r.saved)) {
+				execLog(
+					"batch",
+					batchState.batchId,
+					`preserved partial progress for ${ppResult.results.filter((r) => r.saved).length} failed task(s) before terminal cleanup`,
+				);
 			}
 			// Log warnings for failed preservation attempts — at terminal cleanup
 			// we cannot skip deletion (batch is ending), but operators need to know
 			// that commits may become unreachable via reflog only.
 			for (const r of ppResult.results) {
 				if (!r.saved && (r.commitCount > 0 || r.error)) {
-					execLog("batch", batchState.batchId,
+					execLog(
+						"batch",
+						batchState.batchId,
 						`WARNING: Failed to preserve partial progress for task ${r.taskId} ` +
-						`(${r.commitCount} commit(s) may become unreachable after cleanup)`,
-						{ taskId: r.taskId, commitCount: r.commitCount, error: r.error ?? "unknown" });
+							`(${r.commitCount} commit(s) may become unreachable after cleanup)`,
+						{
+							taskId: r.taskId,
+							commitCount: r.commitCount,
+							error: r.error ?? "unknown",
+						},
+					);
 				}
 			}
 			// TP-028: Stamp task outcomes with partial progress data for persistence
@@ -4265,26 +5962,47 @@ export async function executeOrchBatch(
 				ppOpId,
 				batchState.batchId,
 				(repoId) => {
-					const perRepoRoot = resolveRepoRoot(repoId, repoRoot, workspaceConfig);
+					const perRepoRoot = resolveRepoRoot(
+						repoId,
+						repoRoot,
+						workspaceConfig,
+					);
 					let targetBranch = batchState.orchBranch;
 					if (repoId && perRepoRoot !== repoRoot) {
 						try {
-							targetBranch = resolveBaseBranch(repoId, perRepoRoot, batchState.orchBranch, workspaceConfig);
-						} catch { /* fall back to orchBranch */ }
+							targetBranch = resolveBaseBranch(
+								repoId,
+								perRepoRoot,
+								batchState.orchBranch,
+								workspaceConfig,
+							);
+						} catch {
+							/* fall back to orchBranch */
+						}
 					}
 					return { repoRoot: perRepoRoot, targetBranch };
 				},
 			);
-			if (skippedPpResult.results.some(r => r.saved)) {
-				execLog("batch", batchState.batchId,
-					`preserved partial progress for ${skippedPpResult.results.filter(r => r.saved).length} skipped task(s) before terminal cleanup`);
+			if (skippedPpResult.results.some((r) => r.saved)) {
+				execLog(
+					"batch",
+					batchState.batchId,
+					`preserved partial progress for ${skippedPpResult.results.filter((r) => r.saved).length} skipped task(s) before terminal cleanup`,
+				);
 			}
 			for (const r of skippedPpResult.results) {
 				if (!r.saved && (r.commitCount > 0 || r.error)) {
-					execLog("batch", batchState.batchId,
+					execLog(
+						"batch",
+						batchState.batchId,
 						`WARNING: Failed to preserve partial progress for skipped task ${r.taskId} ` +
-						`(${r.commitCount} commit(s) may become unreachable after cleanup)`,
-						{ taskId: r.taskId, commitCount: r.commitCount, error: r.error ?? "unknown" });
+							`(${r.commitCount} commit(s) may become unreachable after cleanup)`,
+						{
+							taskId: r.taskId,
+							commitCount: r.commitCount,
+							error: r.error ?? "unknown",
+						},
+					);
 				}
 			}
 			applyPartialProgressToOutcomes(skippedPpResult, allTaskOutcomes);
@@ -4305,37 +6023,66 @@ export async function executeOrchBatch(
 			} else {
 				// Secondary repo (workspace mode): resolve the repo's own branch
 				try {
-					targetBranch = resolveBaseBranch(perRepoId, perRepoRoot, batchState.orchBranch, workspaceConfig);
+					targetBranch = resolveBaseBranch(
+						perRepoId,
+						perRepoRoot,
+						batchState.orchBranch,
+						workspaceConfig,
+					);
 				} catch {
 					// Fall back to undefined — skips branch protection
 					// (safe because successfully merged branches were already cleaned)
 					targetBranch = undefined;
 				}
 			}
-			const removeResult = removeAllWorktrees(prefix, perRepoRoot, cleanupOpId, targetBranch, batchState.batchId, orchConfig);
+			const removeResult = removeAllWorktrees(
+				prefix,
+				perRepoRoot,
+				cleanupOpId,
+				targetBranch,
+				batchState.batchId,
+				orchConfig,
+			);
 
 			// Log preserved branches
 			for (const p of removeResult.preserved) {
-				execLog("batch", batchState.batchId, `preserving unmerged branch as saved ref`, {
-					branch: p.branch,
-					savedBranch: p.savedBranch,
-					lane: p.laneNumber,
-					target: targetBranch,
-					commitCount: p.unmergedCount ?? 0,
-					repoId: perRepoId ?? "(default)",
-				});
+				execLog(
+					"batch",
+					batchState.batchId,
+					`preserving unmerged branch as saved ref`,
+					{
+						branch: p.branch,
+						savedBranch: p.savedBranch,
+						lane: p.laneNumber,
+						target: targetBranch,
+						commitCount: p.unmergedCount ?? 0,
+						repoId: perRepoId ?? "(default)",
+					},
+				);
 			}
 
 			if (removeResult.failed.length > 0) {
-				const failedPaths = removeResult.failed.map(f => f.worktree.path).join(", ");
-				execLog("batch", batchState.batchId, `worktree cleanup: ${removeResult.removed.length} removed, ${removeResult.failed.length} failed, ${removeResult.preserved.length} preserved`, {
-					failedPaths,
-					repoId: perRepoId ?? "(default)",
-				});
+				const failedPaths = removeResult.failed
+					.map((f) => f.worktree.path)
+					.join(", ");
+				execLog(
+					"batch",
+					batchState.batchId,
+					`worktree cleanup: ${removeResult.removed.length} removed, ${removeResult.failed.length} failed, ${removeResult.preserved.length} preserved`,
+					{
+						failedPaths,
+						repoId: perRepoId ?? "(default)",
+					},
+				);
 			} else if (removeResult.totalAttempted > 0) {
-				execLog("batch", batchState.batchId, `worktree cleanup: ${removeResult.removed.length} removed, ${removeResult.preserved.length} preserved`, {
-					repoId: perRepoId ?? "(default)",
-				});
+				execLog(
+					"batch",
+					batchState.batchId,
+					`worktree cleanup: ${removeResult.removed.length} removed, ${removeResult.preserved.length} preserved`,
+					{
+						repoId: perRepoId ?? "(default)",
+					},
+				);
 			}
 		}
 
@@ -4348,31 +6095,60 @@ export async function executeOrchBatch(
 		// In workspace mode, each lane's branch lives in its owning repo,
 		// so we resolve the correct repo root per lane using repoId.
 		for (const mergeResult of allMergeResults) {
-			if (mergeResult.status === "succeeded" || mergeResult.status === "partial") {
+			if (
+				mergeResult.status === "succeeded" ||
+				mergeResult.status === "partial"
+			) {
 				for (const lr of mergeResult.laneResults) {
 					// TP-032 R006-3: Exclude verification_new_failure lanes from branch cleanup
 					// (their merge commits were rolled back, so the branch is NOT merged)
-					if (!lr.error && (lr.result?.status === "SUCCESS" || lr.result?.status === "CONFLICT_RESOLVED")) {
-						const laneRepoRoot = resolveRepoRoot(lr.repoId, repoRoot, workspaceConfig);
+					if (
+						!lr.error &&
+						(lr.result?.status === "SUCCESS" ||
+							lr.result?.status === "CONFLICT_RESOLVED")
+					) {
+						const laneRepoRoot = resolveRepoRoot(
+							lr.repoId,
+							repoRoot,
+							workspaceConfig,
+						);
 						const ancestorCheck = runGit(
 							["merge-base", "--is-ancestor", lr.sourceBranch, lr.targetBranch],
 							laneRepoRoot,
 						);
 						if (ancestorCheck.ok) {
-							const deleted = deleteBranchBestEffort(lr.sourceBranch, laneRepoRoot);
+							const deleted = deleteBranchBestEffort(
+								lr.sourceBranch,
+								laneRepoRoot,
+							);
 							if (deleted) {
-								execLog("batch", batchState.batchId, `deleted merged branch ${lr.sourceBranch}`, {
-									repoId: lr.repoId ?? "(default)",
-								});
+								execLog(
+									"batch",
+									batchState.batchId,
+									`deleted merged branch ${lr.sourceBranch}`,
+									{
+										repoId: lr.repoId ?? "(default)",
+									},
+								);
 							} else {
-								execLog("batch", batchState.batchId, `warning: failed to delete merged branch ${lr.sourceBranch} — retained for manual cleanup`, {
-									repoId: lr.repoId ?? "(default)",
-								});
+								execLog(
+									"batch",
+									batchState.batchId,
+									`warning: failed to delete merged branch ${lr.sourceBranch} — retained for manual cleanup`,
+									{
+										repoId: lr.repoId ?? "(default)",
+									},
+								);
 							}
 						} else {
-							execLog("batch", batchState.batchId, `warning: branch ${lr.sourceBranch} not fully merged into ${lr.targetBranch} — retained`, {
-								repoId: lr.repoId ?? "(default)",
-							});
+							execLog(
+								"batch",
+								batchState.batchId,
+								`warning: branch ${lr.sourceBranch} not fully merged into ${lr.targetBranch} — retained`,
+								{
+									repoId: lr.repoId ?? "(default)",
+								},
+							);
 						}
 					}
 				}
@@ -4382,12 +6158,17 @@ export async function executeOrchBatch(
 
 	// Set final state
 	batchState.endedAt = Date.now();
-	const totalElapsedSec = Math.round((batchState.endedAt - batchState.startedAt) / 1000);
+	const totalElapsedSec = Math.round(
+		(batchState.endedAt - batchState.startedAt) / 1000,
+	);
 
 	// Determine final batch state. Cast to OrchBatchPhase to bypass control-flow
 	// narrowing — mergeWave() could leave phase as "merging" if an unexpected
 	// throw occurs between setting "merging" and restoring "executing".
-	if ((batchState.phase as OrchBatchPhase) === "executing" || (batchState.phase as OrchBatchPhase) === "merging") {
+	if (
+		(batchState.phase as OrchBatchPhase) === "executing" ||
+		(batchState.phase as OrchBatchPhase) === "merging"
+	) {
 		// Normal completion (not stopped, paused, or aborted)
 		if (batchState.failedTasks > 0) {
 			// TP-031: Default to "paused" so the batch is resumable without --force.
@@ -4414,31 +6195,59 @@ export async function executeOrchBatch(
 	// supervisor is active (fallback). For "supervised" mode, the supervisor
 	// always handles integration.
 	const mergedTaskCount = batchState.succeededTasks;
-	const isTerminalPhase = batchState.phase === "completed" || batchState.phase === "failed";
-	if (isTerminalPhase && !preserveWorktreesForResume && batchState.orchBranch && mergedTaskCount > 0) {
-		if (orchConfig.orchestrator.integration === "supervised" || orchConfig.orchestrator.integration === "auto") {
+	const isTerminalPhase =
+		batchState.phase === "completed" || batchState.phase === "failed";
+	if (
+		isTerminalPhase &&
+		!preserveWorktreesForResume &&
+		batchState.orchBranch &&
+		mergedTaskCount > 0
+	) {
+		if (
+			orchConfig.orchestrator.integration === "supervised" ||
+			orchConfig.orchestrator.integration === "auto"
+		) {
 			// TP-043: Supervisor-managed integration modes. The supervisor
 			// agent handles integration after batch_complete event. The engine
 			// does NOT perform legacy fast-forward here — defer to supervisor.
-			execLog("batch", batchState.batchId, `integration deferred to supervisor (mode: ${orchConfig.orchestrator.integration})`);
+			execLog(
+				"batch",
+				batchState.batchId,
+				`integration deferred to supervisor (mode: ${orchConfig.orchestrator.integration})`,
+			);
 		} else {
 			// Manual mode (default): show integration guidance
 			onNotify(
-				ORCH_MESSAGES.orchIntegrationManual(batchState.orchBranch, batchState.baseBranch, mergedTaskCount),
+				ORCH_MESSAGES.orchIntegrationManual(
+					batchState.orchBranch,
+					batchState.baseBranch,
+					mergedTaskCount,
+				),
 				"info",
 			);
 		}
 	}
 
 	// ── TS-009: Persist terminal state ──
-	persistRuntimeState("batch-terminal", batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, discoveryRef, stateRoot);
+	persistRuntimeState(
+		"batch-terminal",
+		batchState,
+		wavePlan,
+		latestAllocatedLanes,
+		allTaskOutcomes,
+		discoveryRef,
+		stateRoot,
+	);
 
 	// ── TP-076: Emit supervisor alert for batch completion ──────
 	if (batchState.phase === "completed" || batchState.phase === "failed") {
-		const batchDurationMs = batchState.endedAt ? batchState.endedAt - batchState.startedAt : 0;
-		const durationStr = batchDurationMs > 0
-			? `${Math.floor(batchDurationMs / 60000)}m ${Math.round((batchDurationMs % 60000) / 1000)}s`
-			: "unknown";
+		const batchDurationMs = batchState.endedAt
+			? batchState.endedAt - batchState.startedAt
+			: 0;
+		const durationStr =
+			batchDurationMs > 0
+				? `${Math.floor(batchDurationMs / 60000)}m ${Math.round((batchDurationMs % 60000) / 1000)}s`
+				: "unknown";
 		if (batchState.phase === "completed" && batchState.failedTasks === 0) {
 			emitAlert({
 				category: "batch-complete",
@@ -4478,12 +6287,26 @@ export async function executeOrchBatch(
 
 	// ── TP-031: Emit diagnostic reports (JSONL + markdown) ──
 	// Non-fatal: errors are logged but never crash batch finalization.
-	emitDiagnosticReports(assembleDiagnosticInput(orchConfig, batchState, wavePlan, latestAllocatedLanes, allTaskOutcomes, stateRoot));
+	emitDiagnosticReports(
+		assembleDiagnosticInput(
+			orchConfig,
+			batchState,
+			wavePlan,
+			latestAllocatedLanes,
+			allTaskOutcomes,
+			stateRoot,
+		),
+	);
 
 	if (batchState.phase === "paused" || batchState.phase === "stopped") {
-		execLog("batch", batchState.batchId, "batch ended in non-terminal execution state; completion banner suppressed", {
-			phase: batchState.phase,
-		});
+		execLog(
+			"batch",
+			batchState.batchId,
+			"batch ended in non-terminal execution state; completion banner suppressed",
+			{
+				phase: batchState.phase,
+			},
+		);
 	} else {
 		onNotify(
 			ORCH_MESSAGES.orchBatchComplete(
@@ -4505,23 +6328,34 @@ export async function executeOrchBatch(
 		// Only delete state if there's no orch branch to integrate.
 		if (batchState.phase === "completed") {
 			if (batchState.orchBranch) {
-				execLog("state", batchState.batchId, "state file preserved for /orch-integrate", {
-					orchBranch: batchState.orchBranch,
-				});
+				execLog(
+					"state",
+					batchState.batchId,
+					"state file preserved for /orch-integrate",
+					{
+						orchBranch: batchState.orchBranch,
+					},
+				);
 			} else {
 				// Legacy mode (no orch branch) — clean up state
 				try {
 					deleteBatchState(stateRoot);
-					execLog("state", batchState.batchId, "state file deleted on clean completion");
+					execLog(
+						"state",
+						batchState.batchId,
+						"state file deleted on clean completion",
+					);
 				} catch (err: unknown) {
 					const msg = err instanceof Error ? err.message : String(err);
-					execLog("state", batchState.batchId, `failed to delete state file: ${msg}`);
+					execLog(
+						"state",
+						batchState.batchId,
+						`failed to delete state file: ${msg}`,
+					);
 				}
 			}
 		}
 	}
 }
 
-
 // ── Dashboard Widget (Step 6) ────────────────────────────────────────
-

--- a/extensions/taskplane/execution.ts
+++ b/extensions/taskplane/execution.ts
@@ -2,20 +2,76 @@
  * Lane execution, monitoring, wave execution loop
  * @module orch/execution
  */
-import { readFileSync, existsSync, statSync, unlinkSync, mkdirSync, writeFileSync, copyFileSync } from "fs";
-import { access as fsAccess, readFile as fsReadFile, stat as fsStat } from "fs/promises";
-import { join, dirname, basename, resolve, relative, delimiter as pathDelimiter } from "path";
+import {
+	copyFileSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	statSync,
+	unlinkSync,
+	writeFileSync,
+} from "fs";
+import {
+	access as fsAccess,
+	readFile as fsReadFile,
+	stat as fsStat,
+} from "fs/promises";
 import { userInfo } from "os";
-
-import { DONE_GRACE_MS, EXECUTION_POLL_INTERVAL_MS, ExecutionError, SESSION_SPAWN_RETRY_MAX } from "./types.ts";
-import type { AllocatedLane, AllocatedTask, DependencyGraph, LaneExecutionResult, LaneMonitorSnapshot, LaneTaskOutcome, LaneTaskStatus, MonitorState, MtimeTracker, OrchestratorConfig, ParsedTask, TaskMonitorSnapshot, WaveExecutionResult, WorkspaceConfig, ExecutionUnit, PacketPaths, RuntimeAgentId, RuntimeAgentRole, SupervisorAlertCallback } from "./types.ts";
-import { resolvePacketPaths, buildRuntimeAgentId } from "./types.ts";
-import { readRegistrySnapshot, readLaneSnapshot, isTerminalStatus, isProcessAlive, detectOrphans, markOrphansCrashed, buildRegistrySnapshot, writeRegistrySnapshot } from "./process-registry.ts";
-import { allocateLanes } from "./waves.ts";
-import { resolveOperatorId } from "./naming.ts";
+import {
+	basename,
+	dirname,
+	join,
+	delimiter as pathDelimiter,
+	relative,
+	resolve,
+} from "path";
 import { runGit, runGitWithEnv } from "./git.ts";
-import { resolveTaskplanePackageFile, resolveTaskplaneAgentTemplate } from "./path-resolver.ts";
-import { resolvePointer, loadWorkspaceConfig } from "./workspace.ts";
+import { resolveOperatorId } from "./naming.ts";
+import {
+	resolveTaskplaneAgentTemplate,
+	resolveTaskplanePackageFile,
+} from "./path-resolver.ts";
+import {
+	buildRegistrySnapshot,
+	detectOrphans,
+	isProcessAlive,
+	isTerminalStatus,
+	markOrphansCrashed,
+	readLaneSnapshot,
+	readRegistrySnapshot,
+	writeRegistrySnapshot,
+} from "./process-registry.ts";
+import type {
+	AllocatedLane,
+	AllocatedTask,
+	DependencyGraph,
+	ExecutionUnit,
+	LaneExecutionResult,
+	LaneMonitorSnapshot,
+	LaneTaskOutcome,
+	LaneTaskStatus,
+	MonitorState,
+	MtimeTracker,
+	OrchestratorConfig,
+	PacketPaths,
+	ParsedTask,
+	RuntimeAgentId,
+	RuntimeAgentRole,
+	SupervisorAlertCallback,
+	TaskMonitorSnapshot,
+	WaveExecutionResult,
+	WorkspaceConfig,
+} from "./types.ts";
+import {
+	buildRuntimeAgentId,
+	DONE_GRACE_MS,
+	EXECUTION_POLL_INTERVAL_MS,
+	ExecutionError,
+	resolvePacketPaths,
+	SESSION_SPAWN_RETRY_MAX,
+} from "./types.ts";
+import { allocateLanes } from "./waves.ts";
+import { loadWorkspaceConfig, resolvePointer } from "./workspace.ts";
 
 // ── Taskplane Package File Resolution ────────────────────────────────
 // getNpmGlobalRoot() and resolveTaskplanePackageFile() consolidated in path-resolver.ts (TP-157)
@@ -73,7 +129,11 @@ export function execLog(
  * @returns true if agent is alive
  * @since TP-112
  */
-export function isV2AgentAlive(agentIdOrSessionName: string, _runtimeBackend?: RuntimeBackend, laneNumber?: number): boolean {
+export function isV2AgentAlive(
+	agentIdOrSessionName: string,
+	_runtimeBackend?: RuntimeBackend,
+	laneNumber?: number,
+): boolean {
 	// Read the registry from the global state root.
 	// Since this is a pure liveness check, we scan for matching agentId
 	// patterns: direct match, or lane-session + "-worker" suffix.
@@ -81,18 +141,32 @@ export function isV2AgentAlive(agentIdOrSessionName: string, _runtimeBackend?: R
 	const agents = _v2LivenessRegistryCache.agents;
 	// Direct match
 	const manifest = agents[agentIdOrSessionName];
-	if (manifest && !isTerminalStatus(manifest.status) && isProcessAlive(manifest.pid)) return true;
+	if (
+		manifest &&
+		!isTerminalStatus(manifest.status) &&
+		isProcessAlive(manifest.pid)
+	)
+		return true;
 	// Try worker suffix (monitor uses lane session name, registry uses agentId)
 	const workerManifest = agents[`${agentIdOrSessionName}-worker`];
-	if (workerManifest && !isTerminalStatus(workerManifest.status) && isProcessAlive(workerManifest.pid)) return true;
+	if (
+		workerManifest &&
+		!isTerminalStatus(workerManifest.status) &&
+		isProcessAlive(workerManifest.pid)
+	)
+		return true;
 	// TP-148: In workspace mode, laneSessionId includes repoId and uses a local
 	// lane number (e.g., "orch-henry-api-lane-1") while the V2 registry uses
 	// global lane numbers without repoId (e.g., "orch-henry-lane-3-worker").
 	// Fall back to scanning the registry by global lane number when provided.
 	if (laneNumber != null) {
 		for (const agent of Object.values(agents)) {
-			if (agent.laneNumber === laneNumber && agent.role === "worker" &&
-				!isTerminalStatus(agent.status) && isProcessAlive(agent.pid)) {
+			if (
+				agent.laneNumber === laneNumber &&
+				agent.role === "worker" &&
+				!isTerminalStatus(agent.status) &&
+				isProcessAlive(agent.pid)
+			) {
 				return true;
 			}
 		}
@@ -101,14 +175,18 @@ export function isV2AgentAlive(agentIdOrSessionName: string, _runtimeBackend?: R
 }
 
 /** Cached registry for V2 liveness checks within a monitor cycle. @since TP-112 */
-let _v2LivenessRegistryCache: import("./process-registry.ts").RuntimeRegistry | null = null;
+let _v2LivenessRegistryCache:
+	| import("./process-registry.ts").RuntimeRegistry
+	| null = null;
 
 /**
  * Set the V2 liveness registry cache for the current monitor cycle.
  * Called at the start of each monitor poll to avoid re-reading the file per-task.
  * @since TP-112
  */
-export function setV2LivenessRegistryCache(registry: import("./process-registry.ts").RuntimeRegistry | null): void {
+export function setV2LivenessRegistryCache(
+	registry: import("./process-registry.ts").RuntimeRegistry | null,
+): void {
 	_v2LivenessRegistryCache = registry;
 }
 
@@ -122,13 +200,18 @@ export function setV2LivenessRegistryCache(registry: import("./process-registry.
  */
 export function killV2LaneAgents(
 	sessionName: string,
-	options?: { stateRoot?: string; batchId?: string; logContext?: string; laneNumber?: number },
+	options?: {
+		stateRoot?: string;
+		batchId?: string;
+		logContext?: string;
+		laneNumber?: number;
+	},
 ): void {
-	const registry = _v2LivenessRegistryCache ?? (
-		options?.stateRoot && options?.batchId
+	const registry =
+		_v2LivenessRegistryCache ??
+		(options?.stateRoot && options?.batchId
 			? readRegistrySnapshot(options.stateRoot, options.batchId)
-			: null
-	);
+			: null);
 	if (!registry) return;
 
 	const agents = registry.agents;
@@ -137,32 +220,48 @@ export function killV2LaneAgents(
 	for (const suffix of ["-worker", "-reviewer", ""]) {
 		const key = `${sessionName}${suffix}`;
 		const manifest = agents[key];
-		if (manifest && !isTerminalStatus(manifest.status) && isProcessAlive(manifest.pid) && !killedPids.has(manifest.pid)) {
+		if (
+			manifest &&
+			!isTerminalStatus(manifest.status) &&
+			isProcessAlive(manifest.pid) &&
+			!killedPids.has(manifest.pid)
+		) {
 			try {
 				process.kill(manifest.pid, "SIGTERM");
 				killedPids.add(manifest.pid);
 				execLog(logContext, key, `killed V2 agent (PID ${manifest.pid})`);
-			} catch { /* already dead */ }
+			} catch {
+				/* already dead */
+			}
 		}
 	}
 	// TP-148: Workspace-mode fallback — match by global lane number when
 	// session name lookup misses (repoId/local-vs-global lane mismatch).
 	if (options?.laneNumber != null) {
 		for (const agent of Object.values(agents)) {
-			if (agent.laneNumber === options.laneNumber &&
-				!isTerminalStatus(agent.status) && isProcessAlive(agent.pid) && !killedPids.has(agent.pid)) {
+			if (
+				agent.laneNumber === options.laneNumber &&
+				!isTerminalStatus(agent.status) &&
+				isProcessAlive(agent.pid) &&
+				!killedPids.has(agent.pid)
+			) {
 				try {
 					process.kill(agent.pid, "SIGTERM");
 					killedPids.add(agent.pid);
-					execLog(logContext, agent.agentId, `killed V2 agent by lane number (PID ${agent.pid})`);
-				} catch { /* already dead */ }
+					execLog(
+						logContext,
+						agent.agentId,
+						`killed V2 agent by lane number (PID ${agent.pid})`,
+					);
+				} catch {
+					/* already dead */
+				}
 			}
 		}
 	}
 }
 
 // ── Async File/Status Helpers (TP-070) ───────────────────────────────
-
 
 /**
  * Async version of readTaskStatusTail — reads STATUS.md tail without
@@ -186,7 +285,9 @@ export async function readTaskStatusTailAsync(
 		return "";
 	}
 	try {
-		const raw = (await fsReadFile(statusPath, "utf-8")).replace(/\r\n/g, "\n").trim();
+		const raw = (await fsReadFile(statusPath, "utf-8"))
+			.replace(/\r\n/g, "\n")
+			.trim();
 		if (!raw) return "";
 		const tail = raw.split("\n").slice(-maxLines).join("\n").trim();
 		if (!tail) return "";
@@ -218,7 +319,12 @@ export function resolveLaneLogPath(
 	lane: AllocatedLane,
 	task: AllocatedTask,
 ): string {
-	return join(lane.worktreePath, ".pi", "orch-logs", `${laneSessionIdOf(lane)}-${task.taskId}.log`);
+	return join(
+		lane.worktreePath,
+		".pi",
+		"orch-logs",
+		`${laneSessionIdOf(lane)}-${task.taskId}.log`,
+	);
 }
 
 /**
@@ -230,7 +336,11 @@ export function resolveLaneLogRelativePath(
 	lane: AllocatedLane,
 	task: AllocatedTask,
 ): string {
-	return join(".pi", "orch-logs", `${laneSessionIdOf(lane)}-${task.taskId}.log`).replace(/\\/g, "/");
+	return join(
+		".pi",
+		"orch-logs",
+		`${laneSessionIdOf(lane)}-${task.taskId}.log`,
+	).replace(/\\/g, "/");
 }
 
 /**
@@ -445,9 +555,13 @@ export function resolveTaskDonePath(
 	repoRoot: string,
 	isWorkspaceMode?: boolean,
 ): string {
-	return resolveCanonicalTaskPaths(taskFolder, worktreePath, repoRoot, isWorkspaceMode).donePath;
+	return resolveCanonicalTaskPaths(
+		taskFolder,
+		worktreePath,
+		repoRoot,
+		isWorkspaceMode,
+	).donePath;
 }
-
 
 /*
  * Removed in TP-120 while decommissioning the legacy session backend.
@@ -456,7 +570,7 @@ export function resolveTaskDonePath(
  * Runtime V2 completion detection now lives in lane-runner + agent-host.
  */
 // pollUntilTaskComplete function body removed — was ~170 lines of legacy .DONE polling.
-// @ts-ignore — export kept as stub for test compatibility
+// @ts-expect-error — export kept as stub for test compatibility
 export async function pollUntilTaskComplete(
 	_lane: AllocatedLane,
 	_task: AllocatedTask,
@@ -464,8 +578,16 @@ export async function pollUntilTaskComplete(
 	_repoRoot: string,
 	_pauseSignal: { paused: boolean },
 	_isWorkspaceMode?: boolean,
-): Promise<{ status: LaneTaskStatus; exitReason: string; doneFileFound: boolean }> {
-	return { status: "failed", exitReason: "Legacy pollUntilTaskComplete removed — use V2 lane-runner", doneFileFound: false };
+): Promise<{
+	status: LaneTaskStatus;
+	exitReason: string;
+	doneFileFound: boolean;
+}> {
+	return {
+		status: "failed",
+		exitReason: "Legacy pollUntilTaskComplete removed — use V2 lane-runner",
+		doneFileFound: false,
+	};
 }
 
 // ── Post-Task Commit ─────────────────────────────────────────────────
@@ -501,19 +623,31 @@ function commitTaskArtifacts(
 	// Stage all changes in the worktree
 	const addResult = runGit(["add", "-A"], worktreePath);
 	if (!addResult.ok) {
-		execLog(laneId, task.taskId, `post-task stage failed (non-fatal): ${addResult.stderr.slice(0, 200)}`);
+		execLog(
+			laneId,
+			task.taskId,
+			`post-task stage failed (non-fatal): ${addResult.stderr.slice(0, 200)}`,
+		);
 		return;
 	}
 
 	// Commit with task ID for traceability
 	const commitResult = runGit(
-		["commit", "-m", `checkpoint: ${task.taskId} task artifacts (.DONE, STATUS.md)`],
+		[
+			"commit",
+			"-m",
+			`checkpoint: ${task.taskId} task artifacts (.DONE, STATUS.md)`,
+		],
 		worktreePath,
 	);
 	if (!commitResult.ok) {
 		// "nothing to commit" is not an error — worker may have already committed
 		if (!commitResult.stderr.includes("nothing to commit")) {
-			execLog(laneId, task.taskId, `post-task commit failed (non-fatal): ${commitResult.stderr.slice(0, 200)}`);
+			execLog(
+				laneId,
+				task.taskId,
+				`post-task commit failed (non-fatal): ${commitResult.stderr.slice(0, 200)}`,
+			);
 		}
 		return;
 	}
@@ -522,9 +656,6 @@ function commitTaskArtifacts(
 		commit: commitResult.stdout.trim().split("\n")[0],
 	});
 }
-
-
-
 
 // ── STATUS.md Parsing for Worktree ───────────────────────────────────
 
@@ -569,7 +700,12 @@ export function parseWorktreeStatusMd(
 	isWorkspaceMode?: boolean,
 ): { parsed: ParsedWorktreeStatus | null; error: string | null } {
 	// Use canonical resolver for consistent path translation
-	const resolved = resolveCanonicalTaskPaths(taskFolder, worktreePath, repoRoot, isWorkspaceMode);
+	const resolved = resolveCanonicalTaskPaths(
+		taskFolder,
+		worktreePath,
+		repoRoot,
+		isWorkspaceMode,
+	);
 	const statusPath = resolved.statusPath;
 
 	if (!existsSync(statusPath)) {
@@ -582,7 +718,10 @@ export function parseWorktreeStatusMd(
 		content = readFileSync(statusPath, "utf-8");
 		mtime = statSync(statusPath).mtimeMs;
 	} catch (err: unknown) {
-		return { parsed: null, error: `Cannot read STATUS.md: ${err instanceof Error ? err.message : String(err)}` };
+		return {
+			parsed: null,
+			error: `Cannot read STATUS.md: ${err instanceof Error ? err.message : String(err)}`,
+		};
 	}
 
 	// Parse using same regex patterns as task-runner's parseStatusMd
@@ -606,7 +745,7 @@ export function parseWorktreeStatusMd(
 		const stepMatch = line.match(/^###\s+Step\s+(\d+):\s*(.+)/);
 		if (stepMatch) {
 			if (currentStep) {
-				const totalChecked = currentStep.checkboxes.filter(c => c).length;
+				const totalChecked = currentStep.checkboxes.filter((c) => c).length;
 				steps.push({
 					number: currentStep.number,
 					name: currentStep.name,
@@ -629,7 +768,11 @@ export function parseWorktreeStatusMd(
 				const s = ss[1];
 				if (s.includes("✅") || s.toLowerCase().includes("complete")) {
 					currentStep.status = "complete";
-				} else if (s.includes("🟨") || s.includes("🟡") || s.toLowerCase().includes("progress")) {
+				} else if (
+					s.includes("🟨") ||
+					s.includes("🟡") ||
+					s.toLowerCase().includes("progress")
+				) {
 					currentStep.status = "in-progress";
 				}
 			}
@@ -640,7 +783,7 @@ export function parseWorktreeStatusMd(
 		}
 	}
 	if (currentStep) {
-		const totalChecked = currentStep.checkboxes.filter(c => c).length;
+		const totalChecked = currentStep.checkboxes.filter((c) => c).length;
 		steps.push({
 			number: currentStep.number,
 			name: currentStep.name,
@@ -689,7 +832,12 @@ export async function parseWorktreeStatusMdAsync(
 	repoRoot: string,
 	isWorkspaceMode?: boolean,
 ): Promise<{ parsed: ParsedWorktreeStatus | null; error: string | null }> {
-	const resolved = resolveCanonicalTaskPaths(taskFolder, worktreePath, repoRoot, isWorkspaceMode);
+	const resolved = resolveCanonicalTaskPaths(
+		taskFolder,
+		worktreePath,
+		repoRoot,
+		isWorkspaceMode,
+	);
 	return parseStatusMdContent(resolved.statusPath);
 }
 
@@ -707,7 +855,10 @@ async function parseStatusMdContent(
 		content = await fsReadFile(statusPath, "utf-8");
 		mtime = (await fsStat(statusPath)).mtimeMs;
 	} catch (err: unknown) {
-		return { parsed: null, error: `Cannot read STATUS.md: ${err instanceof Error ? err.message : String(err)}` };
+		return {
+			parsed: null,
+			error: `Cannot read STATUS.md: ${err instanceof Error ? err.message : String(err)}`,
+		};
 	}
 
 	// Parse logic is identical to the sync version
@@ -731,7 +882,7 @@ async function parseStatusMdContent(
 		const stepMatch = line.match(/^###\s+Step\s+(\d+):\s*(.+)/);
 		if (stepMatch) {
 			if (currentStep) {
-				const totalChecked = currentStep.checkboxes.filter(c => c).length;
+				const totalChecked = currentStep.checkboxes.filter((c) => c).length;
 				steps.push({
 					number: currentStep.number,
 					name: currentStep.name,
@@ -754,7 +905,11 @@ async function parseStatusMdContent(
 				const s = ss[1];
 				if (s.includes("✅") || s.toLowerCase().includes("complete")) {
 					currentStep.status = "complete";
-				} else if (s.includes("🟨") || s.includes("🟡") || s.toLowerCase().includes("progress")) {
+				} else if (
+					s.includes("🟨") ||
+					s.includes("🟡") ||
+					s.toLowerCase().includes("progress")
+				) {
 					currentStep.status = "in-progress";
 				}
 			}
@@ -765,7 +920,7 @@ async function parseStatusMdContent(
 		}
 	}
 	if (currentStep) {
-		const totalChecked = currentStep.checkboxes.filter(c => c).length;
+		const totalChecked = currentStep.checkboxes.filter((c) => c).length;
 		steps.push({
 			number: currentStep.number,
 			name: currentStep.name,
@@ -780,7 +935,6 @@ async function parseStatusMdContent(
 		error: null,
 	};
 }
-
 
 // ── State Resolution ─────────────────────────────────────────────────
 
@@ -823,12 +977,16 @@ export async function resolveTaskMonitorState(
 	// Legacy: check lane-session liveness.
 	let sessionAlive: boolean;
 	if (runtimeBackend === "v2" && v2Context) {
-		const snap = readLaneSnapshot(v2Context.stateRoot, v2Context.batchId, v2Context.laneNumber);
+		const snap = readLaneSnapshot(
+			v2Context.stateRoot,
+			v2Context.batchId,
+			v2Context.laneNumber,
+		);
 		if (snap == null || snap.taskId !== taskId) {
 			// Snapshot not written yet OR snapshot still points to a prior task.
 			// Assume alive initially, but if stale for >30s consult the registry
 			// to avoid indefinite false "running" if the lane-runner died.
-			const staleMs = snap?.updatedAt ? (now - snap.updatedAt) : 0;
+			const staleMs = snap?.updatedAt ? now - snap.updatedAt : 0;
 			if (staleMs > 30_000) {
 				// Snapshot hasn't been updated for 30s+ — check registry as fallback.
 				// But also check if the tracker just started (firstObservedAt within
@@ -839,7 +997,11 @@ export async function resolveTaskMonitorState(
 					// New task, stale snapshot — give the worker startup grace period
 					sessionAlive = true;
 				} else {
-					sessionAlive = isV2AgentAlive(sessionName, runtimeBackend, v2Context?.laneNumber);
+					sessionAlive = isV2AgentAlive(
+						sessionName,
+						runtimeBackend,
+						v2Context?.laneNumber,
+					);
 				}
 			} else {
 				sessionAlive = true;
@@ -861,17 +1023,22 @@ export async function resolveTaskMonitorState(
 			const trackerAgeMs = now - tracker.firstObservedAt;
 			if (
 				snap.updatedAt &&
-				(now - snap.updatedAt) > stallTimeoutMs / 2 &&
+				now - snap.updatedAt > stallTimeoutMs / 2 &&
 				trackerAgeMs >= 60_000 &&
 				!isV2AgentAlive(sessionName, runtimeBackend, v2Context?.laneNumber)
 			) {
 				// Ghost worker confirmed: PID dead, snapshot stale beyond half the stall timeout
-				execLog("monitor", taskId, "ghost worker fast-fail — dead PID + stale snapshot", {
-					session: sessionName,
-					snapStaleMs: now - snap.updatedAt,
-					trackerAgeMs,
-					halfStallTimeoutMs: stallTimeoutMs / 2,
-				});
+				execLog(
+					"monitor",
+					taskId,
+					"ghost worker fast-fail — dead PID + stale snapshot",
+					{
+						session: sessionName,
+						snapStaleMs: now - snap.updatedAt,
+						trackerAgeMs,
+						halfStallTimeoutMs: stallTimeoutMs / 2,
+					},
+				);
 				sessionAlive = false;
 			} else {
 				sessionAlive = snap.status === "running";
@@ -890,7 +1057,7 @@ export async function resolveTaskMonitorState(
 	let totalItems = 0;
 	let iteration = 0;
 	let reviewCounter = 0;
-	let parseError = statusResult.error;
+	const parseError = statusResult.error;
 
 	if (statusResult.parsed) {
 		const { steps } = statusResult.parsed;
@@ -904,13 +1071,13 @@ export async function resolveTaskMonitorState(
 		}
 
 		// Find the current step (first in-progress, or first not-started after last complete)
-		const inProgress = steps.find(s => s.status === "in-progress");
+		const inProgress = steps.find((s) => s.status === "in-progress");
 		if (inProgress) {
 			currentStepName = inProgress.name;
 			currentStepNumber = inProgress.number;
 		} else {
 			// Find first not-started step
-			const notStarted = steps.find(s => s.status === "not-started");
+			const notStarted = steps.find((s) => s.status === "not-started");
 			if (notStarted) {
 				currentStepName = notStarted.name;
 				currentStepNumber = notStarted.number;
@@ -965,7 +1132,7 @@ export async function resolveTaskMonitorState(
 		sessionAlive &&
 		tracker.statusFileSeenOnce &&
 		tracker.stallTimerStart !== null &&
-		(now - tracker.stallTimerStart) >= stallTimeoutMs
+		now - tracker.stallTimerStart >= stallTimeoutMs
 	) {
 		const stallMinutes = Math.round((now - tracker.stallTimerStart) / 60_000);
 		const stallReason = `STATUS.md unchanged for ${stallMinutes} minutes (threshold: ${Math.round(stallTimeoutMs / 60_000)} min)`;
@@ -1037,7 +1204,6 @@ export async function resolveTaskMonitorState(
 		reviewCounter,
 	};
 }
-
 
 // ── Core Monitor Loop ────────────────────────────────────────────────
 
@@ -1122,10 +1288,15 @@ export async function monitorLanes(
 	// Build the total task count
 	const tasksTotal = lanes.reduce((sum, lane) => sum + lane.tasks.length, 0);
 
-	execLog("monitor", "ALL", `starting monitoring for ${lanes.length} lane(s), ${tasksTotal} task(s)`, {
-		pollIntervalMs,
-		stallTimeoutMin: Math.round(stallTimeoutMs / 60_000),
-	});
+	execLog(
+		"monitor",
+		"ALL",
+		`starting monitoring for ${lanes.length} lane(s), ${tasksTotal} task(s)`,
+		{
+			pollIntervalMs,
+			stallTimeoutMin: Math.round(stallTimeoutMs / 60_000),
+		},
+	);
 
 	while (true) {
 		const now = Date.now();
@@ -1134,7 +1305,9 @@ export async function monitorLanes(
 		// TP-112: Refresh V2 liveness registry cache once per poll cycle
 		if (runtimeBackend === "v2" && batchId) {
 			try {
-				setV2LivenessRegistryCache(readRegistrySnapshot(stateRootForRegistry ?? repoRoot, batchId));
+				setV2LivenessRegistryCache(
+					readRegistrySnapshot(stateRootForRegistry ?? repoRoot, batchId),
+				);
 			} catch {
 				setV2LivenessRegistryCache(null);
 			}
@@ -1150,18 +1323,31 @@ export async function monitorLanes(
 		// and the dashboard all reflect reality within one poll interval.
 		if (runtimeBackend === "v2" && batchId) {
 			try {
-				const registry = readRegistrySnapshot(stateRootForRegistry ?? repoRoot, batchId);
+				const registry = readRegistrySnapshot(
+					stateRootForRegistry ?? repoRoot,
+					batchId,
+				);
 				if (registry) {
 					const orphans = detectOrphans(registry);
 					if (orphans.length > 0) {
 						// Mark individual agent manifests as crashed
-						markOrphansCrashed(stateRootForRegistry ?? repoRoot, batchId, orphans);
+						markOrphansCrashed(
+							stateRootForRegistry ?? repoRoot,
+							batchId,
+							orphans,
+						);
 						// Rebuild and write registry.json from the updated individual manifests.
 						// markOrphansCrashed only updates per-agent files; registry.json is a
 						// cached aggregate that must be explicitly rebuilt so readRegistrySnapshot()
 						// and the dashboard see the crashed status within this poll cycle.
-						const freshRegistry = buildRegistrySnapshot(stateRootForRegistry ?? repoRoot, batchId);
-						writeRegistrySnapshot(stateRootForRegistry ?? repoRoot, freshRegistry);
+						const freshRegistry = buildRegistrySnapshot(
+							stateRootForRegistry ?? repoRoot,
+							batchId,
+						);
+						writeRegistrySnapshot(
+							stateRootForRegistry ?? repoRoot,
+							freshRegistry,
+						);
 						setV2LivenessRegistryCache(freshRegistry);
 					}
 				}
@@ -1211,7 +1397,12 @@ export async function monitorLanes(
 					currentTaskId = task.taskId;
 
 					const tracker = getOrCreateTracker(task.taskId, now);
-					const unit = buildExecutionUnit(lane, task, repoRoot, isWorkspaceMode);
+					const unit = buildExecutionUnit(
+						lane,
+						task,
+						repoRoot,
+						isWorkspaceMode,
+					);
 					const donePath = unit.packet.donePath;
 					const statusPath = unit.packet.statusPath;
 					const statusResult = await parseStatusMdAtPath(statusPath);
@@ -1225,17 +1416,23 @@ export async function monitorLanes(
 						stallTimeoutMs,
 						now,
 						runtimeBackend,
-						(runtimeBackend === "v2" && batchId) ? {
-							stateRoot: stateRootForRegistry ?? repoRoot,
-							batchId,
-							laneNumber: lane.laneNumber,
-						} : undefined,
+						runtimeBackend === "v2" && batchId
+							? {
+									stateRoot: stateRootForRegistry ?? repoRoot,
+									batchId,
+									laneNumber: lane.laneNumber,
+								}
+							: undefined,
 					);
 
 					currentTaskSnapshot = snapshot;
 
 					// Check if this task just became terminal
-					if (snapshot.status === "succeeded" || snapshot.status === "failed" || snapshot.status === "stalled") {
+					if (
+						snapshot.status === "succeeded" ||
+						snapshot.status === "failed" ||
+						snapshot.status === "stalled"
+					) {
 						terminalTasks.set(task.taskId, snapshot);
 						if (snapshot.status === "succeeded") {
 							completedTasks.push(task.taskId);
@@ -1270,7 +1467,11 @@ export async function monitorLanes(
 
 			// TP-112: Backend-aware lane liveness for snapshot
 			// TP-148: Pass global laneNumber for workspace-mode fallback lookup
-			const sessionAlive = isV2AgentAlive(laneSessionIdOf(lane), "v2", lane.laneNumber);
+			const sessionAlive = isV2AgentAlive(
+				laneSessionIdOf(lane),
+				"v2",
+				lane.laneNumber,
+			);
 
 			laneSnapshots.push({
 				laneId: lane.laneId,
@@ -1308,8 +1509,12 @@ export async function monitorLanes(
 		// Log summary only on state changes (lane completes or fails) — not every poll
 		const currentStateKey = `${totalDone}/${totalFailed}`;
 		if (currentStateKey !== lastMonitorStateKey) {
-			const activeLanes = laneSnapshots.filter(l => l.currentTaskId !== null);
-			execLog("monitor", "ALL", `poll #${pollCount}: ${totalDone}/${tasksTotal} done, ${totalFailed} failed, ${activeLanes.length} active lane(s)`);
+			const activeLanes = laneSnapshots.filter((l) => l.currentTaskId !== null);
+			execLog(
+				"monitor",
+				"ALL",
+				`poll #${pollCount}: ${totalDone}/${tasksTotal} done, ${totalFailed} failed, ${activeLanes.length} active lane(s)`,
+			);
 			lastMonitorStateKey = currentStateKey;
 		}
 
@@ -1326,12 +1531,12 @@ export async function monitorLanes(
 		}
 
 		// Wait for next poll cycle
-		await new Promise(r => setTimeout(r, pollIntervalMs));
+		await new Promise((r) => setTimeout(r, pollIntervalMs));
 	}
 
 	// Reached here due to pause signal — return current state
 	const now = Date.now();
-	const laneSnapshots: LaneMonitorSnapshot[] = lanes.map(lane => ({
+	const laneSnapshots: LaneMonitorSnapshot[] = lanes.map((lane) => ({
 		laneId: lane.laneId,
 		laneNumber: lane.laneNumber,
 		sessionName: laneSessionIdOf(lane),
@@ -1340,7 +1545,7 @@ export async function monitorLanes(
 		currentTaskSnapshot: null,
 		completedTasks: [],
 		failedTasks: [],
-		remainingTasks: lane.tasks.map(t => t.taskId),
+		remainingTasks: lane.tasks.map((t) => t.taskId),
 	}));
 
 	setV2LivenessRegistryCache(null);
@@ -1355,7 +1560,6 @@ export async function monitorLanes(
 		allTerminal: false,
 	};
 }
-
 
 // ── Transitive Dependent Computation ─────────────────────────────────
 
@@ -1399,7 +1603,6 @@ export function computeTransitiveDependents(
 
 	return blocked;
 }
-
 
 // ── Pre-flight: Commit Untracked Task Files ─────────────────────────
 
@@ -1452,10 +1655,15 @@ export function ensureTaskFilesCommitted(
 	for (const { taskId, relPath } of foldersToCheck) {
 		const status = runGit(["status", "--porcelain", "--", relPath], repoRoot);
 		if (status.ok && status.stdout.trim()) {
-			execLog("wave", `W${waveIndex}`, `task ${taskId} has uncommitted files, staging`, {
-				folder: relPath,
-				status: status.stdout.trim().split("\n").slice(0, 5).join("; "),
-			});
+			execLog(
+				"wave",
+				`W${waveIndex}`,
+				`task ${taskId} has uncommitted files, staging`,
+				{
+					folder: relPath,
+					status: status.stdout.trim().split("\n").slice(0, 5).join("; "),
+				},
+			);
 			foldersToStage.push(relPath);
 		}
 	}
@@ -1478,36 +1686,49 @@ export function ensureTaskFilesCommitted(
 	// Fallback: if orch branch plumbing fails or orchBranch is not provided,
 	// fall back to the legacy path of committing on HEAD.
 	if (orchBranch) {
-		const orchTipRes = runGit(["rev-parse", `refs/heads/${orchBranch}`], repoRoot);
+		const orchTipRes = runGit(
+			["rev-parse", `refs/heads/${orchBranch}`],
+			repoRoot,
+		);
 		if (orchTipRes.ok) {
 			const orchTip = orchTipRes.stdout.trim();
-			const tmpIdx = join(repoRoot, ".git", `tmp-staging-idx-wave-${waveIndex}`);
+			const tmpIdx = join(
+				repoRoot,
+				".git",
+				`tmp-staging-idx-wave-${waveIndex}`,
+			);
 
 			try {
 				// Read orch branch tree into temporary index
-				const readTreeRes = runGitWithEnv(
-					["read-tree", orchTip],
-					repoRoot,
-					{ GIT_INDEX_FILE: tmpIdx },
-				);
+				const readTreeRes = runGitWithEnv(["read-tree", orchTip], repoRoot, {
+					GIT_INDEX_FILE: tmpIdx,
+				});
 				if (!readTreeRes.ok) {
-					execLog("wave", `W${waveIndex}`, `orch branch staging: read-tree failed, falling back to HEAD commit`, {
-						error: readTreeRes.stderr,
-					});
+					execLog(
+						"wave",
+						`W${waveIndex}`,
+						`orch branch staging: read-tree failed, falling back to HEAD commit`,
+						{
+							error: readTreeRes.stderr,
+						},
+					);
 					// Fall through to legacy path
 				} else {
 					// Add task files to temporary index
 					let addFailed = false;
 					for (const folder of foldersToStage) {
-						const addRes = runGitWithEnv(
-							["add", "--", folder],
-							repoRoot,
-							{ GIT_INDEX_FILE: tmpIdx },
-						);
+						const addRes = runGitWithEnv(["add", "--", folder], repoRoot, {
+							GIT_INDEX_FILE: tmpIdx,
+						});
 						if (!addRes.ok) {
-							execLog("wave", `W${waveIndex}`, `orch branch staging: git add failed for ${folder}, falling back`, {
-								error: addRes.stderr,
-							});
+							execLog(
+								"wave",
+								`W${waveIndex}`,
+								`orch branch staging: git add failed for ${folder}, falling back`,
+								{
+									error: addRes.stderr,
+								},
+							);
 							addFailed = true;
 							break;
 						}
@@ -1515,15 +1736,15 @@ export function ensureTaskFilesCommitted(
 
 					if (!addFailed) {
 						// Write tree from temporary index
-						const writeTreeRes = runGitWithEnv(
-							["write-tree"],
-							repoRoot,
-							{ GIT_INDEX_FILE: tmpIdx },
-						);
+						const writeTreeRes = runGitWithEnv(["write-tree"], repoRoot, {
+							GIT_INDEX_FILE: tmpIdx,
+						});
 
 						if (writeTreeRes.ok) {
 							const tree = writeTreeRes.stdout.trim();
-							const taskIds = foldersToStage.map(f => f.split("/").pop() || f).join(", ");
+							const taskIds = foldersToStage
+								.map((f) => f.split("/").pop() || f)
+								.join(", ");
 							const commitMsg = `chore: stage task files for orchestrator wave ${waveIndex} (${taskIds})`;
 
 							// Create commit directly on orch branch
@@ -1535,43 +1756,81 @@ export function ensureTaskFilesCommitted(
 							if (commitTreeRes.ok) {
 								const newCommit = commitTreeRes.stdout.trim();
 								const refUpdateRes = runGit(
-									["update-ref", `refs/heads/${orchBranch}`, newCommit, orchTip],
+									[
+										"update-ref",
+										`refs/heads/${orchBranch}`,
+										newCommit,
+										orchTip,
+									],
 									repoRoot,
 								);
 
 								if (refUpdateRes.ok) {
-									execLog("wave", `W${waveIndex}`, `committed ${foldersToStage.length} task folder(s) directly on orch branch`, {
-										orchBranch,
-										folders: foldersToStage,
-										from: orchTip.slice(0, 8),
-										to: newCommit.slice(0, 8),
-									});
+									execLog(
+										"wave",
+										`W${waveIndex}`,
+										`committed ${foldersToStage.length} task folder(s) directly on orch branch`,
+										{
+											orchBranch,
+											folders: foldersToStage,
+											from: orchTip.slice(0, 8),
+											to: newCommit.slice(0, 8),
+										},
+									);
 									// Clean up temp index and return — no need for legacy path
-									try { unlinkSync(tmpIdx); } catch { /* best effort */ }
+									try {
+										unlinkSync(tmpIdx);
+									} catch {
+										/* best effort */
+									}
 									return;
 								}
-								execLog("wave", `W${waveIndex}`, `orch branch staging: ref update failed, falling back`, {
-									error: refUpdateRes.stderr,
-								});
+								execLog(
+									"wave",
+									`W${waveIndex}`,
+									`orch branch staging: ref update failed, falling back`,
+									{
+										error: refUpdateRes.stderr,
+									},
+								);
 							} else {
-								execLog("wave", `W${waveIndex}`, `orch branch staging: commit-tree failed, falling back`, {
-									error: commitTreeRes.stderr,
-								});
+								execLog(
+									"wave",
+									`W${waveIndex}`,
+									`orch branch staging: commit-tree failed, falling back`,
+									{
+										error: commitTreeRes.stderr,
+									},
+								);
 							}
 						} else {
-							execLog("wave", `W${waveIndex}`, `orch branch staging: write-tree failed, falling back`, {
-								error: writeTreeRes.stderr,
-							});
+							execLog(
+								"wave",
+								`W${waveIndex}`,
+								`orch branch staging: write-tree failed, falling back`,
+								{
+									error: writeTreeRes.stderr,
+								},
+							);
 						}
 					}
 				}
 			} catch (err: unknown) {
-				execLog("wave", `W${waveIndex}`, `orch branch staging: unexpected error, falling back to HEAD commit`, {
-					error: err instanceof Error ? err.message : String(err),
-				});
+				execLog(
+					"wave",
+					`W${waveIndex}`,
+					`orch branch staging: unexpected error, falling back to HEAD commit`,
+					{
+						error: err instanceof Error ? err.message : String(err),
+					},
+				);
 			} finally {
 				// Always clean up temp index
-				try { unlinkSync(tmpIdx); } catch { /* best effort */ }
+				try {
+					unlinkSync(tmpIdx);
+				} catch {
+					/* best effort */
+				}
 			}
 		}
 	}
@@ -1584,7 +1843,12 @@ export function ensureTaskFilesCommitted(
 	for (const folder of foldersToStage) {
 		const addResult = runGit(["add", "--", folder], repoRoot);
 		if (!addResult.ok) {
-			execLog("wave", `W${waveIndex}`, `failed to stage task files: ${addResult.stderr}`, { folder });
+			execLog(
+				"wave",
+				`W${waveIndex}`,
+				`failed to stage task files: ${addResult.stderr}`,
+				{ folder },
+			);
 			throw new ExecutionError(
 				"EXEC_TASK_STAGE_FAILED",
 				`Failed to stage task files in "${folder}": ${addResult.stderr}`,
@@ -1595,11 +1859,15 @@ export function ensureTaskFilesCommitted(
 	}
 
 	// Commit
-	const taskIds = foldersToStage.map(f => f.split("/").pop() || f).join(", ");
+	const taskIds = foldersToStage.map((f) => f.split("/").pop() || f).join(", ");
 	const commitMsg = `chore: stage task files for orchestrator wave ${waveIndex} (${taskIds})`;
 	const commitResult = runGit(["commit", "-m", commitMsg], repoRoot);
 	if (!commitResult.ok) {
-		execLog("wave", `W${waveIndex}`, `failed to commit task files: ${commitResult.stderr}`);
+		execLog(
+			"wave",
+			`W${waveIndex}`,
+			`failed to commit task files: ${commitResult.stderr}`,
+		);
 		throw new ExecutionError(
 			"EXEC_TASK_COMMIT_FAILED",
 			`Failed to commit task files for wave ${waveIndex}: ${commitResult.stderr}`,
@@ -1608,10 +1876,15 @@ export function ensureTaskFilesCommitted(
 		);
 	}
 
-	execLog("wave", `W${waveIndex}`, `committed ${foldersToStage.length} task folder(s) to ensure worktree visibility`, {
-		folders: foldersToStage,
-		commit: commitResult.stdout.trim().split("\n")[0],
-	});
+	execLog(
+		"wave",
+		`W${waveIndex}`,
+		`committed ${foldersToStage.length} task folder(s) to ensure worktree visibility`,
+		{
+			folders: foldersToStage,
+			commit: commitResult.stdout.trim().split("\n")[0],
+		},
+	);
 
 	// Fast-forward (or merge) the orch branch to include the staging commit so
 	// that worktrees—which branch from orchBranch—see the new task files and
@@ -1619,7 +1892,10 @@ export function ensureTaskFilesCommitted(
 	if (orchBranch) {
 		try {
 			const headRes = runGit(["rev-parse", "HEAD"], repoRoot);
-			const orchTipRes = runGit(["rev-parse", `refs/heads/${orchBranch}`], repoRoot);
+			const orchTipRes = runGit(
+				["rev-parse", `refs/heads/${orchBranch}`],
+				repoRoot,
+			);
 
 			if (headRes.ok && orchTipRes.ok) {
 				const newHead = headRes.stdout.trim();
@@ -1636,16 +1912,26 @@ export function ensureTaskFilesCommitted(
 						repoRoot,
 					);
 					if (ffResult.ok) {
-						execLog("wave", `W${waveIndex}`, `fast-forwarded orch branch to include staging commit`, {
-							orchBranch,
-							from: orchTip.slice(0, 8),
-							to: newHead.slice(0, 8),
-						});
+						execLog(
+							"wave",
+							`W${waveIndex}`,
+							`fast-forwarded orch branch to include staging commit`,
+							{
+								orchBranch,
+								from: orchTip.slice(0, 8),
+								to: newHead.slice(0, 8),
+							},
+						);
 					} else {
-						execLog("wave", `W${waveIndex}`, `warning: failed to fast-forward orch branch (non-fatal)`, {
-							orchBranch,
-							error: ffResult.stderr,
-						});
+						execLog(
+							"wave",
+							`W${waveIndex}`,
+							`warning: failed to fast-forward orch branch (non-fatal)`,
+							{
+								orchBranch,
+								error: ffResult.stderr,
+							},
+						);
 					}
 				} else {
 					const mergeTreeRes = runGit(
@@ -1657,20 +1943,39 @@ export function ensureTaskFilesCommitted(
 						if (/^[0-9a-f]{40}$/i.test(mergedTree)) {
 							const mergeMsg = `merge: include staged task files for wave ${waveIndex} into orch branch`;
 							const commitTreeRes = runGit(
-								["commit-tree", mergedTree, "-p", orchTip, "-p", newHead, "-m", mergeMsg],
+								[
+									"commit-tree",
+									mergedTree,
+									"-p",
+									orchTip,
+									"-p",
+									newHead,
+									"-m",
+									mergeMsg,
+								],
 								repoRoot,
 							);
 							if (commitTreeRes.ok) {
 								const mergeCommitSha = commitTreeRes.stdout.trim();
 								const refUpdateRes = runGit(
-									["update-ref", `refs/heads/${orchBranch}`, mergeCommitSha, orchTip],
+									[
+										"update-ref",
+										`refs/heads/${orchBranch}`,
+										mergeCommitSha,
+										orchTip,
+									],
 									repoRoot,
 								);
 								if (refUpdateRes.ok) {
-									execLog("wave", `W${waveIndex}`, `merged staging commit into orch branch (non-FF wave)`, {
-										orchBranch,
-										mergeCommit: mergeCommitSha.slice(0, 8),
-									});
+									execLog(
+										"wave",
+										`W${waveIndex}`,
+										`merged staging commit into orch branch (non-FF wave)`,
+										{
+											orchBranch,
+											mergeCommit: mergeCommitSha.slice(0, 8),
+										},
+									);
 								}
 							}
 						}
@@ -1678,10 +1983,15 @@ export function ensureTaskFilesCommitted(
 				}
 			}
 		} catch (refErr: unknown) {
-			execLog("wave", `W${waveIndex}`, `warning: orch branch ref update threw unexpectedly (non-fatal)`, {
-				orchBranch,
-				error: refErr instanceof Error ? refErr.message : String(refErr),
-			});
+			execLog(
+				"wave",
+				`W${waveIndex}`,
+				`warning: orch branch ref update threw unexpectedly (non-fatal)`,
+				{
+					orchBranch,
+					error: refErr instanceof Error ? refErr.message : String(refErr),
+				},
+			);
 		}
 	}
 }
@@ -1753,8 +2063,22 @@ export async function executeWave(
 	workspaceConfig?: WorkspaceConfig | null,
 	runtimeBackend?: RuntimeBackend,
 	onSupervisorAlert?: SupervisorAlertCallback,
-	supervisorAutonomy: "interactive" | "supervised" | "autonomous" = "autonomous",
-	reviewerConfig?: { model?: string; thinking?: string; tools?: string; excludeExtensions?: string[] },
+	supervisorAutonomy:
+		| "interactive"
+		| "supervised"
+		| "autonomous" = "autonomous",
+	reviewerConfig?: {
+		model?: string;
+		thinking?: string;
+		tools?: string;
+		excludeExtensions?: string[];
+	},
+	workerConfig?: {
+		model?: string;
+		thinking?: string;
+		tools?: string;
+		excludeExtensions?: string[];
+	} | null,
 	workerExcludeExtensions?: string[],
 ): Promise<WaveExecutionResult> {
 	const startedAt = Date.now();
@@ -1773,7 +2097,13 @@ export async function executeWave(
 	// Pass orchBranch so the staging commit is reflected in the orch branch
 	// before worktrees are allocated from it.
 	try {
-		ensureTaskFilesCommitted(waveTasks, pending, repoRoot, waveIndex, orchBranch);
+		ensureTaskFilesCommitted(
+			waveTasks,
+			pending,
+			repoRoot,
+			waveIndex,
+			orchBranch,
+		);
 	} catch (err: unknown) {
 		const errMsg = err instanceof Error ? err.message : String(err);
 		execLog("wave", `W${waveIndex}`, `task file commit failed: ${errMsg}`);
@@ -1788,7 +2118,9 @@ export async function executeWave(
 			failedTaskIds: waveTasks,
 			skippedTaskIds: [],
 			succeededTaskIds: [],
-			blockedTaskIds: [...computeTransitiveDependents(new Set(waveTasks), dependencyGraph)],
+			blockedTaskIds: [
+				...computeTransitiveDependents(new Set(waveTasks), dependencyGraph),
+			],
 			laneCount: 0,
 			overallStatus: "failed",
 			finalMonitorState: null,
@@ -1797,7 +2129,15 @@ export async function executeWave(
 	}
 
 	// ── Stage 1: Allocate lanes ──────────────────────────────────
-	const allocResult = allocateLanes(waveTasks, pending, config, repoRoot, batchId, orchBranch, workspaceConfig);
+	const allocResult = allocateLanes(
+		waveTasks,
+		pending,
+		config,
+		repoRoot,
+		batchId,
+		orchBranch,
+		workspaceConfig,
+	);
 
 	if (!allocResult.success) {
 		const errMsg = allocResult.error?.message || "Unknown allocation failure";
@@ -1813,7 +2153,9 @@ export async function executeWave(
 			failedTaskIds: waveTasks, // All tasks in the wave are considered failed
 			skippedTaskIds: [],
 			succeededTaskIds: [],
-			blockedTaskIds: [...computeTransitiveDependents(new Set(waveTasks), dependencyGraph)],
+			blockedTaskIds: [
+				...computeTransitiveDependents(new Set(waveTasks), dependencyGraph),
+			],
 			laneCount: 0,
 			overallStatus: "failed",
 			finalMonitorState: null,
@@ -1838,11 +2180,17 @@ export async function executeWave(
 	// Start lane execution promises
 	// In workspace mode, pass the workspace root so lane sessions can find .pi/ config.
 	// configPath is .pi/taskplane-workspace.yaml → parent of parent is workspace root.
-	const wsRoot = workspaceConfig ? dirname(dirname(workspaceConfig.configPath)) : undefined;
+	const wsRoot = workspaceConfig
+		? dirname(dirname(workspaceConfig.configPath))
+		: undefined;
 	const isWsMode = !!workspaceConfig;
 	const backend: RuntimeBackend = "v2";
 	if (runtimeBackend && runtimeBackend !== "v2") {
-		execLog("wave", `W${waveIndex}`, `legacy runtime backend '${runtimeBackend}' requested but ignored; using Runtime V2`);
+		execLog(
+			"wave",
+			`W${waveIndex}`,
+			`legacy runtime backend '${runtimeBackend}' requested but ignored; using Runtime V2`,
+		);
 	}
 	execLog("wave", `W${waveIndex}`, "using Runtime V2 backend (executeLaneV2)");
 
@@ -1853,18 +2201,37 @@ export async function executeWave(
 	const snapshotStateRoot = resolveRuntimeStateRoot(repoRoot, wsRoot);
 	for (const lane of lanes) {
 		try {
-			const snapPath = join(snapshotStateRoot, ".pi", "runtime", batchId, "lanes", `lane-${lane.laneNumber}.json`);
+			const snapPath = join(
+				snapshotStateRoot,
+				".pi",
+				"runtime",
+				batchId,
+				"lanes",
+				`lane-${lane.laneNumber}.json`,
+			);
 			if (existsSync(snapPath)) unlinkSync(snapPath);
-		} catch { /* best effort */ }
+		} catch {
+			/* best effort */
+		}
 	}
 
-	const lanePromises = lanes.map(lane =>
-		executeLaneV2(lane, config, repoRoot, wavePauseSignal, wsRoot, isWsMode, {
-			ORCH_BATCH_ID: batchId,
-			TASKPLANE_SUPERVISOR_AUTONOMY: supervisorAutonomy,
-			...buildReviewerEnv(reviewerConfig),
-			...buildWorkerExcludeEnv(workerExcludeExtensions),
-		}, onSupervisorAlert),
+	const lanePromises = lanes.map((lane) =>
+		executeLaneV2(
+			lane,
+			config,
+			repoRoot,
+			wavePauseSignal,
+			wsRoot,
+			isWsMode,
+			{
+				ORCH_BATCH_ID: batchId,
+				TASKPLANE_SUPERVISOR_AUTONOMY: supervisorAutonomy,
+				...buildWorkerEnv(workerConfig),
+				...buildReviewerEnv(reviewerConfig),
+				...buildWorkerExcludeEnv(workerExcludeExtensions),
+			},
+			onSupervisorAlert,
+		),
 	);
 
 	// Start monitoring as a sibling async loop
@@ -1894,7 +2261,12 @@ export async function executeWave(
 	if (policy === "stop-all") {
 		// For stop-all: race detection — as soon as any lane reports failure,
 		// kill all sessions immediately.
-		laneResults = await executeWithStopAll(lanes, lanePromises, wavePauseSignal, waveIndex);
+		laneResults = await executeWithStopAll(
+			lanes,
+			lanePromises,
+			wavePauseSignal,
+			waveIndex,
+		);
 	} else {
 		// For skip-dependents and stop-wave:
 		// Let all lanes run to completion (or until pauseSignal stops them).
@@ -1906,12 +2278,19 @@ export async function executeWave(
 				return result.value;
 			}
 			// Rejected promise — shouldn't normally happen (executeLane catches errors)
-			const errMsg = result.reason instanceof Error ? result.reason.message : String(result.reason);
-			execLog("wave", `W${waveIndex}`, `lane ${lanes[idx].laneId} promise rejected: ${errMsg}`);
+			const errMsg =
+				result.reason instanceof Error
+					? result.reason.message
+					: String(result.reason);
+			execLog(
+				"wave",
+				`W${waveIndex}`,
+				`lane ${lanes[idx].laneId} promise rejected: ${errMsg}`,
+			);
 			return {
 				laneNumber: lanes[idx].laneNumber,
 				laneId: lanes[idx].laneId,
-				tasks: lanes[idx].tasks.map(t => ({
+				tasks: lanes[idx].tasks.map((t) => ({
 					taskId: t.taskId,
 					status: "failed" as LaneTaskStatus,
 					startTime: null,
@@ -1929,12 +2308,16 @@ export async function executeWave(
 
 		// For stop-wave: if any task failed, set pause to prevent next wave
 		if (policy === "stop-wave") {
-			const hasFailure = laneResults.some(lr =>
-				lr.tasks.some(t => t.status === "failed" || t.status === "stalled"),
+			const hasFailure = laneResults.some((lr) =>
+				lr.tasks.some((t) => t.status === "failed" || t.status === "stalled"),
 			);
 			if (hasFailure) {
 				wavePauseSignal.paused = true;
-				execLog("wave", `W${waveIndex}`, `stop-wave policy triggered — pausing after this wave`);
+				execLog(
+					"wave",
+					`W${waveIndex}`,
+					`stop-wave policy triggered — pausing after this wave`,
+				);
 			}
 		}
 	}
@@ -1979,15 +2362,21 @@ export async function executeWave(
 		);
 		blockedTaskIds = [...blocked].sort();
 		if (blockedTaskIds.length > 0) {
-			execLog("wave", `W${waveIndex}`, `skip-dependents: ${blockedTaskIds.length} task(s) blocked for future waves`, {
-				blocked: blockedTaskIds.join(","),
-			});
+			execLog(
+				"wave",
+				`W${waveIndex}`,
+				`skip-dependents: ${blockedTaskIds.length} task(s) blocked for future waves`,
+				{
+					blocked: blockedTaskIds.join(","),
+				},
+			);
 		}
 	}
 
 	// Determine overall wave status
-	const stoppedEarly = policy === "stop-all" && failedTaskIds.length > 0
-		|| policy === "stop-wave" && failedTaskIds.length > 0;
+	const stoppedEarly =
+		(policy === "stop-all" && failedTaskIds.length > 0) ||
+		(policy === "stop-wave" && failedTaskIds.length > 0);
 
 	let overallStatus: WaveExecutionResult["overallStatus"];
 	if (policy === "stop-all" && failedTaskIds.length > 0) {
@@ -2003,14 +2392,19 @@ export async function executeWave(
 	const endedAt = Date.now();
 	const elapsedSec = Math.round((endedAt - startedAt) / 1000);
 
-	execLog("wave", `W${waveIndex}`, `wave execution complete: ${overallStatus}`, {
-		succeeded: succeededTaskIds.length,
-		failed: failedTaskIds.length,
-		skipped: skippedTaskIds.length,
-		blocked: blockedTaskIds.length,
-		elapsed: `${elapsedSec}s`,
-		stoppedEarly,
-	});
+	execLog(
+		"wave",
+		`W${waveIndex}`,
+		`wave execution complete: ${overallStatus}`,
+		{
+			succeeded: succeededTaskIds.length,
+			failed: failedTaskIds.length,
+			skipped: skippedTaskIds.length,
+			blocked: blockedTaskIds.length,
+			elapsed: `${elapsedSec}s`,
+			stoppedEarly,
+		},
+	);
 
 	return {
 		waveIndex,
@@ -2055,7 +2449,9 @@ export async function executeWithStopAll(
 	waveIndex: number,
 ): Promise<LaneExecutionResult[]> {
 	// Track results as they complete
-	const results: (LaneExecutionResult | null)[] = new Array(lanes.length).fill(null);
+	const results: (LaneExecutionResult | null)[] = new Array(lanes.length).fill(
+		null,
+	);
 	let abortTriggered = false;
 
 	// Create a promise that resolves when all lanes are done
@@ -2068,7 +2464,7 @@ export async function executeWithStopAll(
 			// Check if any task failed
 			if (!abortTriggered) {
 				const hasFailure = result.tasks.some(
-					t => t.status === "failed" || t.status === "stalled",
+					(t) => t.status === "failed" || t.status === "stalled",
 				);
 				if (hasFailure) {
 					// First failure detected — trigger stop-all
@@ -2077,7 +2473,7 @@ export async function executeWithStopAll(
 
 					// Determine which task failed first for logging
 					const firstFailed = result.tasks
-						.filter(t => t.status === "failed" || t.status === "stalled")
+						.filter((t) => t.status === "failed" || t.status === "stalled")
 						.sort((a, b) => {
 							// Sort by startTime, then by taskId for deterministic tie-break
 							const timeA = a.startTime || 0;
@@ -2086,13 +2482,20 @@ export async function executeWithStopAll(
 							return a.taskId.localeCompare(b.taskId);
 						})[0];
 
-					execLog("wave", `W${waveIndex}`, `stop-all triggered by ${firstFailed?.taskId || "unknown"} in ${lanes[idx].laneId}`, {
-						session: laneSessionIdOf(lanes[idx]),
-					});
+					execLog(
+						"wave",
+						`W${waveIndex}`,
+						`stop-all triggered by ${firstFailed?.taskId || "unknown"} in ${lanes[idx].laneId}`,
+						{
+							session: laneSessionIdOf(lanes[idx]),
+						},
+					);
 
 					// Kill ALL lane sessions immediately
 					for (const lane of lanes) {
-						killV2LaneAgents(laneSessionIdOf(lane), { laneNumber: lane.laneNumber });
+						killV2LaneAgents(laneSessionIdOf(lane), {
+							laneNumber: lane.laneNumber,
+						});
 					}
 				}
 			}
@@ -2104,9 +2507,15 @@ export async function executeWithStopAll(
 			if (!abortTriggered) {
 				abortTriggered = true;
 				pauseSignal.paused = true;
-				execLog("wave", `W${waveIndex}`, `stop-all triggered by lane error in ${lanes[idx].laneId}: ${errMsg}`);
+				execLog(
+					"wave",
+					`W${waveIndex}`,
+					`stop-all triggered by lane error in ${lanes[idx].laneId}: ${errMsg}`,
+				);
 				for (const lane of lanes) {
-					killV2LaneAgents(laneSessionIdOf(lane), { laneNumber: lane.laneNumber });
+					killV2LaneAgents(laneSessionIdOf(lane), {
+						laneNumber: lane.laneNumber,
+					});
 				}
 			}
 
@@ -2114,7 +2523,7 @@ export async function executeWithStopAll(
 			const failedResult: LaneExecutionResult = {
 				laneNumber: lanes[idx].laneNumber,
 				laneId: lanes[idx].laneId,
-				tasks: lanes[idx].tasks.map(t => ({
+				tasks: lanes[idx].tasks.map((t) => ({
 					taskId: t.taskId,
 					status: "failed" as LaneTaskStatus,
 					startTime: null,
@@ -2137,14 +2546,17 @@ export async function executeWithStopAll(
 	await Promise.allSettled(wrappedPromises);
 
 	// Fill in any null results (shouldn't happen, but defensive)
-	return results.map((r, idx) => r || {
-		laneNumber: lanes[idx].laneNumber,
-		laneId: lanes[idx].laneId,
-		tasks: [],
-		overallStatus: "failed" as const,
-		startTime: Date.now(),
-		endTime: Date.now(),
-	});
+	return results.map(
+		(r, idx) =>
+			r || {
+				laneNumber: lanes[idx].laneNumber,
+				laneId: lanes[idx].laneId,
+				tasks: [],
+				overallStatus: "failed" as const,
+				startTime: Date.now(),
+				endTime: Date.now(),
+			},
+	);
 }
 
 // ── Runtime V2 Bridge Helpers (TP-102) ─────────────────────────────────────
@@ -2205,8 +2617,8 @@ export function buildExecutionUnit(
 		throw new ExecutionError(
 			"EXEC_MISSING_TASK_FOLDER",
 			`Cannot build execution unit for task ${task.taskId}: taskFolder is ${taskFolder === "" ? "empty" : "undefined"}. ` +
-			`This typically means the task's persisted record was not enriched with discovery data. ` +
-			`Re-run discovery or check that the task exists in the task area.`,
+				`This typically means the task's persisted record was not enriched with discovery data. ` +
+				`Re-run discovery or check that the task exists in the task area.`,
 			"execution",
 			task.taskId,
 		);
@@ -2230,18 +2642,18 @@ export function buildExecutionUnit(
 	// the execution repo (cross-repo segment). When they're the same repo,
 	// resolve packet paths inside the worktree so .DONE, STATUS.md etc. are
 	// written to the worktree (not the original repo outside the worktree).
-	const useAbsolutePacketPath = task.task.packetTaskPath
-		&& packetHomeRepoId !== executionRepoId;
+	const useAbsolutePacketPath =
+		task.task.packetTaskPath && packetHomeRepoId !== executionRepoId;
 
 	const packet = useAbsolutePacketPath
 		? resolvePacketPaths(task.task.packetTaskPath!)
 		: {
-			promptPath: resolved.taskFolderResolved + "/PROMPT.md",
-			statusPath: resolved.statusPath,
-			donePath: resolved.donePath,
-			reviewsDir: resolved.taskFolderResolved + "/.reviews",
-			taskFolder: resolved.taskFolderResolved,
-		};
+				promptPath: resolved.taskFolderResolved + "/PROMPT.md",
+				statusPath: resolved.statusPath,
+				donePath: resolved.donePath,
+				reviewsDir: resolved.taskFolderResolved + "/.reviews",
+				taskFolder: resolved.taskFolderResolved,
+			};
 
 	return {
 		id,
@@ -2308,7 +2720,9 @@ export function buildAgentIdFromLane(
  * Returns null if file doesn't exist or is malformed.
  * @since TP-117
  */
-function parseAgentFile(filePath: string): { fm: Record<string, string>; body: string } | null {
+function parseAgentFile(
+	filePath: string,
+): { fm: Record<string, string>; body: string } | null {
 	try {
 		if (!existsSync(filePath)) return null;
 		const raw = readFileSync(filePath, "utf-8");
@@ -2321,7 +2735,9 @@ function parseAgentFile(filePath: string): { fm: Record<string, string>; body: s
 			if (m) fm[m[1]] = m[2].trim();
 		}
 		return { fm, body: raw.slice(fmEnd + 3).trim() };
-	} catch { return null; }
+	} catch {
+		return null;
+	}
 }
 
 /**
@@ -2339,7 +2755,9 @@ function loadBaseAgentPrompt(agentName: string): string {
 			const def = parseAgentFile(resolved);
 			if (def?.body) return def.body;
 		}
-	} catch { /* fall through */ }
+	} catch {
+		/* fall through */
+	}
 	return "";
 }
 
@@ -2415,7 +2833,10 @@ function resolveAgentPointerRoot(): string | null {
  * @returns Composed agent definition, or null if no base and no local file found
  * @since TP-161
  */
-export function loadAgentDef(cwd: string, name: string): { systemPrompt: string; tools: string; model: string } | null {
+export function loadAgentDef(
+	cwd: string,
+	name: string,
+): { systemPrompt: string; tools: string; model: string } | null {
 	const localPaths = [
 		join(cwd, ".pi", "agents", `${name}.md`),
 		join(cwd, "agents", `${name}.md`),
@@ -2434,7 +2855,9 @@ export function loadAgentDef(cwd: string, name: string): { systemPrompt: string;
 		if (existsSync(basePath)) {
 			baseDef = parseAgentFile(basePath);
 		}
-	} catch { /* fall through */ }
+	} catch {
+		/* fall through */
+	}
 
 	// Load local override (first found wins)
 	let localDef: { fm: Record<string, string>; body: string } | null = null;
@@ -2478,7 +2901,11 @@ export function resolveRuntimeStateRoot(
 
 // ── Runtime V2 Lane Execution (TP-105) ────────────────────────────
 
-import { executeTaskV2, type LaneRunnerConfig, type LaneRunnerTaskResult } from "./lane-runner.ts";
+import {
+	executeTaskV2,
+	type LaneRunnerConfig,
+	type LaneRunnerTaskResult,
+} from "./lane-runner.ts";
 
 /**
  * Execute a lane using the Runtime V2 headless backend.
@@ -2513,21 +2940,69 @@ function parseJsonArrayEnv(value?: string): string[] {
 	if (!value) return [];
 	try {
 		const parsed = JSON.parse(value);
-		if (Array.isArray(parsed)) return parsed.filter((v: unknown): v is string => typeof v === "string");
-	} catch { /* ignore malformed */ }
+		if (Array.isArray(parsed))
+			return parsed.filter((v: unknown): v is string => typeof v === "string");
+	} catch {
+		/* ignore malformed */
+	}
 	return [];
 }
 
 export function buildReviewerEnv(
-	reviewerConfig?: { model?: string; thinking?: string; tools?: string; excludeExtensions?: string[] } | null,
+	reviewerConfig?: {
+		model?: string;
+		thinking?: string;
+		tools?: string;
+		excludeExtensions?: string[];
+	} | null,
 ): Record<string, string> {
 	const env: Record<string, string> = {};
-	if (reviewerConfig?.model) env.TASKPLANE_REVIEWER_MODEL = reviewerConfig.model;
-	if (reviewerConfig?.thinking) env.TASKPLANE_REVIEWER_THINKING = reviewerConfig.thinking;
-	if (reviewerConfig?.tools) env.TASKPLANE_REVIEWER_TOOLS = reviewerConfig.tools;
+	if (reviewerConfig?.model)
+		env.TASKPLANE_REVIEWER_MODEL = reviewerConfig.model;
+	if (reviewerConfig?.thinking)
+		env.TASKPLANE_REVIEWER_THINKING = reviewerConfig.thinking;
+	if (reviewerConfig?.tools)
+		env.TASKPLANE_REVIEWER_TOOLS = reviewerConfig.tools;
 	// TP-180: Forward reviewer extension exclusions as JSON array
-	if (reviewerConfig?.excludeExtensions && reviewerConfig.excludeExtensions.length > 0) {
-		env.TASKPLANE_REVIEWER_EXCLUDE_EXTENSIONS = JSON.stringify(reviewerConfig.excludeExtensions);
+	if (
+		reviewerConfig?.excludeExtensions &&
+		reviewerConfig.excludeExtensions.length > 0
+	) {
+		env.TASKPLANE_REVIEWER_EXCLUDE_EXTENSIONS = JSON.stringify(
+			reviewerConfig.excludeExtensions,
+		);
+	}
+	return env;
+}
+
+/**
+ * Build worker env vars from config.
+ *
+ * Threads worker model/thinking/tools through to the lane runner
+ * via env vars, mirroring the reviewer pattern (buildReviewerEnv).
+ *
+ * @since TP-183
+ */
+export function buildWorkerEnv(
+	workerConfig?: {
+		model?: string;
+		thinking?: string;
+		tools?: string;
+		excludeExtensions?: string[];
+	} | null,
+): Record<string, string> {
+	const env: Record<string, string> = {};
+	if (workerConfig?.model) env.TASKPLANE_WORKER_MODEL = workerConfig.model;
+	if (workerConfig?.thinking)
+		env.TASKPLANE_WORKER_THINKING = workerConfig.thinking;
+	if (workerConfig?.tools) env.TASKPLANE_WORKER_TOOLS = workerConfig.tools;
+	if (
+		workerConfig?.excludeExtensions &&
+		workerConfig.excludeExtensions.length > 0
+	) {
+		env.TASKPLANE_WORKER_EXCLUDE_EXTENSIONS = JSON.stringify(
+			workerConfig.excludeExtensions,
+		);
 	}
 	return env;
 }
@@ -2541,7 +3016,9 @@ export function buildWorkerExcludeEnv(
 ): Record<string, string> {
 	const env: Record<string, string> = {};
 	if (workerExcludeExtensions && workerExcludeExtensions.length > 0) {
-		env.TASKPLANE_WORKER_EXCLUDE_EXTENSIONS = JSON.stringify(workerExcludeExtensions);
+		env.TASKPLANE_WORKER_EXCLUDE_EXTENSIONS = JSON.stringify(
+			workerExcludeExtensions,
+		);
 	}
 	return env;
 }
@@ -2562,7 +3039,10 @@ export async function executeLaneV2(
 	let shouldSkipRemaining = false;
 
 	const stateRoot = resolveRuntimeStateRoot(repoRoot, workspaceRoot);
-	const batchId = config.orchestrator?.batchId || extraEnvVars?.ORCH_BATCH_ID || String(Date.now());
+	const batchId =
+		config.orchestrator?.batchId ||
+		extraEnvVars?.ORCH_BATCH_ID ||
+		String(Date.now());
 
 	// Build agent ID prefix — must match the wave planner's naming (TP-115).
 	// Uses resolveOperatorId() so agent registry keys align with lane session IDs.
@@ -2574,13 +3054,17 @@ export async function executeLaneV2(
 	// The base template (templates/agents/task-worker.md) contains critical behavioral
 	// rules: checkpoint discipline, STATUS.md resume algorithm, review_step instructions.
 	// The local file (.pi/agents/task-worker.md) adds project-specific guidance.
-	let workerSystemPrompt = "You are a task execution agent. Read STATUS.md first, find unchecked items, work on them, checkpoint after each.";
+	let workerSystemPrompt =
+		"You are a task execution agent. Read STATUS.md first, find unchecked items, work on them, checkpoint after each.";
 	let workerSegmentPrompt = "";
 	try {
 		const basePrompt = loadBaseAgentPrompt("task-worker");
 		const localPrompt = loadLocalAgentPrompt(stateRoot, "task-worker");
 		if (basePrompt && localPrompt) {
-			workerSystemPrompt = basePrompt + "\n\n---\n\n## Project-Specific Guidance\n\n" + localPrompt;
+			workerSystemPrompt =
+				basePrompt +
+				"\n\n---\n\n## Project-Specific Guidance\n\n" +
+				localPrompt;
 		} else if (basePrompt) {
 			workerSystemPrompt = basePrompt;
 		} else if (localPrompt) {
@@ -2589,17 +3073,26 @@ export async function executeLaneV2(
 		// Load segment-scoped prompt overlay (appended when isSegmentScoped)
 		const segPrompt = loadBaseAgentPrompt("task-worker-segment");
 		if (segPrompt) workerSegmentPrompt = segPrompt;
-	} catch { /* use default */ }
+	} catch {
+		/* use default */
+	}
 
-	execLog(laneId, "LANE", `starting Runtime V2 execution of ${lane.tasks.length} task(s)`, {
-		worktree: lane.worktreePath,
-		agentPrefix: agentIdPrefix,
-	});
+	execLog(
+		laneId,
+		"LANE",
+		`starting Runtime V2 execution of ${lane.tasks.length} task(s)`,
+		{
+			worktree: lane.worktreePath,
+			agentPrefix: agentIdPrefix,
+		},
+	);
 
 	for (const task of lane.tasks) {
 		const taskSegmentId = task.task.activeSegmentId ?? null;
 		if (shouldSkipRemaining || pauseSignal.paused) {
-			const reason = pauseSignal.paused ? "Skipped due to pause signal" : "Skipped due to prior task failure in lane";
+			const reason = pauseSignal.paused
+				? "Skipped due to pause signal"
+				: "Skipped due to prior task failure in lane";
 			outcomes.push({
 				taskId: task.taskId,
 				status: "skipped",
@@ -2607,7 +3100,11 @@ export async function executeLaneV2(
 				startTime: null,
 				endTime: null,
 				exitReason: reason,
-				sessionName: buildRuntimeAgentId(agentIdPrefix, lane.laneNumber, "worker"),
+				sessionName: buildRuntimeAgentId(
+					agentIdPrefix,
+					lane.laneNumber,
+					"worker",
+				),
 				doneFileFound: false,
 				laneNumber: lane.laneNumber,
 			});
@@ -2617,10 +3114,14 @@ export async function executeLaneV2(
 		// Build execution unit
 		const unit = buildExecutionUnit(lane, task, repoRoot, isWorkspaceMode);
 
-		const rawAutonomy = String(extraEnvVars?.TASKPLANE_SUPERVISOR_AUTONOMY ?? "autonomous").toLowerCase();
+		const rawAutonomy = String(
+			extraEnvVars?.TASKPLANE_SUPERVISOR_AUTONOMY ?? "autonomous",
+		).toLowerCase();
 		const supervisorAutonomy: LaneRunnerConfig["supervisorAutonomy"] =
-			(rawAutonomy === "interactive" || rawAutonomy === "supervised" || rawAutonomy === "autonomous")
-				? rawAutonomy as LaneRunnerConfig["supervisorAutonomy"]
+			rawAutonomy === "interactive" ||
+			rawAutonomy === "supervised" ||
+			rawAutonomy === "autonomous"
+				? (rawAutonomy as LaneRunnerConfig["supervisorAutonomy"])
 				: "autonomous";
 
 		const laneRunnerConfig: LaneRunnerConfig = {
@@ -2631,17 +3132,23 @@ export async function executeLaneV2(
 			branch: lane.branch,
 			repoId: lane.repoId ?? "default",
 			stateRoot,
-			workerModel: "",
-			workerTools: "read,write,edit,bash,grep,find,ls",
-			workerThinking: "",
+			workerModel: extraEnvVars?.TASKPLANE_WORKER_MODEL || "",
+			workerTools:
+				extraEnvVars?.TASKPLANE_WORKER_TOOLS ||
+				"read,write,edit,bash,grep,find,ls",
+			workerThinking: extraEnvVars?.TASKPLANE_WORKER_THINKING || "",
 			workerSystemPrompt,
 			workerSegmentPrompt,
 			reviewerModel: extraEnvVars?.TASKPLANE_REVIEWER_MODEL || "",
 			reviewerThinking: extraEnvVars?.TASKPLANE_REVIEWER_THINKING || "",
 			reviewerTools: extraEnvVars?.TASKPLANE_REVIEWER_TOOLS || "",
 			// TP-180: Extension exclusion lists from config
-			workerExcludeExtensions: parseJsonArrayEnv(extraEnvVars?.TASKPLANE_WORKER_EXCLUDE_EXTENSIONS),
-			reviewerExcludeExtensions: parseJsonArrayEnv(extraEnvVars?.TASKPLANE_REVIEWER_EXCLUDE_EXTENSIONS),
+			workerExcludeExtensions: parseJsonArrayEnv(
+				extraEnvVars?.TASKPLANE_WORKER_EXCLUDE_EXTENSIONS,
+			),
+			reviewerExcludeExtensions: parseJsonArrayEnv(
+				extraEnvVars?.TASKPLANE_REVIEWER_EXCLUDE_EXTENSIONS,
+			),
 			supervisorAutonomy,
 			projectName: config.project?.name || "project",
 			maxIterations: 20,
@@ -2669,7 +3176,10 @@ export async function executeLaneV2(
 				}
 			}
 
-			if (result.outcome.status === "failed" || result.outcome.status === "stalled") {
+			if (
+				result.outcome.status === "failed" ||
+				result.outcome.status === "stalled"
+			) {
 				shouldSkipRemaining = true;
 			}
 		} catch (err: unknown) {
@@ -2682,7 +3192,11 @@ export async function executeLaneV2(
 				startTime: Date.now(),
 				endTime: Date.now(),
 				exitReason: `Runtime V2 execution error: ${errMsg}`,
-				sessionName: buildRuntimeAgentId(agentIdPrefix, lane.laneNumber, "worker"),
+				sessionName: buildRuntimeAgentId(
+					agentIdPrefix,
+					lane.laneNumber,
+					"worker",
+				),
 				doneFileFound: false,
 				laneNumber: lane.laneNumber,
 			});
@@ -2691,8 +3205,10 @@ export async function executeLaneV2(
 	}
 
 	const endTime = Date.now();
-	const succeeded = outcomes.every(o => o.status === "succeeded");
-	const failed = outcomes.some(o => o.status === "failed" || o.status === "stalled");
+	const succeeded = outcomes.every((o) => o.status === "succeeded");
+	const failed = outcomes.some(
+		(o) => o.status === "failed" || o.status === "stalled",
+	);
 
 	return {
 		laneNumber: lane.laneNumber,
@@ -2705,4 +3221,3 @@ export async function executeLaneV2(
 }
 
 // ── /orch Command — Full Execution (Step 5) ─────────────────────────
-

--- a/extensions/taskplane/types.ts
+++ b/extensions/taskplane/types.ts
@@ -70,7 +70,9 @@ export interface OrchestratorConfig {
  * SegmentId is opaque — never parse by string-splitting.
  * Use structured node/record fields (`repoId`, `taskId`) instead.
  */
-export type SegmentId = `${string}::${string}` | `${string}::${string}::${number}`;
+export type SegmentId =
+	| `${string}::${string}`
+	| `${string}::${string}::${number}`;
 
 /** How an intra-task segment edge was produced (for observability/debugging). */
 export type SegmentEdgeProvenance = "explicit" | "inferred";
@@ -135,8 +137,16 @@ export interface ParsedTask {
 }
 
 /** Build a stable segment ID from task + repo identity (`<taskId>::<repoId>[::N]`). */
-export function buildSegmentId(taskId: string, repoId: string, sequence?: number): SegmentId {
-	if (typeof sequence === "number" && Number.isFinite(sequence) && sequence >= 2) {
+export function buildSegmentId(
+	taskId: string,
+	repoId: string,
+	sequence?: number,
+): SegmentId {
+	if (
+		typeof sequence === "number" &&
+		Number.isFinite(sequence) &&
+		sequence >= 2
+	) {
 		return `${taskId}::${repoId}::${Math.floor(sequence)}` as SegmentId;
 	}
 	return `${taskId}::${repoId}` as SegmentId;
@@ -154,7 +164,11 @@ export function parseSegmentIdRepo(segment: { repoId: string }): string {
 /** Build a dynamic segment expansion request ID (`exp-{timestamp}-{random5}`). */
 export function buildExpansionRequestId(timestamp = Date.now()): string {
 	const ts = Number.isFinite(timestamp) ? Math.floor(timestamp) : Date.now();
-	const base = Math.random().toString(36).slice(2).toLowerCase().replace(/[^a-z0-9]/g, "");
+	const base = Math.random()
+		.toString(36)
+		.slice(2)
+		.toLowerCase()
+		.replace(/[^a-z0-9]/g, "");
 	const random5 = (base + "00000").slice(0, 5);
 	return `exp-${ts}-${random5}`;
 }
@@ -267,7 +281,15 @@ export interface LaneAssignment {
 
 /** Runtime state of the entire batch execution */
 export interface BatchState {
-	phase: "idle" | "planning" | "running" | "paused" | "merging" | "complete" | "error" | "aborted";
+	phase:
+		| "idle"
+		| "planning"
+		| "running"
+		| "paused"
+		| "merging"
+		| "complete"
+		| "error"
+		| "aborted";
 	batchId: string;
 	waves: WaveAssignment[];
 	currentWave: number;
@@ -328,6 +350,21 @@ export interface TaskRunnerConfig {
 		/** Package specifiers to exclude from extension forwarding (exact match). @since TP-180 */
 		excludeExtensions?: string[];
 	};
+	/**
+	 * Worker agent model/thinking/tools configuration.
+	 * Threaded through to `spawnAgent()` via env vars.
+	 * @since TP-183
+	 */
+	worker?: {
+		/** Model string (empty = inherit session default) */
+		model: string;
+		/** Thinking mode ("on" | "off" | budget string, empty = inherit) */
+		thinking: string;
+		/** Comma-separated tool allowlist */
+		tools: string;
+		/** Package specifiers to exclude from extension forwarding (exact match). @since TP-180 */
+		excludeExtensions?: string[];
+	};
 	/** Worker agent extension exclusion list. @since TP-180 */
 	workerExcludeExtensions?: string[];
 }
@@ -345,7 +382,6 @@ export interface PreflightCheck {
 	message: string;
 	hint?: string;
 }
-
 
 // ── Defaults ─────────────────────────────────────────────────────────
 
@@ -403,7 +439,6 @@ export const DEFAULT_TASK_RUNNER_CONFIG: TaskRunnerConfig = {
 	reference_docs: {},
 	model_fallback: "inherit",
 };
-
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -574,7 +609,12 @@ export interface RemoveAllWorktreesResult {
 	/** All per-worktree outcomes in order */
 	outcomes: RemoveWorktreeOutcome[];
 	/** Branches preserved (had unmerged commits) */
-	preserved: Array<{ branch: string; savedBranch: string; laneNumber: number; unmergedCount?: number }>;
+	preserved: Array<{
+		branch: string;
+		savedBranch: string;
+		laneNumber: number;
+		unmergedCount?: number;
+	}>;
 }
 
 // ── Discovery Types ──────────────────────────────────────────────────
@@ -632,7 +672,6 @@ export interface DiscoveryResult {
 	errors: DiscoveryError[];
 }
 
-
 // ── Wave Computation Types ───────────────────────────────────────────
 
 /** Dependency graph: adjacency list (task → tasks it depends on) */
@@ -658,7 +697,6 @@ export interface WaveComputationResult {
 	/** Optional task→segment planning map (TP-080, additive contract). */
 	segmentPlans?: TaskSegmentPlanMap;
 }
-
 
 // ── Lane Allocation (Phase 3) ────────────────────────────────────────
 
@@ -736,7 +774,6 @@ export interface AllocatedLane {
 	repoId?: string;
 }
 
-
 // ── Execution Types & Contracts ──────────────────────────────────────
 
 /**
@@ -748,7 +785,13 @@ export interface AllocatedLane {
  *                     → stalled
  *   pending → skipped  (pause/abort before task starts, or prior task failed)
  */
-export type LaneTaskStatus = "pending" | "running" | "succeeded" | "failed" | "stalled" | "skipped";
+export type LaneTaskStatus =
+	| "pending"
+	| "running"
+	| "succeeded"
+	| "failed"
+	| "stalled"
+	| "skipped";
 
 /**
  * Embedded telemetry attached to a lane task outcome.
@@ -905,7 +948,12 @@ export class ExecutionError extends Error {
 	laneId?: string;
 	taskId?: string;
 
-	constructor(code: ExecutionErrorCode, message: string, laneId?: string, taskId?: string) {
+	constructor(
+		code: ExecutionErrorCode,
+		message: string,
+		laneId?: string,
+		taskId?: string,
+	) {
 		super(message);
 		this.name = "ExecutionError";
 		this.code = code;
@@ -913,7 +961,6 @@ export class ExecutionError extends Error {
 		this.taskId = taskId;
 	}
 }
-
 
 // ── Monitoring Types & Contracts ─────────────────────────────────────
 
@@ -930,7 +977,14 @@ export interface TaskMonitorSnapshot {
 	/** Task ID (e.g., "TO-014") */
 	taskId: string;
 	/** Resolved monitoring status */
-	status: "pending" | "running" | "succeeded" | "failed" | "stalled" | "skipped" | "unknown";
+	status:
+		| "pending"
+		| "running"
+		| "succeeded"
+		| "failed"
+		| "stalled"
+		| "skipped"
+		| "unknown";
 	/** Current step name (e.g., "Implement Service Layer"), null if not parsed */
 	currentStepName: string | null;
 	/** Current step number, null if not parsed */
@@ -1026,7 +1080,6 @@ export interface MtimeTracker {
 	stallTimerStart: number | null;
 }
 
-
 // ── Wave Execution Types & Contracts ─────────────────────────────────
 
 /**
@@ -1098,7 +1151,6 @@ export interface WaveExecutionResult {
 	} | null;
 }
 
-
 // ── Orchestrator Runtime State ───────────────────────────────────────
 
 /**
@@ -1111,7 +1163,16 @@ export interface WaveExecutionResult {
  *                   → paused (via /orch-pause)
  *   Any active state → idle (via cleanup after completion/failure)
  */
-export type OrchBatchPhase = "idle" | "launching" | "planning" | "executing" | "merging" | "paused" | "stopped" | "completed" | "failed";
+export type OrchBatchPhase =
+	| "idle"
+	| "launching"
+	| "planning"
+	| "executing"
+	| "merging"
+	| "paused"
+	| "stopped"
+	| "completed"
+	| "failed";
 
 /**
  * Runtime state for a batch execution.
@@ -1264,14 +1325,17 @@ export function freshOrchBatchState(): OrchBatchRuntimeState {
 	};
 }
 
-
 // ── Merge Types ──────────────────────────────────────────────────────
 
 /**
  * Valid merge result statuses.
  * Matches the contract in .pi/agents/task-merger.md.
  */
-export type MergeResultStatus = "SUCCESS" | "CONFLICT_RESOLVED" | "CONFLICT_UNRESOLVED" | "BUILD_FAILURE";
+export type MergeResultStatus =
+	| "SUCCESS"
+	| "CONFLICT_RESOLVED"
+	| "CONFLICT_UNRESOLVED"
+	| "BUILD_FAILURE";
 
 /** All valid status strings for runtime validation. */
 export const VALID_MERGE_STATUSES: ReadonlySet<string> = new Set([
@@ -1405,7 +1469,11 @@ export interface RepoMergeOutcome {
  *
  * @since TP-033
  */
-export type TransactionStatus = "committed" | "rolled_back" | "rollback_failed" | "merge_failed";
+export type TransactionStatus =
+	| "committed"
+	| "rolled_back"
+	| "rollback_failed"
+	| "merge_failed";
 
 /**
  * Transactional record for a single lane merge attempt.
@@ -1662,7 +1730,6 @@ export interface MergeSessionHealthState {
 	deadEmitted: boolean;
 }
 
-
 // ── Merge Retry Policy Matrix (TP-033 Step 2) ───────────────────────
 
 /**
@@ -1719,7 +1786,9 @@ export interface MergeRetryPolicy {
  *
  * @since TP-033
  */
-export const MERGE_RETRY_POLICY_MATRIX: Readonly<Record<MergeFailureClassification, MergeRetryPolicy>> = {
+export const MERGE_RETRY_POLICY_MATRIX: Readonly<
+	Record<MergeFailureClassification, MergeRetryPolicy>
+> = {
 	verification_new_failure: {
 		retriable: true,
 		maxAttempts: 1,
@@ -1756,14 +1825,14 @@ export const MERGE_RETRY_POLICY_MATRIX: Readonly<Record<MergeFailureClassificati
  * All merge failure classifications as a readonly array, for iteration/validation.
  * @since TP-033
  */
-export const MERGE_FAILURE_CLASSIFICATIONS: readonly MergeFailureClassification[] = [
-	"verification_new_failure",
-	"merge_conflict_unresolved",
-	"cleanup_post_merge_failed",
-	"git_worktree_dirty",
-	"git_lock_file",
-] as const;
-
+export const MERGE_FAILURE_CLASSIFICATIONS: readonly MergeFailureClassification[] =
+	[
+		"verification_new_failure",
+		"merge_conflict_unresolved",
+		"cleanup_post_merge_failed",
+		"git_worktree_dirty",
+		"git_lock_file",
+	] as const;
 
 // ── Tier 0 Watchdog Recovery Types (TP-039) ──────────────────────────
 
@@ -1824,7 +1893,9 @@ export interface Tier0RetryBudget {
  *
  * @since TP-039
  */
-export const TIER0_RETRY_BUDGETS: Readonly<Record<Tier0RecoveryPattern, Tier0RetryBudget>> = {
+export const TIER0_RETRY_BUDGETS: Readonly<
+	Record<Tier0RecoveryPattern, Tier0RetryBudget>
+> = {
 	worker_crash: {
 		maxRetries: 1,
 		cooldownMs: 5_000,
@@ -1894,7 +1965,11 @@ export interface EscalationContext {
  *
  * @since TP-039
  */
-export function tier0ScopeKey(pattern: Tier0RecoveryPattern, taskId: string, waveIndex: number): string {
+export function tier0ScopeKey(
+	pattern: Tier0RecoveryPattern,
+	taskId: string,
+	waveIndex: number,
+): string {
 	return `t0:${pattern}:${taskId}:w${waveIndex}`;
 }
 
@@ -1906,7 +1981,10 @@ export function tier0ScopeKey(pattern: Tier0RecoveryPattern, taskId: string, wav
  *
  * @since TP-039
  */
-export function tier0WaveScopeKey(pattern: Tier0RecoveryPattern, waveIndex: number): string {
+export function tier0WaveScopeKey(
+	pattern: Tier0RecoveryPattern,
+	waveIndex: number,
+): string {
 	return `t0:${pattern}:w${waveIndex}`;
 }
 
@@ -2036,7 +2114,6 @@ export interface EngineEvent {
  * @since TP-040
  */
 export type EngineEventCallback = (event: EngineEvent) => void;
-
 
 // ── Supervisor Alert Types (TP-076) ──────────────────────────────────
 
@@ -2206,7 +2283,10 @@ export function buildSupervisorSegmentFrontierSnapshot(
 	preferredSegmentId?: string | null,
 ): SupervisorSegmentFrontierSnapshot | undefined {
 	const orderedSegmentIds = Array.isArray(segmentIds)
-		? segmentIds.filter((segmentId): segmentId is string => typeof segmentId === "string" && segmentId.trim().length > 0)
+		? segmentIds.filter(
+				(segmentId): segmentId is string =>
+					typeof segmentId === "string" && segmentId.trim().length > 0,
+			)
 		: [];
 	if (orderedSegmentIds.length === 0) return undefined;
 
@@ -2217,16 +2297,18 @@ export function buildSupervisorSegmentFrontierSnapshot(
 		}
 	}
 
-	const resolvedActiveSegmentId = (activeSegmentId && orderedSegmentIds.includes(activeSegmentId))
-		? activeSegmentId
-		: (preferredSegmentId && orderedSegmentIds.includes(preferredSegmentId)
-			? preferredSegmentId
-			: null);
+	const resolvedActiveSegmentId =
+		activeSegmentId && orderedSegmentIds.includes(activeSegmentId)
+			? activeSegmentId
+			: preferredSegmentId && orderedSegmentIds.includes(preferredSegmentId)
+				? preferredSegmentId
+				: null;
 
 	const segments = orderedSegmentIds.map((segmentId) => {
 		const persisted = bySegmentId.get(segmentId);
-		const status: PersistedSegmentStatus = persisted?.status
-			?? (resolvedActiveSegmentId === segmentId ? "running" : "pending");
+		const status: PersistedSegmentStatus =
+			persisted?.status ??
+			(resolvedActiveSegmentId === segmentId ? "running" : "pending");
 		return {
 			segmentId,
 			repoId: persisted ? parseSegmentIdRepo(persisted) : "unknown",
@@ -2235,11 +2317,12 @@ export function buildSupervisorSegmentFrontierSnapshot(
 		};
 	});
 
-	const terminalSegments = segments.filter((segment) =>
-		segment.status === "succeeded"
-		|| segment.status === "failed"
-		|| segment.status === "stalled"
-		|| segment.status === "skipped",
+	const terminalSegments = segments.filter(
+		(segment) =>
+			segment.status === "succeeded" ||
+			segment.status === "failed" ||
+			segment.status === "stalled" ||
+			segment.status === "skipped",
 	).length;
 
 	return {
@@ -2273,7 +2356,6 @@ export function buildEngineEventBase(
 		phase,
 	};
 }
-
 
 /**
  * Decision output from the merge retry policy evaluator.
@@ -2311,50 +2393,50 @@ export interface MergeRetryDecision {
  */
 export type MergeRetryLoopOutcome =
 	| {
-		/** Retry succeeded — caller should continue normal post-merge flow */
-		kind: "retry_succeeded";
-		mergeResult: MergeWaveResult;
-		/** Classification of the failure that was retried */
-		classification: MergeFailureClassification | null;
-		/** Scope key used for retry counter tracking */
-		scopeKey: string;
-		/** Last retry decision (carries attempt/maxAttempts for event emission) */
-		lastDecision: MergeRetryDecision;
-	}
+			/** Retry succeeded — caller should continue normal post-merge flow */
+			kind: "retry_succeeded";
+			mergeResult: MergeWaveResult;
+			/** Classification of the failure that was retried */
+			classification: MergeFailureClassification | null;
+			/** Scope key used for retry counter tracking */
+			scopeKey: string;
+			/** Last retry decision (carries attempt/maxAttempts for event emission) */
+			lastDecision: MergeRetryDecision;
+	  }
 	| {
-		/** Safe-stop triggered during retry — caller should break the wave loop */
-		kind: "safe_stop";
-		mergeResult: MergeWaveResult;
-		/** Classification of the failure that was retried */
-		classification: MergeFailureClassification | null;
-		/** Scope key used for retry counter tracking */
-		scopeKey: string;
-		/** Last retry decision (carries attempt/maxAttempts for event emission) */
-		lastDecision: MergeRetryDecision;
-		errorMessage: string;
-		notifyMessage: string;
-	}
+			/** Safe-stop triggered during retry — caller should break the wave loop */
+			kind: "safe_stop";
+			mergeResult: MergeWaveResult;
+			/** Classification of the failure that was retried */
+			classification: MergeFailureClassification | null;
+			/** Scope key used for retry counter tracking */
+			scopeKey: string;
+			/** Last retry decision (carries attempt/maxAttempts for event emission) */
+			lastDecision: MergeRetryDecision;
+			errorMessage: string;
+			notifyMessage: string;
+	  }
 	| {
-		/**
-		 * Retry exhausted or failure is non-retriable — caller should
-		 * force `paused` regardless of on_merge_failure config.
-		 */
-		kind: "exhausted";
-		mergeResult: MergeWaveResult;
-		classification: MergeFailureClassification | null;
-		scopeKey: string;
-		lastDecision: MergeRetryDecision;
-		errorMessage: string;
-		notifyMessage: string;
-	}
+			/**
+			 * Retry exhausted or failure is non-retriable — caller should
+			 * force `paused` regardless of on_merge_failure config.
+			 */
+			kind: "exhausted";
+			mergeResult: MergeWaveResult;
+			classification: MergeFailureClassification | null;
+			scopeKey: string;
+			lastDecision: MergeRetryDecision;
+			errorMessage: string;
+			notifyMessage: string;
+	  }
 	| {
-		/** No retry attempted (unclassifiable or non-retriable with 0 attempts).
-		 *  Caller should fall through to standard on_merge_failure policy. */
-		kind: "no_retry";
-		mergeResult: MergeWaveResult;
-		classification: MergeFailureClassification | null;
-		scopeKey: string;
-	};
+			/** No retry attempted (unclassifiable or non-retriable with 0 attempts).
+			 *  Caller should fall through to standard on_merge_failure policy. */
+			kind: "no_retry";
+			mergeResult: MergeWaveResult;
+			classification: MergeFailureClassification | null;
+			scopeKey: string;
+	  };
 
 /**
  * Callbacks provided to `applyMergeRetryLoop()` for side effects
@@ -2437,7 +2519,6 @@ export interface OrchDashboardViewModel {
 	errors: string[];
 	failurePolicy: string | null; // e.g., "stop-wave" if stopped by policy
 }
-
 
 // ── State Persistence Types (TS-009) ─────────────────────────────────
 
@@ -2760,7 +2841,13 @@ export interface PersistedTaskRecord {
  *
  * @since v4 (TP-081)
  */
-export type PersistedSegmentStatus = "pending" | "running" | "succeeded" | "failed" | "stalled" | "skipped";
+export type PersistedSegmentStatus =
+	| "pending"
+	| "running"
+	| "succeeded"
+	| "failed"
+	| "stalled"
+	| "skipped";
 
 /**
  * Persisted record of a single segment's execution state.
@@ -3023,7 +3110,6 @@ export interface PersistedBatchState {
 	_extraFields?: Record<string, unknown>;
 }
 
-
 // ── Resume (TS-009 Step 4) ───────────────────────────────────────────
 
 /**
@@ -3081,7 +3167,13 @@ export interface ReconciledTaskState {
 	/** Whether the lane worktree still exists on disk */
 	worktreeExists: boolean;
 	/** Action the resume engine should take */
-	action: "reconnect" | "mark-complete" | "mark-failed" | "re-execute" | "skip" | "pending";
+	action:
+		| "reconnect"
+		| "mark-complete"
+		| "mark-failed"
+		| "re-execute"
+		| "skip"
+		| "pending";
 }
 
 /**
@@ -3252,7 +3344,6 @@ export function getTaskDurationMinutes(
 	return weight * DURATION_BASE_MINUTES;
 }
 
-
 // ── Batch History ────────────────────────────────────────────────────
 
 /** Token counts for a task, wave, or batch. */
@@ -3268,9 +3359,15 @@ export interface TokenCounts {
 export interface BatchTaskSummary {
 	taskId: string;
 	taskName: string;
-	status: "succeeded" | "failed" | "skipped" | "blocked" | "stalled" | "pending";
-	wave: number;      // 1-based
-	lane: number;      // 1-based
+	status:
+		| "succeeded"
+		| "failed"
+		| "skipped"
+		| "blocked"
+		| "stalled"
+		| "pending";
+	wave: number; // 1-based
+	lane: number; // 1-based
 	durationMs: number;
 	tokens: TokenCounts;
 	exitReason: string | null;
@@ -3278,8 +3375,8 @@ export interface BatchTaskSummary {
 
 /** Per-wave summary for history. */
 export interface BatchWaveSummary {
-	wave: number;      // 1-based
-	tasks: string[];   // task IDs
+	wave: number; // 1-based
+	tasks: string[]; // task IDs
 	mergeStatus: "succeeded" | "failed" | "partial" | "skipped";
 	durationMs: number;
 	tokens: TokenCounts;
@@ -3307,7 +3404,6 @@ export interface BatchHistorySummary {
 
 /** Max number of batch history entries to retain. */
 export const BATCH_HISTORY_MAX_ENTRIES = 100;
-
 
 // ── Workspace Mode Types ─────────────────────────────────────────────
 
@@ -3446,7 +3542,6 @@ export interface ExecutionContext {
 	pointer: PointerResolution | null;
 }
 
-
 // ── Workspace Validation Error Types ─────────────────────────────────
 
 /**
@@ -3488,7 +3583,7 @@ export type WorkspaceConfigErrorCode =
 	| "WORKSPACE_TASK_AREA_OUTSIDE_TASKS_ROOT"
 	| "WORKSPACE_SETUP_REQUIRED"
 	| "WORKSPACE_DUPLICATE_REPO_PATH"
-	| "WORKSPACE_SCHEMA_INVALID";/**
+	| "WORKSPACE_SCHEMA_INVALID"; /**
  * Typed error class for workspace configuration failures.
  *
  * Thrown during workspace config loading/validation when the config file
@@ -3505,7 +3600,12 @@ export class WorkspaceConfigError extends Error {
 	/** Optional filesystem path related to the error */
 	relatedPath?: string;
 
-	constructor(code: WorkspaceConfigErrorCode, message: string, repoId?: string, relatedPath?: string) {
+	constructor(
+		code: WorkspaceConfigErrorCode,
+		message: string,
+		repoId?: string,
+		relatedPath?: string,
+	) {
 		super(message);
 		this.name = "WorkspaceConfigError";
 		this.code = code;
@@ -3513,7 +3613,6 @@ export class WorkspaceConfigError extends Error {
 		this.relatedPath = relatedPath;
 	}
 }
-
 
 // ── Pointer Resolution Types ─────────────────────────────────────────
 
@@ -3581,7 +3680,6 @@ export interface PointerResolution {
 	warning?: string;
 }
 
-
 // ── Workspace Defaults ───────────────────────────────────────────────
 
 /**
@@ -3625,7 +3723,6 @@ export function createRepoModeContext(
 	};
 }
 
-
 // ── Agent Mailbox Types (TP-089) ─────────────────────────────────────
 
 /**
@@ -3656,15 +3753,27 @@ export const MAILBOX_MAX_CONTENT_BYTES = 4096;
  *
  * @since TP-089
  */
-export type MailboxMessageType = "steer" | "query" | "abort" | "info" | "reply" | "escalate";
+export type MailboxMessageType =
+	| "steer"
+	| "query"
+	| "abort"
+	| "info"
+	| "reply"
+	| "escalate";
 
 /**
  * Set of valid mailbox message types for runtime validation.
  * @since TP-089
  */
-export const MAILBOX_MESSAGE_TYPES: ReadonlySet<string> = new Set<MailboxMessageType>([
-	"steer", "query", "abort", "info", "reply", "escalate",
-]);
+export const MAILBOX_MESSAGE_TYPES: ReadonlySet<string> =
+	new Set<MailboxMessageType>([
+		"steer",
+		"query",
+		"abort",
+		"info",
+		"reply",
+		"escalate",
+	]);
 
 /**
  * Message format for the file-based agent mailbox.
@@ -3765,9 +3874,9 @@ export type RuntimeAgentStatus =
 	| "killed";
 
 /** Set of terminal agent statuses (process is no longer alive). @since TP-102 */
-export const TERMINAL_AGENT_STATUSES: ReadonlySet<RuntimeAgentStatus> = new Set([
-	"exited", "crashed", "timed_out", "killed",
-]);
+export const TERMINAL_AGENT_STATUSES: ReadonlySet<RuntimeAgentStatus> = new Set(
+	["exited", "crashed", "timed_out", "killed"],
+);
 
 /**
  * Stable agent identity for Runtime V2.
@@ -4101,7 +4210,11 @@ export function runtimeRoot(stateRoot: string, batchId: string): string {
  *
  * @since TP-102
  */
-export function runtimeAgentDir(stateRoot: string, batchId: string, agentId: RuntimeAgentId): string {
+export function runtimeAgentDir(
+	stateRoot: string,
+	batchId: string,
+	agentId: RuntimeAgentId,
+): string {
 	return `${stateRoot}/.pi/runtime/${batchId}/agents/${agentId}`;
 }
 
@@ -4110,7 +4223,11 @@ export function runtimeAgentDir(stateRoot: string, batchId: string, agentId: Run
  *
  * @since TP-102
  */
-export function runtimeManifestPath(stateRoot: string, batchId: string, agentId: RuntimeAgentId): string {
+export function runtimeManifestPath(
+	stateRoot: string,
+	batchId: string,
+	agentId: RuntimeAgentId,
+): string {
 	return `${runtimeAgentDir(stateRoot, batchId, agentId)}/manifest.json`;
 }
 
@@ -4119,7 +4236,11 @@ export function runtimeManifestPath(stateRoot: string, batchId: string, agentId:
  *
  * @since TP-102
  */
-export function runtimeAgentEventsPath(stateRoot: string, batchId: string, agentId: RuntimeAgentId): string {
+export function runtimeAgentEventsPath(
+	stateRoot: string,
+	batchId: string,
+	agentId: RuntimeAgentId,
+): string {
 	return `${runtimeAgentDir(stateRoot, batchId, agentId)}/events.jsonl`;
 }
 
@@ -4128,7 +4249,11 @@ export function runtimeAgentEventsPath(stateRoot: string, batchId: string, agent
  *
  * @since TP-102
  */
-export function runtimeLaneSnapshotPath(stateRoot: string, batchId: string, laneNumber: number): string {
+export function runtimeLaneSnapshotPath(
+	stateRoot: string,
+	batchId: string,
+	laneNumber: number,
+): string {
 	return `${stateRoot}/.pi/runtime/${batchId}/lanes/lane-${laneNumber}.json`;
 }
 
@@ -4172,7 +4297,11 @@ export interface RuntimeMergeSnapshot {
  *
  * @since TP-164
  */
-export function runtimeMergeSnapshotPath(stateRoot: string, batchId: string, mergeNumber: number): string {
+export function runtimeMergeSnapshotPath(
+	stateRoot: string,
+	batchId: string,
+	mergeNumber: number,
+): string {
 	return `${stateRoot}/.pi/runtime/${batchId}/lanes/merge-${mergeNumber}.json`;
 }
 
@@ -4181,7 +4310,10 @@ export function runtimeMergeSnapshotPath(stateRoot: string, batchId: string, mer
  *
  * @since TP-102
  */
-export function runtimeRegistryPath(stateRoot: string, batchId: string): string {
+export function runtimeRegistryPath(
+	stateRoot: string,
+	batchId: string,
+): string {
 	return `${stateRoot}/.pi/runtime/${batchId}/registry.json`;
 }
 
@@ -4232,22 +4364,47 @@ export function validateAgentManifest(manifest: unknown): string[] {
 	}
 	const m = manifest as Record<string, unknown>;
 
-	if (typeof m.batchId !== "string" || !m.batchId) errors.push("batchId must be a non-empty string");
-	if (typeof m.agentId !== "string" || !m.agentId) errors.push("agentId must be a non-empty string");
+	if (typeof m.batchId !== "string" || !m.batchId)
+		errors.push("batchId must be a non-empty string");
+	if (typeof m.agentId !== "string" || !m.agentId)
+		errors.push("agentId must be a non-empty string");
 	if (typeof m.role !== "string") errors.push("role must be a string");
 	else {
-		const validRoles: ReadonlySet<string> = new Set(["worker", "reviewer", "merger", "lane-runner"]);
-		if (!validRoles.has(m.role as string)) errors.push(`role must be one of: ${[...validRoles].join(", ")}`);
+		const validRoles: ReadonlySet<string> = new Set([
+			"worker",
+			"reviewer",
+			"merger",
+			"lane-runner",
+		]);
+		if (!validRoles.has(m.role as string))
+			errors.push(`role must be one of: ${[...validRoles].join(", ")}`);
 	}
-	if (typeof m.pid !== "number" || !Number.isFinite(m.pid) || m.pid <= 0) errors.push("pid must be a positive finite number");
-	if (typeof m.parentPid !== "number" || !Number.isFinite(m.parentPid) || m.parentPid <= 0) errors.push("parentPid must be a positive finite number");
-	if (typeof m.startedAt !== "number" || !Number.isFinite(m.startedAt)) errors.push("startedAt must be a finite number");
+	if (typeof m.pid !== "number" || !Number.isFinite(m.pid) || m.pid <= 0)
+		errors.push("pid must be a positive finite number");
+	if (
+		typeof m.parentPid !== "number" ||
+		!Number.isFinite(m.parentPid) ||
+		m.parentPid <= 0
+	)
+		errors.push("parentPid must be a positive finite number");
+	if (typeof m.startedAt !== "number" || !Number.isFinite(m.startedAt))
+		errors.push("startedAt must be a finite number");
 	if (typeof m.status !== "string") errors.push("status must be a string");
 	else {
-		const validStatuses: ReadonlySet<string> = new Set(["spawning", "running", "wrapping_up", "exited", "crashed", "timed_out", "killed"]);
-		if (!validStatuses.has(m.status as string)) errors.push(`status must be one of: ${[...validStatuses].join(", ")}`);
+		const validStatuses: ReadonlySet<string> = new Set([
+			"spawning",
+			"running",
+			"wrapping_up",
+			"exited",
+			"crashed",
+			"timed_out",
+			"killed",
+		]);
+		if (!validStatuses.has(m.status as string))
+			errors.push(`status must be one of: ${[...validStatuses].join(", ")}`);
 	}
-	if (typeof m.cwd !== "string" || !m.cwd) errors.push("cwd must be a non-empty string");
+	if (typeof m.cwd !== "string" || !m.cwd)
+		errors.push("cwd must be a non-empty string");
 	if (typeof m.repoId !== "string") errors.push("repoId must be a string");
 
 	return errors;
@@ -4267,7 +4424,13 @@ export function validatePacketPaths(packet: unknown): string[] {
 	}
 	const p = packet as Record<string, unknown>;
 
-	for (const field of ["promptPath", "statusPath", "donePath", "reviewsDir", "taskFolder"] as const) {
+	for (const field of [
+		"promptPath",
+		"statusPath",
+		"donePath",
+		"reviewsDir",
+		"taskFolder",
+	] as const) {
 		if (typeof p[field] !== "string" || !(p[field] as string)) {
 			errors.push(`${field} must be a non-empty string`);
 		}
@@ -4275,4 +4438,3 @@ export function validatePacketPaths(packet: unknown): string[] {
 
 	return errors;
 }
-


### PR DESCRIPTION
## Summary

Mirrors the existing reviewer model pipeline (`buildReviewerEnv` → `TASKPLANE_REVIEWER_MODEL` → `extraEnvVars` → `LaneRunnerConfig`) for workers, so `taskRunner.worker.model` in `preferences.json` actually takes effect.

## Type of Change

- [x] fix (bug fix)

## Problem

The reviewer model flows through a dedicated pipeline:

```
buildReviewerEnv() → TASKPLANE_REVIEWER_MODEL → extraEnvVars → LaneRunnerConfig.reviewerModel → --model flag
```

No equivalent exists for workers. Three specific gaps:

1. `TaskRunnerConfig` has `reviewer?: { model, thinking, tools, … }` but workers only get `workerExcludeExtensions?: string[]` — no model field
2. `buildReviewerEnv()` exists but no `buildWorkerEnv()`
3. `LaneRunnerConfig` hardcodes `workerModel: ""` while `reviewerModel` reads from env

## Changes

| File               | Change                                                                                                                                                     |
| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `types.ts`         | Add `worker?: { model, thinking, tools, excludeExtensions }` to `TaskRunnerConfig`                                                                         |
| `config-loader.ts` | Add `worker` field to `toTaskRunnerConfig()` return value                                                                                                  |
| `execution.ts`     | Add `buildWorkerEnv()`, add `workerConfig` param to `executeWave()`, wire into `extraEnvVars`, read `workerModel/workerTools/workerThinking` from env vars |
| `engine.ts`        | Pass worker config in `executeWave()` calls, wire `buildWorkerEnv()` into `executeLaneV2` retries                                                          |

### Key before/after

**`execution.ts` — LaneRunnerConfig builder:**

```diff
- workerModel: "",
- workerTools: "read,write,edit,bash,grep,find,ls",
- workerThinking: "",
+ workerModel: extraEnvVars?.TASKPLANE_WORKER_MODEL || "",
+ workerTools: extraEnvVars?.TASKPLANE_WORKER_TOOLS || "read,write,edit,bash,grep,find,ls",
+ workerThinking: extraEnvVars?.TASKPLANE_WORKER_THINKING || "",
```

**`engine.ts` — executeWave call:**

```diff
+ runnerConfig?.worker ? {
+     model: runnerConfig.worker.model || "",
+     thinking: runnerConfig.worker.thinking || "",
+     tools: runnerConfig.worker.tools || "",
+     excludeExtensions: runnerConfig.worker.excludeExtensions ?? [],
+ } : undefined,
  runnerConfig?.workerExcludeExtensions ?? [],
```

## Validation

- [x] `npm test` — config-loader: 95 pass / 0 fail, lane-runner: 47 pass / 1 fail (pre-existing, fails on clean branch too)
- [x] Manual smoke test performed — configured `taskRunner.worker.model: "openrouter/moonshotai/kimi-k2.6"` in preferences.json, verified kimi-k2.6 usage appears in OpenRouter dashboard. Reviewer model continues to work as before.
- [x] `taskplane doctor` — all checks passed
- [x] All test failures are pre-existing, not caused by this change

## Documentation

- [ ] Docs updated for user-facing changes
- [ ] Reference docs updated (commands/config/task format), if applicable
- [ ] `CHANGELOG.md` updated (for release-relevant changes)

## Checklist

- [x] Changes are scoped and focused
- [x] No secrets/private data introduced
- [x] No breaking changes — backward compatible (empty string = inherit, as before)
- [x] Follows reviewer model pattern exactly

## Related Issues

None (new bug discovered)