### PR TITLE
Localize /orch-resume usage errors

### DIFF
--- a/extensions/taskplane/extension.ts
+++ b/extensions/taskplane/extension.ts
@@ -65,6 +65,7 @@ import {
 	resolveModelFromString,
 } from "./supervisor.ts";
 import type { SupervisorConfig, SupervisorRoutingContext, IntegrationExecutor, CiDeps, SummaryDeps } from "./supervisor.ts";
+import { initI18n, t } from "./i18n.ts";
 
 // ── Integrate Args Parsing ────────────────────────────────────────────
 
@@ -152,11 +153,11 @@ export function parseResumeArgs(raw: string | undefined): ResumeArgs | { error: 
 		if (token === "--force") {
 			force = true;
 		} else if (token === "--help") {
-			return { error: "Usage: /orch-resume [--force]\n\n  --force   Resume from stopped or failed state (runs pre-resume diagnostics first)" };
+			return { error: t("orch.resume.usage", "Usage: /orch-resume [--force]\n\n  --force   Resume from stopped or failed state (runs pre-resume diagnostics first)") };
 		} else if (token.startsWith("--")) {
-			return { error: `Unknown flag: ${token}\n\nUsage: /orch-resume [--force]` };
+			return { error: t("orch.resume.unknownFlag", "Unknown flag: {flag}\n\nUsage: /orch-resume [--force]", { flag: token }) };
 		} else {
-			return { error: `Unexpected argument: ${token}\n\nUsage: /orch-resume [--force]` };
+			return { error: t("orch.resume.unexpectedArg", "Unexpected argument: {arg}\n\nUsage: /orch-resume [--force]", { arg: token }) };
 		}
 	}
 
@@ -1645,6 +1646,7 @@ export function detectOrchState(deps: OrchStateDetectionDeps): OrchStateDetectio
 // ── Extension ────────────────────────────────────────────────────────
 
 export default function (pi: ExtensionAPI) {
+	initI18n(pi);
 	let orchBatchState = freshOrchBatchState();
 	let orchConfig: OrchestratorConfig = { ...DEFAULT_ORCHESTRATOR_CONFIG };
 	let runnerConfig: TaskRunnerConfig = { ...DEFAULT_TASK_RUNNER_CONFIG };

--- a/extensions/taskplane/i18n.ts
+++ b/extensions/taskplane/i18n.ts
@@ -1,0 +1,48 @@
+type Locale = "en" | "es" | "fr" | "pt-BR";
+type Params = Record<string, string | number>;
+
+const translations: Record<Exclude<Locale, "en">, Record<string, string>> = {
+	es: {
+		"orch.resume.usage": "Uso: /orch-resume [--force]\n\n  --force   Reanuda desde estado detenido o fallido (ejecuta primero diagnósticos previos)",
+		"orch.resume.unknownFlag": "Flag desconocido: {flag}\n\nUso: /orch-resume [--force]",
+		"orch.resume.unexpectedArg": "Argumento inesperado: {arg}\n\nUso: /orch-resume [--force]",
+	},
+	fr: {
+		"orch.resume.usage": "Utilisation : /orch-resume [--force]\n\n  --force   Reprendre depuis un état arrêté ou en échec (exécute d’abord les diagnostics préalables)",
+		"orch.resume.unknownFlag": "Option inconnue : {flag}\n\nUtilisation : /orch-resume [--force]",
+		"orch.resume.unexpectedArg": "Argument inattendu : {arg}\n\nUtilisation : /orch-resume [--force]",
+	},
+	"pt-BR": {
+		"orch.resume.usage": "Uso: /orch-resume [--force]\n\n  --force   Retoma de um estado parado ou com falha (executa diagnósticos prévios primeiro)",
+		"orch.resume.unknownFlag": "Flag desconhecida: {flag}\n\nUso: /orch-resume [--force]",
+		"orch.resume.unexpectedArg": "Argumento inesperado: {arg}\n\nUso: /orch-resume [--force]",
+	},
+};
+
+let currentLocale: Locale = "en";
+
+export function initI18n(pi: { events?: { emit?: (event: string, payload: unknown) => void } }): void {
+	pi.events?.emit?.("pi-core/i18n/registerBundle", {
+		namespace: "taskplane",
+		defaultLocale: "en",
+		locales: translations,
+	});
+	pi.events?.emit?.("pi-core/i18n/requestApi", {
+		onReady: (api: { getLocale?: () => string; onLocaleChange?: (cb: (locale: string) => void) => void }) => {
+			const locale = api.getLocale?.();
+			if (isLocale(locale)) currentLocale = locale;
+			api.onLocaleChange?.((next) => {
+				if (isLocale(next)) currentLocale = next;
+			});
+		},
+	});
+}
+
+export function t(key: string, fallback: string, params: Params = {}): string {
+	const template = currentLocale === "en" ? fallback : translations[currentLocale]?.[key] ?? fallback;
+	return template.replace(/\{(\w+)\}/g, (_, name) => String(params[name] ?? `{${name}}`));
+}
+
+function isLocale(locale: string | undefined): locale is Locale {
+	return locale === "en" || locale === "es" || locale === "fr" || locale === "pt-BR";
+}


### PR DESCRIPTION
This is a smaller follow-up after I retracted the earlier over-broad localization PR. I kept this one limited to the /orch-resume argument-error path only, since --force is a recovery/safety decision.\n\nWhat changed:\n- adds a tiny local i18n helper with English fallback\n- localizes only /orch-resume help, unknown-flag, and unexpected-argument errors\n- registers an optional pi-core i18n bundle when available\n- includes es, fr, and pt-BR strings\n\nWhat did not change:\n- no required dependency\n- English remains the default/fallback\n- resume behavior, persisted state, diagnostics, and force semantics stay untouched\n\nValidation:\n- passed: esbuild bundle check for extensions/task-orchestrator.ts with peer deps externalized\n- passed: npm pack --dry-run\n- note: package.json has no typecheck/test scripts in this checkout\n\nIf useful later, I’m happy to handle broader localization in small follow-up PRs using whatever locale set you prefer.