### PR TITLE
release: v0.28.6 — TP-186 worker death-spiral fix (#537, #542)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.6] - 2026-05-06
+
 ### Fixed
 
 - **Worker death-spiral when code review returns REVISE on a step already

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.28.5",
+      "version": "0.28.6",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
## Release v0.28.6

Single P0 bug fix: the **worker death-spiral** that made Review Level ≥ 2 unsafe in production.

### Fixed

- **TP-186 / #537 / #542** — Worker death-spiral when code review returns REVISE on a step already marked Complete in STATUS. Adds explicit Order of Operations rule + Recovery Recipe + Forbidden callout to `templates/agents/task-worker.md` (Option A, preventive). Adds `isStepMarkedComplete()` helper + guard in `agent-bridge-extension.ts` that refuses `review_step(type='code'|'test')` on already-complete steps with REFUSED + recovery instructions (Option B, defensive). Plan reviews are NOT blocked. Supersedes #510 (earlier partial diagnosis). Sage-reviewed.

### Validation

- ✅ Tests: **3467 passing** / 0 failed / 1 skipped (was 3452 baseline + 15 new)
- ✅ Plan + code reviews fired during the implementation batch — both APPROVED
- ✅ Sage independent review — primary fix confidence High; folded in 2 follow-ups (REFUSED in Handling verdicts; markdown emphasis typo) before merge
- ✅ CLI smokes clean
- ✅ Worker writing the fix completed without triggering the bug being fixed (recursive self-consistency check)

### Test count growth

- v0.28.5: 3452 passing
- v0.28.6: 3467 passing (+15 from `worker-step-completion-protocol.test.ts`)

### Tag

`v0.28.6` will be pushed AFTER this PR merges (so the release workflow's tag-push trigger fires against a commit already on main). Use `--merge` (not squash) when merging this PR so the version-bump commit is preserved in main's linear history for `npm view taskplane time` and `gh release view v0.28.6`.

### Closes

This release ships:
- Closes #537 (already closed by PR #547 merge)
- Closes #542 (already closed by PR #547 merge)
- Closes #510 (manually closed; superseded by #547)

### Post-merge sequence

1. Merge with `--merge` (preserves the tagged commit)
2. Sync local main: `git switch main && git pull --ff-only`
3. Push tag: `git push origin v0.28.6` — this triggers the release workflow
4. Workflow auto-publishes to npm with provenance + creates GitHub release

### Deferred (TP-189 candidates)

Sage-flagged polish items intentionally not blocking this release:
- Reconcile older-prompt ambiguity about checkbox-done vs. step-transition vs. the new rule
- Runtime refusal test for the guard's execution path (mock spawn, assert no reviewer + no counter increment)
- Fenced-code-block filter in `isStepMarkedComplete` (edge case)
- TP-187 + TP-188 from the same emailgistics-astro postmortem (recovery UX + reviewer typecheck + Windows worktree fallback)
