### PR TITLE
fix(release): upgrade npm to 11.5+ before publish (OIDC Trusted Publishing fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,17 @@ jobs:
           cache: npm
           cache-dependency-path: extensions/package-lock.json
 
+      - name: Upgrade npm to latest (Trusted Publishing requires >= 11.5.1)
+        # Node 22 LTS ships with npm 10.x. OIDC Trusted Publishing for npm
+        # requires npm 11.5.1+. Without this, `npm publish --provenance`
+        # signs provenance to Sigstore (works on npm 10) but then fails the
+        # registry PUT with a misleading 404 because the actual publish
+        # auth still uses the placeholder NODE_AUTH_TOKEN from setup-node
+        # instead of OIDC.
+        run: |
+          npm install -g npm@latest
+          echo "npm version after upgrade: $(npm --version)"
+
       - name: Validate tag matches package.json version
         id: version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,21 +56,22 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: npm
           cache-dependency-path: extensions/package-lock.json
 
-      - name: Upgrade npm to latest (Trusted Publishing requires >= 11.5.1)
-        # Node 22 LTS ships with npm 10.x. OIDC Trusted Publishing for npm
-        # requires npm 11.5.1+. Without this, `npm publish --provenance`
-        # signs provenance to Sigstore (works on npm 10) but then fails the
-        # registry PUT with a misleading 404 because the actual publish
-        # auth still uses the placeholder NODE_AUTH_TOKEN from setup-node
-        # instead of OIDC.
+      - name: Verify npm version supports OIDC Trusted Publishing
+        # OIDC Trusted Publishing for npm requires npm 11.5.1+.
+        # Node 24 LTS ships with npm 11.x natively, so this is just a
+        # belt-and-suspenders check + future-proofing in case a Node 24
+        # patch ever ships with an older npm. The `install -g npm@latest`
+        # is a no-op when the bundled version is already current.
         run: |
+          echo "Node version:        $(node --version)"
+          echo "npm version (pre):   $(npm --version)"
           npm install -g npm@latest
-          echo "npm version after upgrade: $(npm --version)"
+          echo "npm version (post):  $(npm --version)"
 
       - name: Validate tag matches package.json version
         id: version


### PR DESCRIPTION
## Bug

The release workflow's `npm publish --provenance` was failing with `404 Not Found` from the npm registry, even with Trusted Publisher correctly configured. Investigation of workflow run [25461334369](https://github.com/HenryLach/taskplane/actions/runs/25461334369) revealed:

- Sigstore provenance signing **succeeded** (logIndex=1453543393)
- npm registry PUT **failed** with 404 (npm's auth-failure code)
- Runner had Node 22.22.2 → bundled npm 10.x
- `actions/setup-node` with `registry-url` writes a `.npmrc` with placeholder `NODE_AUTH_TOKEN`

## Root cause

OIDC Trusted Publishing for npm **requires npm 11.5.1+** ([docs](https://docs.npmjs.com/trusted-publishers)). Earlier npm versions support `--provenance` for Sigstore signing but don't use the OIDC token for the actual registry auth — they fall through to the broken placeholder token from `.npmrc` and get rejected.

## Fix

Add an explicit `npm install -g npm@latest` step after `setup-node`. Trivial change, ~3 seconds added to runtime, eliminates the version-skew issue regardless of which Node LTS the workflow uses.

## Validation

This PR can't validate the fix until merged — only workflows on the default branch are usable for tag pushes / dispatches. After merge, I'll re-trigger `workflow_dispatch` on `v0.28.5` and we should see a clean publish.