### PR TITLE
Localize orchestration command descriptions

### DIFF
--- a/extensions/taskplane/extension.ts
+++ b/extensions/taskplane/extension.ts
@@ -65,6 +65,7 @@ import {
 	resolveModelFromString,
 } from "./supervisor.ts";
 import type { SupervisorConfig, SupervisorRoutingContext, IntegrationExecutor, CiDeps, SummaryDeps } from "./supervisor.ts";
+import { initI18n, t } from "./i18n.ts";
 
 // ── Integrate Args Parsing ────────────────────────────────────────────
 
@@ -1645,6 +1646,7 @@ export function detectOrchState(deps: OrchStateDetectionDeps): OrchStateDetectio
 // ── Extension ────────────────────────────────────────────────────────
 
 export default function (pi: ExtensionAPI) {
+	initI18n(pi);
 	let orchBatchState = freshOrchBatchState();
 	let orchConfig: OrchestratorConfig = { ...DEFAULT_ORCHESTRATOR_CONFIG };
 	let runnerConfig: TaskRunnerConfig = { ...DEFAULT_TASK_RUNNER_CONFIG };
@@ -1709,7 +1711,7 @@ export default function (pi: ExtensionAPI) {
 	// ── Commands ─────────────────────────────────────────────────────
 
 	pi.registerCommand("orch", {
-		description: "Start batch execution or supervisor: /orch [<areas|paths|all>]",
+		description: t("cmd.orch.description", "Start batch execution or supervisor: /orch [<areas|paths|all>]"),
 		handler: async (args, ctx) => {
 			// ── TP-042: No-args → supervisor routing ─────────────────
 			// When /orch is called without arguments, detect project state
@@ -1800,7 +1802,7 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("orch-plan", {
-		description: "Preview execution plan: /orch-plan <areas|paths|all> [--refresh]",
+		description: t("cmd.orchPlan.description", "Preview execution plan: /orch-plan <areas|paths|all> [--refresh]"),
 		handler: async (args, ctx) => {
 			if (!args?.trim()) {
 				ctx.ui.notify(
@@ -3381,7 +3383,7 @@ export default function (pi: ExtensionAPI) {
 	}
 
 	pi.registerCommand("orch-status", {
-		description: "Show current batch progress",
+		description: t("cmd.orchStatus.description", "Show current batch progress"),
 		handler: async (_args, ctx) => {
 			const result = doOrchStatus(ctx.cwd);
 			ctx.ui.notify(result, "info");
@@ -3389,7 +3391,7 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("orch-pause", {
-		description: "Pause batch after current tasks finish",
+		description: t("cmd.orchPause.description", "Pause batch after current tasks finish"),
 		handler: async (_args, ctx) => {
 			const result = doOrchPause();
 			// Determine notification level from result content
@@ -3399,7 +3401,7 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("orch-resume", {
-		description: "Resume a paused or interrupted batch: /orch-resume [--force]",
+		description: t("cmd.orchResume.description", "Resume a paused or interrupted batch: /orch-resume [--force]"),
 		handler: async (args, ctx) => {
 			if (!requireExecCtx(ctx)) return;
 
@@ -3416,7 +3418,7 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("orch-abort", {
-		description: "Abort batch: /orch-abort [--hard]",
+		description: t("cmd.orchAbort.description", "Abort batch: /orch-abort [--hard]"),
 		handler: async (args, ctx) => {
 			try {
 				const hard = args?.trim() === "--hard";
@@ -3434,7 +3436,7 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("orch-deps", {
-		description: "Show dependency graph: /orch-deps <areas|paths|all> [--refresh] [--task <id>]",
+		description: t("cmd.orchDeps.description", "Show dependency graph: /orch-deps <areas|paths|all> [--refresh] [--task <id>]"),
 		handler: async (args, ctx) => {
 			if (!args?.trim()) {
 				ctx.ui.notify(
@@ -3512,7 +3514,7 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("orch-sessions", {
-		description: "List active orchestrator sessions",
+		description: t("cmd.orchSessions.description", "List active orchestrator sessions"),
 		handler: async (_args, ctx) => {
 			const sessions = listOrchSessions(orchConfig.orchestrator.sessionPrefix, orchBatchState);
 			ctx.ui.notify(formatOrchSessions(sessions), "info");
@@ -3521,7 +3523,7 @@ export default function (pi: ExtensionAPI) {
 
 	// ── TP-041 Step 2: /orch-takeover — force supervisor takeover ────
 	pi.registerCommand("orch-takeover", {
-		description: "Force takeover supervisor from another session: /orch-takeover",
+		description: t("cmd.orchTakeover.description", "Force takeover supervisor from another session: /orch-takeover"),
 		handler: async (_args, ctx) => {
 			// Use workspaceRoot so supervisor state root matches engine (R006-1).
 			const stateRoot = execCtx.workspaceRoot;
@@ -3650,7 +3652,7 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.registerCommand("orch-integrate", {
-		description: "Integrate completed orch batch into your working branch",
+		description: t("cmd.orchIntegrate.description", "Integrate completed orch batch into your working branch"),
 		handler: async (args, ctx) => {
 			// Show usage if no args and no active batch state to infer from
 			if (args?.trim() === "--help" || args?.trim() === "-h") {
@@ -4779,7 +4781,7 @@ export default function (pi: ExtensionAPI) {
 	// ── Settings TUI ─────────────────────────────────────────────────
 
 	pi.registerCommand("taskplane-settings", {
-		description: "View and edit taskplane configuration",
+		description: t("cmd.settings.description", "View and edit taskplane configuration"),
 		handler: async (_args, ctx) => {
 			if (!requireExecCtx(ctx)) return;
 

--- a/extensions/taskplane/i18n.ts
+++ b/extensions/taskplane/i18n.ts
@@ -1,0 +1,81 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type Params = Record<string, string | number>;
+type Translate = (key: string, fallback: string, params?: Params) => string;
+
+let translate: Translate = (_key, fallback, params) => format(fallback, params);
+
+function format(text: string, params?: Params): string {
+	if (!params) return text;
+	return text.replace(/\{(\w+)\}/g, (_match, key: string) => String(params[key] ?? `{${key}}`));
+}
+
+export function t(key: string, fallback: string, params?: Params): string {
+	return translate(key, fallback, params);
+}
+
+const bundles = [
+	{
+		locale: "ja",
+		namespace: "taskplane",
+		messages: {
+			"cmd.orch.description": "バッチ実行またはスーパーバイザーを開始: /orch [<areas|paths|all>]",
+			"cmd.orchPlan.description": "実行計画をプレビュー: /orch-plan <areas|paths|all> [--refresh]",
+			"cmd.orchStatus.description": "現在のバッチ進捗を表示",
+			"cmd.orchPause.description": "現在のタスク完了後にバッチを一時停止",
+			"cmd.orchResume.description": "一時停止または中断したバッチを再開: /orch-resume [--force]",
+			"cmd.orchAbort.description": "バッチを中止: /orch-abort [--hard]",
+			"cmd.orchDeps.description": "依存関係グラフを表示: /orch-deps <areas|paths|all> [--refresh] [--task <id>]",
+			"cmd.orchSessions.description": "アクティブなオーケストレーターセッションを一覧表示",
+			"cmd.orchTakeover.description": "別セッションのスーパーバイザーを強制的に引き継ぐ: /orch-takeover",
+			"cmd.orchIntegrate.description": "完了した orch バッチを作業ブランチへ統合",
+			"cmd.settings.description": "taskplane 設定を表示・編集",
+		},
+	},
+	{
+		locale: "zh-CN",
+		namespace: "taskplane",
+		messages: {
+			"cmd.orch.description": "启动批量执行或监督器: /orch [<areas|paths|all>]",
+			"cmd.orchPlan.description": "预览执行计划: /orch-plan <areas|paths|all> [--refresh]",
+			"cmd.orchStatus.description": "显示当前批次进度",
+			"cmd.orchPause.description": "当前任务完成后暂停批次",
+			"cmd.orchResume.description": "恢复已暂停或中断的批次: /orch-resume [--force]",
+			"cmd.orchAbort.description": "中止批次: /orch-abort [--hard]",
+			"cmd.orchDeps.description": "显示依赖图: /orch-deps <areas|paths|all> [--refresh] [--task <id>]",
+			"cmd.orchSessions.description": "列出活动的编排器会话",
+			"cmd.orchTakeover.description": "从另一个会话强制接管监督器: /orch-takeover",
+			"cmd.orchIntegrate.description": "将完成的 orch 批次集成到工作分支",
+			"cmd.settings.description": "查看和编辑 taskplane 配置",
+		},
+	},
+	{
+		locale: "de",
+		namespace: "taskplane",
+		messages: {
+			"cmd.orch.description": "Batch-Ausführung oder Supervisor starten: /orch [<areas|paths|all>]",
+			"cmd.orchPlan.description": "Ausführungsplan anzeigen: /orch-plan <areas|paths|all> [--refresh]",
+			"cmd.orchStatus.description": "Aktuellen Batch-Fortschritt anzeigen",
+			"cmd.orchPause.description": "Batch nach Abschluss der aktuellen Tasks pausieren",
+			"cmd.orchResume.description": "Pausierten oder unterbrochenen Batch fortsetzen: /orch-resume [--force]",
+			"cmd.orchAbort.description": "Batch abbrechen: /orch-abort [--hard]",
+			"cmd.orchDeps.description": "Abhängigkeitsgraph anzeigen: /orch-deps <areas|paths|all> [--refresh] [--task <id>]",
+			"cmd.orchSessions.description": "Aktive Orchestrator-Sitzungen auflisten",
+			"cmd.orchTakeover.description": "Supervisor aus einer anderen Sitzung erzwingen übernehmen: /orch-takeover",
+			"cmd.orchIntegrate.description": "Abgeschlossenen orch-Batch in den Arbeitsbranch integrieren",
+			"cmd.settings.description": "taskplane-Konfiguration anzeigen und bearbeiten",
+		},
+	},
+];
+
+export function initI18n(pi: ExtensionAPI): void {
+	const events = pi.events;
+	if (!events) return;
+	for (const bundle of bundles) events.emit("pi-core/i18n/registerBundle", bundle);
+	events.emit("pi-core/i18n/requestApi", {
+		namespace: "taskplane",
+		callback(api: { t?: Translate } | undefined) {
+			if (typeof api?.t === "function") translate = api.t;
+		},
+	});
+}


### PR DESCRIPTION
The main Pi command surface contains the high-risk orchestration choices: start vs plan, pause/resume/abort, dependency graph, session takeover, and integration.

This PR makes those command descriptions optionally localizable while preserving the current English fallbacks.

- No new dependency
- No behavior change without an i18n provider
- English remains the default/fallback
- Locales: ja, zh-CN, de
- Focused on the Pi command palette; runtime notifications/dashboard/generated assets are unchanged

Validation:
- npm install --ignore-scripts
- npm pack --dry-run
- npx -y node@22 bin/taskplane.mjs help
- npx -y node@22 bin/taskplane.mjs doctor

Notes:
- Local default Node is v20, while taskplane requires Node >=22, so CLI validation was run through node@22.
- `taskplane doctor` ran and reported expected missing project config/agent files in this scratch checkout.
