### PR TITLE
release: v0.29.0 — TP-187 supervisor recovery + TP-189 polish + #559/#560 hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-05-09
+
 ### New
 
 - **`supervisor_takeover(reason)` tool (TP-187, #538):** Non-destructive
@@ -224,6 +226,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   thrown with the original stderr; non-win32 + MAX_PATH text →
   platform guard in `isWindowsMaxPathError` correctly skips the
   fallback.
+
+### Fixed (post-PR-#556 hotfixes)
+
+- **Orchestrator parent crashes on first IPC frame from engine-worker
+  (#559):** `ReferenceError: batchState is not defined` thrown from
+  `ipcBatchIdMatches` in the supervisor IPC closure crashed the
+  orchestrator parent process the moment any engine-worker emitted its
+  first `lane-terminated` or `lane-respawned` message. Affected every
+  batch — the batch state file was left in `phase=executing` with 0
+  progress, and git worktrees / `task/...` branches were orphaned.
+  Root cause: TP-187's batchId-gating helper (added to fold sage's
+  post-integration finding) referenced `batchState.batchId` 5 times,
+  but `batchState` is NOT bound in the supervisor IPC closure — only
+  `orchBatchState` and `supervisorState` are. The crash slipped through
+  because (1) `node --experimental-strip-types` performs no
+  name-resolution checks, only strips type annotations; (2) TP-187's
+  in-batch tests mock IPC handlers at a different layer
+  (engine-worker → supervisor callbacks via `executeOrchBatch`'s `deps`
+  parameter), bypassing the actual extension closure under fault.
+  Fix: switched 5 sites from `batchState.batchId` to
+  `orchBatchState.batchId` (NOT `supervisorState.batchId` — sage's
+  post-mortem on the first attempted fix flagged that
+  `supervisorState.batchId` is only populated when the supervisor
+  activates, so for batches where the supervisor never activates the
+  gate would never fire and the zombie-alert filter would be defeated).
+  `orchBatchState.batchId` is the canonical live runtime batch ID for
+  the extension closure: declared next to `supervisorState`, populated
+  reliably via state-sync IPC. Regression test in
+  `extensions/tests/extension-ipc-batchid-scope.test.ts` (4 tests)
+  asserts via source-pattern that the supervisor IPC closure region
+  contains zero references to `batchState.batchId` and at least one
+  reference to `orchBatchState.batchId`. Comments are stripped before
+  the check so documentation-of-the-bug doesn't trigger false
+  positives.
+
+- **Pi CLI path resolution broken after `@mariozechner` →
+  `@earendil-works` rename (#560):** Pi v0.74.0 republished under the
+  `@earendil-works` npm scope. Taskplane's Runtime V2 spawn pathway
+  resolves Pi's CLI on disk via `path-resolver.ts:resolvePiCliPath()`,
+  which hardcoded `@mariozechner` as the only scope to search under
+  `npm root -g`. Result: every Runtime V2 spawn (workers, reviewers,
+  mergers) failed immediately with `Cannot find Pi CLI entrypoint` on
+  any system whose only globally-installed Pi was the new scope.
+  Critically, Pi's own extension loader bundles aliases for BOTH
+  scopes at runtime (`<pi>/dist/core/extensions/loader.js` lines
+  41-45), so all of taskplane's `import type { ExtensionAPI } from
+  "@mariozechner/pi-coding-agent"` and `import { Type } from
+  "@mariozechner/pi-ai"` sites continue to resolve correctly via Pi's
+  in-process aliasing — the rename only breaks **disk-side** lookup
+  for child-process spawning. Fix is therefore narrowly scoped to
+  `path-resolver.ts`: refactored `resolvePiCliPath()` to walk the cross
+  product of base directories × scopes, with `@earendil-works` checked
+  first and `@mariozechner` second within each base directory.
+  Operators with EITHER scope installed get a working Pi resolution;
+  operators with BOTH installed (e.g., during a transition window)
+  pick up `@earendil-works`. The error message and the
+  `worktree.ts` install hint now name both scopes for diagnosability.
+  Other ~10 files that reference `@mariozechner` (TypeScript imports,
+  test mocks, peerDependencies, docs) deliberately left as-is because
+  Pi's bundled-alias handling makes them work at runtime regardless of
+  scope, and updating them risks breaking compat for users on Pi
+  versions older than v0.74.0 (which don't have the alias map).
+  Regression test in
+  `extensions/tests/path-resolver-pi-scope.test.ts` (4 tests) sets up
+  temp directories with each scope combination and asserts the
+  resolver behaves correctly via real `child_process` probes.
 
 ## [0.28.8] - 2026-05-07
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.28.8",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.28.8",
+      "version": "0.29.0",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.28.8",
+  "version": "0.29.0",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Minor release bundling supervisor recovery flows + accumulated polish + two critical post-merge hotfixes.

## Why minor (not patch)

- **New `supervisor_takeover(reason)` tool surface** (TP-187, #538) — additive but observable
- **New `batch-meta.json` runtime artifact** (TP-187, #539) — additive on-disk surface, written at every batch start
- **CLI behavior change**: `taskplane doctor` now actually shows the pi version (was empty parens — TP-189 / #185 follow-up)
- **Refined worker / supervisor prompt templates** — behavior change for new tasks
- **New `lane-terminated` / `lane-respawned` IPC messages** between engine-worker and supervisor

Per semver, these warrant a minor bump (0.28.x → 0.29.0). Pure bug-fix entries also shipping here as part of the same release.

## Highlights

### TP-187 — Supervisor recovery flows (PR #556 main batch, all reviews APPROVE)
- **#538** zombie alert drain: per-agent on-disk outbox drain at lane termination + supervisor-side terminated-lane filter that drops in-transit zombie alerts before they reach `pi.sendUserMessage`. New `supervisor_takeover(reason)` tool for non-destructive batch parking.
- **#539** force-resume reconstruction: `batch-meta.json` artifact written at batch-start lets `orch_resume(force=true)` rebuild a validator-compliant `PersistedBatchState` from runtime artifacts after `orch_abort` deletes `.pi/batch-state.json`.
- **#540** worker exit-reason surfacing: `Worker said: "..."` field in supervisor alerts now falls back to walking the worker's `events.jsonl` when the current turn produced no visible output.

### TP-189 — Polish bundle (PR #556 main batch, all reviews APPROVE)
- **A** defensive tests for spawn-site wiring, `review_step` REFUSED runtime, fenced-code-block filter, `removeWorktree()` Windows fallback decision branches.
- **B** constants module migration (`tool-allowlist-constants.ts` single source of truth).
- **C** `taskplane doctor` shows pi version (extracted to testable `bin/get-version.mjs`).
- **D** ci.yml on Node 24 (already shipped in v0.28.8).
- **E** worker prompt + skill reconciliation with TP-186's Order of Operations rule.

### Sage post-integration folds (PR #556)
- **batchId IPC gating** (sage #3): `lane-terminated` / `lane-respawned` handlers gate on the supervisor's tracked `orchBatchState.batchId` so stale messages from a prior batch can't taint the live batch's suppression map.
- **Multi-repo reconstruction guard** (sage's blocker reframed): refuse force-resume reconstruction when worker manifests indicate >1 distinct repoId. Prevents silent `segments: []` state loss for polyrepo batches.

### Critical post-merge hotfixes
- **#559** orchestrator parent crashes on first IPC frame (`ReferenceError: batchState is not defined`). My TP-187 sage-fold commit referenced an undefined identifier in the supervisor IPC closure. Affected every batch. Fixed in commits `4a8aea6` + `ff02265` with sage post-mortem switching to `orchBatchState.batchId` (the canonical live runtime batch ID, not `supervisorState.batchId` which is only populated when the supervisor activates).
- **#560** Pi CLI path resolution broken after `@mariozechner` → `@earendil-works` rename in Pi v0.74.0. `resolvePiCliPath()` now searches both scopes (new first, legacy fallback). Backward compat preserved for users still on the legacy scope.

## Validation

- **Tests:** 3587 passing / 1 skipped / 0 failed on Node 24.15.0 (Windows local). +91 new tests over the v0.28.8 baseline (3496).
- **CI:** green on Linux Node 24
- **CLI smoke:** `taskplane help`, `taskplane doctor`, `taskplane init --dry-run`, `taskplane uninstall --dry-run` all clean. `taskplane doctor` correctly displays `✅ pi installed (0.74.0)` (the rename target).
- **Polyrepo end-to-end test:** ✅ verified by operator on a real 6-wave multi-repo batch (3 repos, 6 tasks). All waves completed; #559 and #560 fixes confirmed working in the wild.
- **Package contents:** `npm pack --dry-run` clean — 660 kB, 77 files
- **No publish-blocking external dependencies changed** — peerDependencies still on `@mariozechner/*` (intentional; Pi's runtime aliasing handles both scopes, and updating peer deps risks breaking compat for users on Pi <v0.74.0).

## Issues closed

- #538, #539, #540 (TP-187)
- #559 (post-merge hotfix)
- #560 (post-merge hotfix)

## Issues queued (next release)

- **TP-190 / #561** — Runtime V2 spawn errors are silent; lanes stay "running" forever. Task packet staged at `taskplane-tasks/TP-190-runtime-v2-spawn-failure-visibility/`. Review Level 2, Size M. Will ship in v0.29.x or v0.30.0 after the orchestrator runs the task.
- **#509 update** — operator commented with refined hypothesis (off-by-one wave attribution in dashboard merge telemetry). Awaiting triage.

## Tag

`v0.29.0` will be pushed AFTER this PR merges. Use `--merge` to preserve the version-bump commit in main's history.
