### PR TITLE
release: v0.28.7 — dashboard polish (#484, #485)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.7] - 2026-05-07
+
+### Enhanced
+
+- **Dashboard: lane parallelization visible in wave indicator chips (#484):**
+  Wave chips at the top of the dashboard now group tasks by lane within each
+  wave, joining same-lane tasks with `→` (serial) and different-lane tasks
+  with ` | ` (parallel). For example, `W1 [TP-165, TP-166, TP-168, TP-167]`
+  now reads `W1 [TP-165 → TP-166 | TP-168 | TP-167]`, immediately revealing
+  that TP-165→TP-166 are serialized on lane 1 while TP-168 and TP-167 run in
+  parallel on lanes 2 and 3. Within each lane, tasks render in execution
+  order (per `lane.taskIds`). Hover tooltip on the chip exposes the
+  expanded multi-line lane breakdown. Future waves with no lane assignment
+  data fall back to the previous flat comma-separated display — no
+  regression for unprovisioned waves.
+- **Dashboard: task title under task ID in lane view (#485):** The lane
+  view now renders the human-readable task title (extracted from PROMPT.md's
+  `# Task: <ID> - <title>` first-line heading) as a smaller muted subtitle
+  beneath the task ID. Operator no longer needs to remember what each
+  TP-XXX is. The title is read once from PROMPT.md and cached for the
+  server's lifetime (PROMPT.md is immutable above the `---` divider).
+  Surfaced via a new `taskTitle` field on `/api/state` task records;
+  frontend falls back gracefully when the field is null.
+
 ## [0.28.6] - 2026-05-06
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.28.6",
+  "version": "0.28.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.28.6",
+      "version": "0.28.7",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.28.6",
+  "version": "0.28.7",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Patch release for two dashboard enhancements that landed via PR #550.

### Enhanced
- **#484** — Lane parallelization visible in wave indicator chips (` → ` for serial, ` | ` for parallel; tooltip with expanded breakdown)
- **#485** — Task title under task ID in lane view (read from PROMPT.md, cached, gracefully falls back when missing)

### Validation
- Tests: full suite still passing (no test changes; dashboard frontend has no test harness)
- Logic for `formatWaveLaneBreakdown` was unit-tested in isolation against 4 scenarios (issue example, scrambled order, future-wave fallback, empty input)
- Visual validation deferred to first batch run on v0.28.7

### Tag
`v0.28.7` will be pushed AFTER this PR merges (so the release workflow's tag-push trigger fires against a commit already on main). Use `--merge` to preserve the version-bump commit in main's history.

### Post-merge sequence
1. Merge with `--merge`
2. Sync local main
3. Push tag `v0.28.7` → triggers release workflow → npm publish + GH release auto-created
4. Operator should restart the dashboard server after pi update to pick up server-side parseTaskTitle logic