### PR TITLE
release: v0.28.5 — TP-181/183/184/185 bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.5] - 2026-05-05
+
 ### Fixed
 
 - **Pi no longer hard-blocks startup with a red error when run in directories

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
## Release v0.28.5

Bundles four bug fixes that landed since v0.28.4 (April 21).

### Fixed

- **TP-181 / #522** (@NerfEko) — `taskRunner.worker.{model,thinking,tools}` from preferences now actually flow through to spawned workers. Previously `LaneRunnerConfig.workerModel` was hardcoded to `""` and the user's worker model config was silently ignored. Mirrors the existing reviewer pipeline (TP-160). +11 tests.

- **TP-183 / #523** (@mwickens) — Pi no longer hard-blocks startup with a verbose red `WORKSPACE_SETUP_REQUIRED` error when run in directories without Taskplane configured. Soft-fails to a quiet status indicator (`🔀 Orchestrator · disabled (no taskplane config in workspace)`). All other `WorkspaceConfigErrorCode` values still surface loudly so real misconfigurations stay visible. +6 tests.

- **TP-184 / #530** — Workers can now invoke `review_step`, `notify_supervisor`, `escalate_to_supervisor`, and `request_segment_expansion`. Engine-internal coordination tools were missing from the worker `--tools` allowlist, so plan/code/test reviews silently never fired at Review Level ≥ 1, supervisor steering replies were impossible, and multi-repo segment expansion was unreachable. New `ENGINE_BRIDGE_TOOLS` constant + `buildWorkerToolsAllowlist()` helper. +14 tests.

- **TP-185** — Preflight `pi` check no longer misreports cold-start timeouts as "Pi not found". `execCheck` classifies failures by mode (`not-found`, `timeout`, `exit-code`, `signal`, `unknown`). Pi preflight uses 30s timeout (up from 10s) and retries once. Tailored failure hints. Backward compatible. +9 tests.

### Validation

- ✅ Tests: 3452 passing / 0 failed / 1 skipped (full fast suite + integration)
- ✅ CLI smokes: `taskplane help` and `taskplane doctor` clean
- ✅ Package contents: 75 files, 634 KB packed, 2.5 MB unpacked (`npm pack --dry-run`)
- ✅ All four fixes confirmed live in global install via local-build verification
- ✅ TP-184 fix validated end-to-end via TP-114 regression run (4 `review_step` calls, 2 verdict files, Review Counter = 2)
- ✅ Sage code review on TP-184 (1 blocking finding remediated pre-merge: `escalate_to_supervisor` was missing) and TP-183 (no blockers; 1 optional improvement applied)

### Test count growth

- v0.28.4: 3429 passing
- v0.28.5: 3452 passing (+23 across the four fixes)

### What's NOT in this release (deferred)

- TP-186 candidates: static-assertion test for `lane-runner.ts` spawn-site wiring, migration of duplicated literals to a shared lightweight constants module, behavioral helper extraction for TP-183 testability, fix for `taskplane doctor` empty `pi installed ()` display (pi prints version to stderr; getVersion only reads stdout)
- Two unrelated open external PRs (#516 abandoned polyrepo, #520 Nix CLI fix) and several open issues/discussions in the queue

### Tag

`v0.28.5` already pushed to origin and points at the `0.28.5` commit on this branch. Use `--merge` (not squash) when merging this PR so the tagged commit stays in main's linear history for `git describe` and `gh release create v0.28.5`.

### Post-merge sequence

1. Merge with `--merge` (preserves the tagged commit)
2. `npm publish`
3. `gh release create v0.28.5 --title "v0.28.5" --notes-from-tag` (or with a custom body matching this PR)
4. Verify: `npm view taskplane version` and `gh release view v0.28.5`
