### PR TITLE
feat(dashboard): show lane parallelization in wave chips + task title in lane view (#484, #485)

### DIFF
--- a/dashboard/public/app.js
+++ b/dashboard/public/app.js
@@ -616,12 +616,96 @@ function renderSummary(batch) {
       const isCurrent = i === waveIdx && (batch.phase === "executing" || batch.phase === "merging");
       const isMergingChip = i === waveIdx && batch.phase === "merging";
       const cls = isDone ? "done" : isMergingChip ? "current merging" : isCurrent ? "current" : "";
-      wavesHtml += `<span class="wave-chip ${cls}">W${i + 1} [${taskIds.join(", ")}]</span>`;
+      // #484: Show lane parallelization within each wave. Group taskIds by
+      // their assigned lane: tasks on the same lane render with `→` (serial),
+      // tasks on different lanes render with ` | ` (parallel). Tooltip shows
+      // the expanded lane breakdown.
+      const { compact, tooltip } = formatWaveLaneBreakdown(taskIds, batch.lanes || [], i + 1);
+      const titleAttr = tooltip ? ` title="${escapeHtml(tooltip)}"` : "";
+      wavesHtml += `<span class="wave-chip ${cls}"${titleAttr}>W${i + 1} [${compact}]</span>`;
     });
     $summaryWaves.innerHTML = wavesHtml;
   } else {
     $summaryWaves.innerHTML = "";
   }
+}
+
+/**
+ * Compute lane parallelization for a wave's tasks (#484).
+ *
+ * Returns:
+ *   - `compact`: a string like "TP-165 → TP-166 | TP-168 | TP-167" suitable
+ *     for the wave-chip body. Tasks on the same lane are joined by ` → `
+ *     (in lane execution order, not just appearance order); separate lanes
+ *     are joined by ` | `.
+ *   - `tooltip`: a multi-line string like
+ *     "W1\n  L1: TP-165 → TP-166\n  L2: TP-168\n  L3: TP-167" suitable for
+ *     the chip's `title` attribute. Empty string when no lane data is
+ *     available (future waves not yet provisioned).
+ *
+ * When lane data is missing for one or more tasks (e.g., the wave has not
+ * yet been provisioned, or task hasn't been assigned), unassigned tasks
+ * are shown with the previous flat formatting and no tooltip is generated
+ * — this preserves backward compatibility with future-wave display.
+ */
+function formatWaveLaneBreakdown(taskIds, lanes, waveNumber) {
+  if (!Array.isArray(taskIds) || taskIds.length === 0) {
+    return { compact: "", tooltip: "" };
+  }
+  // Build taskId → laneNumber map for the lanes that have any of these tasks.
+  const taskToLane = new Map();
+  for (const lane of lanes) {
+    if (!lane || !Array.isArray(lane.taskIds)) continue;
+    for (const tid of lane.taskIds) {
+      // First lane to claim a task wins (lanes shouldn't overlap, but be defensive).
+      if (!taskToLane.has(tid)) taskToLane.set(tid, lane.laneNumber);
+    }
+  }
+  // If no task in this wave has lane data, fall back to flat display.
+  const hasAnyLaneData = taskIds.some((t) => taskToLane.has(t));
+  if (!hasAnyLaneData) {
+    return { compact: taskIds.join(", "), tooltip: "" };
+  }
+  // Group taskIds by lane. Preserve appearance order across lanes.
+  // Within a lane, preserve the lane's own taskIds order so `→` reflects
+  // execution order, not the order taskIds happens to appear here.
+  const laneOrder = []; // lane numbers in order they first appear in taskIds
+  const laneToTasks = new Map(); // laneNumber → ordered taskIds for this wave
+  const unassigned = []; // taskIds not in any lane (shouldn't happen but be defensive)
+  for (const tid of taskIds) {
+    const ln = taskToLane.get(tid);
+    if (ln === undefined) {
+      unassigned.push(tid);
+      continue;
+    }
+    if (!laneToTasks.has(ln)) {
+      laneToTasks.set(ln, []);
+      laneOrder.push(ln);
+    }
+    laneToTasks.get(ln).push(tid);
+  }
+  // Sort each lane's tasks by their position in the lane.taskIds array
+  // so `→` always reflects execution order on that lane.
+  for (const ln of laneOrder) {
+    const lane = lanes.find((l) => l && l.laneNumber === ln);
+    if (lane && Array.isArray(lane.taskIds)) {
+      const orderIndex = new Map(lane.taskIds.map((t, idx) => [t, idx]));
+      laneToTasks.get(ln).sort((a, b) => (orderIndex.get(a) ?? 0) - (orderIndex.get(b) ?? 0));
+    }
+  }
+  // Build compact representation.
+  const laneSegments = laneOrder.map((ln) => laneToTasks.get(ln).join(" → "));
+  if (unassigned.length > 0) laneSegments.push(unassigned.join(", "));
+  const compact = laneSegments.join(" | ");
+  // Build tooltip representation.
+  const tooltipLines = [`W${waveNumber}`];
+  for (const ln of laneOrder) {
+    tooltipLines.push(`  L${ln}: ${laneToTasks.get(ln).join(" → ")}`);
+  }
+  if (unassigned.length > 0) {
+    tooltipLines.push(`  (unassigned): ${unassigned.join(", ")}`);
+  }
+  return { compact, tooltip: tooltipLines.join("\n") };
 }
 
 // ─── Render: Lanes + Tasks (integrated) ─────────────────────────────────────
@@ -858,11 +942,16 @@ function renderLanesTasks(batch, sessions) {
         ? `<button class="viewer-eye-btn${isViewingStatus ? ' active' : ''}" onclick="viewStatusMd('${escapeHtml(task.taskId)}')" title="View STATUS.md">👁</button>`
         : '';
 
+      // #485: Show task title (from PROMPT.md `# Task: <ID> - <title>`) under
+      // the task-id when available. Falls back to just the ID when missing.
+      const titleHtml = task.taskTitle
+        ? `<div class="task-title-subtitle">${escapeHtml(task.taskTitle)}</div>`
+        : "";
       html += `
         <div class="task-row">
           <span class="task-icon"><span class="status-dot ${task.status}"></span></span>
           <span class="task-actions">${eyeHtml}</span>
-          <span class="task-id status-${task.status}">${escapeHtml(task.taskId)}${showRepos ? repoBadgeHtml(tRepo, "repo-badge-task") : ""}</span>
+          <span class="task-id status-${task.status}"><div class="task-id-line">${escapeHtml(task.taskId)}${showRepos ? repoBadgeHtml(tRepo, "repo-badge-task") : ""}</div>${titleHtml}</span>
           <span><span class="status-badge status-${task.status}"><span class="status-dot ${task.status}"></span> ${task.status}</span></span>
           <span class="task-duration">${dur}</span>
           <span>${progressHtml}</span>

--- a/dashboard/public/style.css
+++ b/dashboard/public/style.css
@@ -625,6 +625,28 @@ body {
   font-family: var(--font-mono);
   font-weight: 600;
   font-size: 0.85rem;
+  /* #485: task-id may now contain a stacked task-id-line + task-title-subtitle */
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0; /* allow inner ellipsis to work */
+}
+
+.task-id-line {
+  /* The original TP-XXX line; preserves the previous single-line look */
+  white-space: nowrap;
+}
+
+.task-title-subtitle {
+  /* #485: human-readable task title under the ID */
+  font-family: var(--font-sans, inherit);
+  font-weight: 400;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
 }
 
 .task-duration {

--- a/dashboard/server.cjs
+++ b/dashboard/server.cjs
@@ -160,6 +160,52 @@ function resolveTaskFolder(task, state) {
   return task.taskFolder;
 }
 
+/**
+ * Read the task title from a task folder's PROMPT.md.
+ *
+ * Extracts the human-readable title from the first `# Task:` heading. The
+ * heading format is `# Task: <ID> - <title>` per the create-taskplane-task
+ * skill's prompt template. Returns null when PROMPT.md is missing, the
+ * pattern doesn't match, or any read error occurs.
+ *
+ * Cached per-folder for the lifetime of this server process: PROMPT.md is
+ * immutable above the `---` divider so the title never changes mid-batch.
+ * Cache is keyed by absolute task folder path. (#485)
+ */
+const _taskTitleCache = new Map();
+function parseTaskTitle(taskFolder) {
+  if (!taskFolder) return null;
+  const cacheKey = path.resolve(taskFolder);
+  if (_taskTitleCache.has(cacheKey)) return _taskTitleCache.get(cacheKey);
+
+  // Look at both the canonical folder and the archive fallback (matches
+  // parseStatusMd's two-candidate strategy).
+  const candidates = [taskFolder];
+  const taskId = path.basename(taskFolder);
+  const archiveBase = taskFolder.replace(/[/\\]tasks[/\\][^/\\]+$/, "/tasks/archive/" + taskId);
+  if (archiveBase !== taskFolder) candidates.push(archiveBase);
+
+  for (const folder of candidates) {
+    const promptPath = path.join(folder, "PROMPT.md");
+    try {
+      const content = fs.readFileSync(promptPath, "utf-8");
+      // Match `# Task: <ID> - <title>` (the canonical first-line heading).
+      const match = content.match(/^# Task:\s*\S+\s*[-\u2014\u2013]\s*(.+?)\s*$/m);
+      if (match) {
+        const title = match[1].trim();
+        _taskTitleCache.set(cacheKey, title);
+        return title;
+      }
+    } catch {
+      // PROMPT.md missing or unreadable in this candidate — try the next.
+      continue;
+    }
+  }
+  // Cache the negative result too, so we don't re-attempt on every poll.
+  _taskTitleCache.set(cacheKey, null);
+  return null;
+}
+
 function parseStatusMd(taskFolder) {
   const candidates = [taskFolder];
   const taskId = path.basename(taskFolder);
@@ -1102,13 +1148,17 @@ function buildDashboardState() {
   const tasks = (state.tasks || []).map((task) => {
     const effectiveFolder = resolveTaskFolder(task, state);
     let statusData = null;
+    let taskTitle = null;
     if (effectiveFolder) {
       statusData = parseStatusMd(effectiveFolder);
+      // #485: read the human-readable title from PROMPT.md once, surface
+      // alongside taskId so the dashboard can show it as a subtitle.
+      taskTitle = parseTaskTitle(effectiveFolder);
     }
     if (!task.doneFileFound && effectiveFolder) {
       task.doneFileFound = checkDoneFile(effectiveFolder);
     }
-    return { ...task, statusData };
+    return { ...task, statusData, taskTitle };
   });
 
   // TP-107: Load Runtime V2 data when available


### PR DESCRIPTION
Two dashboard enhancements bundled in one PR. Both are display-only — cannot affect orchestrator correctness even if rendered imperfectly. Visual validation will happen during the next live batch run.

## #484 — Lane parallelization in wave indicator chips

**Before:**
```
Waves   W1 [TP-165, TP-166, TP-168, TP-167]   W2 [TP-169, TP-170]   W3 [TP-171]
```

W1 looks like 4 independent tasks. In reality TP-165→TP-166 are serialized on lane 1 while TP-168 and TP-167 run in parallel on lanes 2 and 3.

**After:**
```
Waves   W1 [TP-165 → TP-166 | TP-168 | TP-167]   W2 [TP-169 | TP-170]   W3 [TP-171]
```

Same-lane tasks join with `→` (serial). Different-lane tasks join with ` | ` (parallel). At a glance:
- Count of `|` separators = number of parallel lanes used in the wave
- `→` arrows = serialized tasks on a single lane

Hover tooltip on each chip exposes the expanded lane breakdown:
```
W1
  L1: TP-165 → TP-166
  L2: TP-168
  L3: TP-167
```

### Implementation

- New helper `formatWaveLaneBreakdown(taskIds, lanes, waveNumber)` in `dashboard/public/app.js`
- Within each lane, tasks render in execution order (sorted by their position in `lane.taskIds`), not by their appearance order in the wave's task list
- Future waves with no lane assignment data (lanes provisioned per-wave when wave starts) fall back to the previous flat comma-separated display — zero regression for unprovisioned waves
- No server changes: `lanes` data is already exposed via `/api/state`

## #485 — Task title under task ID in lane view

**Before:**
```
●  👁 TP-165                    ● running    11m 11s    ━━━━━━━━━  0% 0/18
```

**After:**
```
●  👁 TP-165                    ● running    11m 11s    ━━━━━━━━━  0% 0/18
      Segment Boundary .DONE Guard and Expansion Consumption
```

Operator no longer needs to remember what each TP-XXX means.

### Implementation

- New helper `parseTaskTitle(taskFolder)` in `dashboard/server.cjs` reads the title from PROMPT.md's `# Task: <ID> - <title>` first-line heading. Regex: `/^# Task:\s*\S+\s*[-—–]\s*(.+?)\s*$/m` (handles dash, em-dash, en-dash separators).
- Per-folder cache for the server lifetime: PROMPT.md is immutable above the `---` divider so the title never changes mid-batch.
- `/api/state` task records now carry a `taskTitle` field alongside the existing `statusData`.
- Frontend wraps the task-id cell in a flex column with the ID on top and the title as a smaller muted subtitle underneath. Falls back gracefully (no subtitle div) when `taskTitle` is null.
- New CSS: `.task-id` is now flex-column; `.task-id-line` preserves the monospace ID look; `.task-title-subtitle` is the smaller muted line with ellipsis truncation for long titles.

## Validation

- ✅ Logic unit-tested in isolation for `formatWaveLaneBreakdown`:
  - Issue example: `TP-165 → TP-166 | TP-168 | TP-167` ✓
  - Scrambled appearance order: still renders lane execution order correctly ✓
  - Future wave with no lane data: falls back to flat display ✓
  - Empty input: returns empty strings ✓
- ✅ No backend behavior change for `parseTaskTitle` (purely additive read of PROMPT.md, cached, fail-safe to null)
- 🔵 Visual validation deferred to next live batch run

## Operator note

Per the supervisor primer rule, after this PR merges and a new dashboard binary lands, **restart the dashboard server** to pick up the new server-side `parseTaskTitle` logic. Frontend-only changes refresh on browser reload, but the new API field requires a server restart.

## Closes

- Closes #484
- Closes #485
