### PR TITLE
docs: align release docs with Trusted Publishing workflow (post-v0.29.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,25 @@ consecutive releases).
    - `npm pack --dry-run` (confirm only intended files ship)
    - `cd extensions && npm run test:fast` (full fast suite passes; record count for CHANGELOG)
    - `node bin/taskplane.mjs help` and `node bin/taskplane.mjs doctor` (CLI smoke)
+   - **Optional but strongly recommended: end-to-end smoke via local-build.**
+     For releases that touch runtime behavior unit tests can't fully exercise
+     (IPC handlers, path resolution, dashboard rendering, lane state machine,
+     spawn-time error paths, mailbox / outbox semantics), run
+     `node scripts/local-build.mjs` from the project root to deploy the
+     merged `main` branch into your global npm install. Then exercise the
+     changes in a real consumer project — for polyrepo work, the 3-repo
+     test workspace at `C:/dev/tp-test-workspace` (set up via the
+     `polyrepo-smoke-test` skill) is the canonical pre-release verification.
+     The `local-build` skill at `.pi/skills/local-build/SKILL.md` documents
+     the script's behavior (incremental copy by default, `--force` for
+     full copy, `--dry` for preview).
+
+     **Why this matters:** this step caught #559 (orchestrator IPC crash on
+     first frame) and #560 (Pi `@earendil-works` rename break) before they
+     shipped public in v0.29.0. Both passed every CI gate (3587 tests +
+     Biome + smoke checks) but failed deterministically in real polyrepo
+     workspaces. Skipping local-build for runtime-affecting changes risks
+     silent regressions that pass automation and fail in production.
 
 3. **Create the release branch and update `CHANGELOG.md` (MANDATORY).**
    - `git switch -c release/v<version>`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,38 +193,111 @@ When in doubt, optimize for: **determinism, recoverability, and clear operator v
   - `npm publish` ships installable package bits.
   - GitHub release publishes human-facing release metadata for a tag.
 - Keep them aligned: **one version → one tag → one npm publish → one GitHub release**.
+- **Both are now automated** via `.github/workflows/release.yml` (npm Trusted
+  Publishing). Pushing a `v*` tag triggers the workflow, which:
+  1. Checks out the tagged commit
+  2. Validates the tag name matches `package.json#version` (no drift allowed)
+  3. Re-runs tests as belt-and-suspenders
+  4. Publishes to npm with `--provenance` attestation (OIDC, no `NPM_TOKEN` secret)
+  5. Creates the GitHub release with notes extracted from `CHANGELOG.md`
+- Authentication is via [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers).
+  Do NOT add `NPM_TOKEN` to repository secrets; the workflow uses OIDC. The
+  trusted publisher is configured at <https://www.npmjs.com/package/taskplane/access>.
 
 ### Default release sequence (only when explicitly requested)
 
-1. Ensure `main` is clean and synced; tests/smokes pass.
-2. **Update `CHANGELOG.md` (MANDATORY — do NOT skip).**
-   - Add a section for the new version with date.
-   - List all user-facing changes since the last changelog entry.
-   - Group by: Breaking, New, Fixed, Docs, Internal.
-   - Read `git log` since the last release tag to find all changes.
-   - This is the permanent record of what shipped. GitHub release notes
-     are derived from this, not the other way around.
-3. Validate package contents:
-   - `npm pack --dry-run`
-4. Bump version and create tag:
-   - `npm version patch` (or `minor`/`major`)
-5. Publish package:
-   - `npm publish` (or `npm publish --tag beta`)
-6. Push commit + tags:
-   - `git push && git push --tags`
-7. Create GitHub release for the same version tag.
-   - Release notes should match or summarize `CHANGELOG.md`.
-8. Verify:
-   - `npm view taskplane version`
-   - `gh release view v<version>`
+This is the actual flow used for v0.28.5 → v0.29.0 (verified across 5
+consecutive releases).
+
+1. **Ensure `main` is clean and synced; all content PRs already merged.**
+   - `git switch main && git pull --ff-only`
+   - All bug-fix / feature PRs that should ship in this release must already
+     be in `main`. The release PR is a thin wrapper around the version bump,
+     not a content PR.
+
+2. **Validate package contents and run pre-release checks.**
+   - `npm pack --dry-run` (confirm only intended files ship)
+   - `cd extensions && npm run test:fast` (full fast suite passes; record count for CHANGELOG)
+   - `node bin/taskplane.mjs help` and `node bin/taskplane.mjs doctor` (CLI smoke)
+
+3. **Create the release branch and update `CHANGELOG.md` (MANDATORY).**
+   - `git switch -c release/v<version>`
+   - Rename the existing `## [Unreleased]` section to `## [<version>] - <YYYY-MM-DD>`
+   - Insert a fresh empty `## [Unreleased]` placeholder above it
+   - Add any `Fixed` entries for hotfixes that landed on `main` after the
+     last `[Unreleased]` write but before the version bump (these are easy
+     to miss if you only look at `[Unreleased]`)
+   - Group by: Breaking, New, Enhanced, Fixed, Docs, Internal
+   - This is the permanent record of what shipped. The release workflow
+     extracts release notes from this section verbatim.
+
+4. **Bump version and create the local tag.**
+   - `npm version patch` (or `minor` / `major`)
+   - This updates `package.json`, `package-lock.json`, creates a git commit
+     (`<version>`), AND creates a local tag (`v<version>`). Don't push the
+     tag yet — it goes after the PR merges.
+
+5. **Push the release branch and open the release PR.**
+   - `git push -u origin release/v<version>`
+   - `gh pr create --base main --head release/v<version> --title "release: v<version> — <summary>" --body-file <body>`
+   - PR body should: explain why the version bump (patch/minor/major
+     justification per semver), list issues closed, summarize highlights,
+     note validation results.
+
+6. **Wait for CI green, then merge the release PR.**
+   - `gh pr merge <num> --merge --delete-branch` (preserves the version-bump
+     commit in main's history under a merge commit)
+   - DO NOT use `--squash` or `--rebase` — the version-bump commit needs to
+     stay intact so the tag points at it.
+
+7. **Sync local main, then push the tag to trigger the release workflow.**
+   - `git switch main && git pull --ff-only`
+   - `git push origin v<version>` — this is what triggers the publish workflow
+   - The workflow runs in ~30-60 seconds. Monitor with:
+     `gh run list --workflow=release.yml --limit 1`
+
+8. **Verify everything published correctly.**
+   - `npm view taskplane version` — should show the new version (allow ~10-15s
+     for npm registry propagation)
+   - `gh release view v<version>` — should show the GitHub release with notes
+   - Optional: `npm view taskplane versions --json | tail` to confirm the
+     version is in the published list
 
 **Pre-release checklist (verify before step 3):**
-- [ ] `CHANGELOG.md` updated with all changes since last release
-- [ ] Tests pass: `cd extensions && node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts`
+- [ ] `main` is clean and synced (`git status -sb` shows no diverging commits)
+- [ ] All content PRs that should ship are already merged
+- [ ] Tests pass: `cd extensions && npm run test:fast`
 - [ ] CLI smoke: `node bin/taskplane.mjs help` and `node bin/taskplane.mjs doctor`
-- [ ] No uncommitted changes on the release branch
+- [ ] No uncommitted changes
+- [ ] Hotfix scan: any commits on `main` after the last `[Unreleased]` write
+      that need a CHANGELOG entry?
 
+**What NOT to do:**
+- Do **not** run `npm publish` locally. The workflow does it. Local publish
+  bypasses the tag’version validation, the test re-run, and the provenance
+  attestation — and it can’t use OIDC, so it would either fail (no
+  `NPM_TOKEN` configured) or use a less-trusted credential.
+- Do **not** create the GitHub release manually with `gh release create`.
+  The workflow does it with notes extracted from `CHANGELOG.md`. A manual
+  release would either conflict with the workflow's release or duplicate
+  it on the same tag.
+- Do **not** push the tag before the release PR is merged. The tag must
+  point at a commit that’s already in `main` (otherwise the release
+  references an orphan commit not reachable from any branch).
+- Do **not** use `--squash` or `--rebase` to merge the release PR. Both
+  rewrite the version-bump commit's SHA, which would orphan the local tag
+  you created in step 4. Use `--merge`.
 - Never perform publish/release actions unless the user explicitly asks.
+
+**If the workflow fails:**
+- Inspect with `gh run view <run-id> --log-failed`
+- Common causes: tag/version mismatch (workflow validates this), test
+  failure on the re-run (unlikely if PR CI was green), npm registry
+  hiccup (rare; re-trigger via Actions UI workflow_dispatch with the same
+  tag input)
+- The workflow is idempotent on a re-run for the same tag — npm rejects
+  republish of an existing version, but the GitHub release step uses
+  `gh release create --notes-file ...` which replaces existing notes.
 
 ---
 

--- a/docs/maintainers/release-process.md
+++ b/docs/maintainers/release-process.md
@@ -2,6 +2,11 @@
 
 This guide covers how to publish a new Taskplane npm release.
 
+**TL;DR:** Pushing a `v*` tag triggers `.github/workflows/release.yml`, which
+publishes to npm via Trusted Publishing (OIDC, no `NPM_TOKEN` needed) and
+creates the GitHub release with notes from `CHANGELOG.md`. You don't run
+`npm publish` or `gh release create` manually.
+
 ## GitHub Releases vs npm Publish
 
 These are related, but not the same operation:
@@ -16,15 +21,61 @@ Best practice for Taskplane is to keep them aligned:
 - one npm publish (`taskplane@X.Y.Z`)
 - one GitHub Release (`vX.Y.Z`)
 
+The release workflow enforces this alignment automatically.
+
+## How automation works
+
+`.github/workflows/release.yml` is triggered by tag pushes (`push` event with
+ref `refs/tags/v*`). It also supports `workflow_dispatch` for manual re-runs
+on an existing tag.
+
+The workflow:
+
+1. Checks out the tagged commit
+2. Validates the tag name matches `package.json#version` (no drift allowed)
+3. Re-runs the test suite as belt-and-suspenders (PR CI already validated `main`,
+   but the tag could in principle point at a different commit)
+4. Publishes to npm with `--provenance` attestation via OIDC
+5. Creates the GitHub release with notes extracted from the matching version
+   section of `CHANGELOG.md`
+
+**Authentication:** [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers)
+is configured for this package. The workflow uses GitHub's OIDC token to
+authenticate to npm; no `NPM_TOKEN` secret is stored in the repository.
+The trusted publisher is configured at:
+<https://www.npmjs.com/package/taskplane/access>.
+
 ## Prerequisites
 
-- npm publish access for `taskplane`
-- clean git working tree
-- Node.js 22+
+- Permission to push tags and merge PRs on the repository
+- `gh` CLI authenticated (`gh auth status`)
+- Node.js 22+ locally (workflow runs Node 24)
+- Clean git working tree
+
+You do **not** need npm publish credentials locally. The workflow handles publish.
 
 ---
 
-## 1) Validate package contents
+## Default release sequence
+
+The workflow assumes `main` is already in the state you want to release. Don't
+include feature work in the release PR — merge content PRs first, then cut a
+thin release PR that only bumps the version and updates the changelog.
+
+### 1) Sync main and verify pre-release state
+
+```bash
+git switch main && git pull --ff-only
+git status -sb                                    # working tree clean
+```
+
+Confirm:
+
+- All bug-fix / feature PRs that should ship are already in `main`.
+- No commits on `main` since the last `[Unreleased]` write that lack a
+  changelog entry. (Easy to miss when hotfixes land between major batches.)
+
+### 2) Validate package contents and run pre-release checks
 
 From repo root:
 
@@ -34,132 +85,210 @@ npm pack --dry-run
 
 Confirm only intended files ship (per `package.json#files`).
 
-Optional tarball inspection:
-
-```bash
-npm pack
-tar -tzf taskplane-<version>.tgz
-```
-
----
-
-## 2) Run tests / smoke checks
+Run the test suite:
 
 ```bash
 cd extensions
-node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/*.test.ts
+npm run test:fast
 cd ..
 ```
 
-Optional local smoke:
+Record the passing test count — useful for the release PR body.
 
-- `node bin/taskplane.mjs help`
-- `node bin/taskplane.mjs doctor`
-
----
-
-## 3) Update changelog
-
-Update `CHANGELOG.md` with release notes.
-
-Use Keep a Changelog style sections:
-
-- Added
-- Changed
-- Fixed
-- Removed
-
----
-
-## 4) Bump version
+CLI smoke:
 
 ```bash
-npm version patch   # or minor / major
+node bin/taskplane.mjs help
+node bin/taskplane.mjs doctor
 ```
 
-This updates `package.json`, creates a git commit, and creates a git tag.
-
----
-
-## 5) Publish
+### 3) Create the release branch and update CHANGELOG
 
 ```bash
-npm publish
+git switch -c release/v<version>
 ```
 
-For pre-release channel:
+Edit `CHANGELOG.md`:
+
+- Rename the existing `## [Unreleased]` section to `## [<version>] - <YYYY-MM-DD>`
+- Insert a fresh empty `## [Unreleased]` placeholder above it
+- Add `Fixed` entries for any hotfixes that landed on `main` after the last
+  `[Unreleased]` write but before the version bump
+- Use Keep a Changelog style sections in this order: Breaking, New, Enhanced,
+  Fixed, Docs, Internal (only sections that have entries)
+
+The release workflow extracts notes from this section verbatim — write it
+operator-readable, not as raw commit titles.
+
+### 4) Bump version and create the local tag
 
 ```bash
-npm publish --tag beta
+npm version patch    # or minor / major
 ```
 
----
+This:
 
-## 6) Push commit and tags
+- Updates `package.json` and `package-lock.json`
+- Creates a git commit titled `<version>` (e.g., `0.29.0`)
+- Creates a local git tag `v<version>` pointing at that commit
+
+**Don't push the tag yet.** The tag has to wait until the release PR is merged
+into `main` so it points at a commit reachable from `main`.
+
+### 5) Push the release branch and open the release PR
 
 ```bash
-git push
-git push --tags
+git push -u origin release/v<version>
 ```
-
----
-
-## 7) Create GitHub Release
-
-After tags are pushed, create a GitHub Release for the same tag/version.
-
-Example:
 
 ```bash
-gh release create v<version> \
-  --title "v<version>" \
-  --notes-file CHANGELOG.md
+gh pr create --base main \
+             --head release/v<version> \
+             --title "release: v<version> — <summary>" \
+             --body-file <release-body.md>
 ```
 
-Or create it in the GitHub UI and paste release notes from `CHANGELOG.md`.
+The PR body should:
 
----
+- Justify the version bump (patch / minor / major) per semver
+- List issues closed in this release
+- Summarize highlights (features, fixes, internal changes)
+- Note validation results (tests, smoke, polyrepo if applicable)
+- Reference the tag-push step that follows the merge
 
-## 8) Post-release verification
+### 6) Wait for CI green, then merge the release PR
 
-Verify published metadata:
+Monitor:
+
+```bash
+gh pr view <num> --json statusCheckRollup
+```
+
+Once green, merge **with `--merge` (NOT `--squash` or `--rebase`)**:
+
+```bash
+gh pr merge <num> --merge --delete-branch
+```
+
+Why `--merge` matters: the local tag created in step 4 points at the
+version-bump commit's SHA. `--squash` and `--rebase` rewrite that commit's
+SHA, which would orphan the tag. `--merge` preserves the original commit
+under a merge commit on `main`, so the tag still resolves correctly.
+
+### 7) Sync local main, then push the tag
+
+```bash
+git switch main && git pull --ff-only
+git push origin v<version>
+```
+
+This tag push is what triggers the release workflow. Monitor with:
+
+```bash
+gh run list --workflow=release.yml --limit 1 --json databaseId,status
+gh run view <run-id> --log         # if you want full logs
+```
+
+The workflow typically completes in 30–60 seconds.
+
+### 8) Verify
 
 ```bash
 npm view taskplane version
-npm view taskplane versions --json
 ```
 
-Verify GitHub release/tag:
+Allow ~10–15 seconds for the npm registry to propagate. If it returns the
+old version or empty, retry.
 
 ```bash
 gh release view v<version>
-git tag --list | grep "^v<version>$"
 ```
 
-Sanity install in scratch project:
+Should show the GitHub release with notes from `CHANGELOG.md`.
+
+Optional sanity install in scratch project:
 
 ```bash
 pi install -l npm:taskplane
-npx taskplane version
+npx taskplane --version
 ```
 
 ---
 
-## Recommended release checklist
+## What NOT to do
 
-- [ ] Tests pass
-- [ ] Changelog updated
-- [ ] Version bumped
-- [ ] `npm pack --dry-run` reviewed
-- [ ] Published successfully
-- [ ] Tag pushed
-- [ ] GitHub release created for the same tag/version
-- [ ] Install smoke test passed
+- **Do not** run `npm publish` locally. The workflow does it. Local publish
+  bypasses tag↔version validation, the test re-run, and provenance
+  attestation. It also can't use OIDC.
+- **Do not** create the GitHub release manually with `gh release create`. The
+  workflow does it with notes from `CHANGELOG.md`. A manual release would
+  either conflict with or duplicate the workflow's release.
+- **Do not** push the tag before the release PR is merged into `main`. The
+  tag must point at a commit that's reachable from `main` — otherwise the
+  release references an orphan commit.
+- **Do not** use `--squash` or `--rebase` to merge the release PR. They
+  rewrite the version-bump commit's SHA, orphaning your local tag.
+
+---
+
+## If the workflow fails
+
+Inspect:
+
+```bash
+gh run view <run-id> --log-failed
+```
+
+Common causes and fixes:
+
+| Cause | Fix |
+|---|---|
+| Tag/version drift (tag is `v0.29.0`, but `package.json` says `0.28.8`) | Delete the tag, re-bump correctly: `git tag -d v<version>; git push --delete origin v<version>; npm version <bump>; git push --follow-tags` |
+| Test failure on the re-run | Investigate the failure. CI on the PR was green, so the failure is either flaky-test or environment-difference. Re-trigger via Actions UI `workflow_dispatch` with the same tag input. |
+| npm registry hiccup (timeout, transient 5xx) | Re-trigger via Actions UI `workflow_dispatch`. The workflow is idempotent on retry — npm rejects republish of an existing version, but the GitHub release step uses `gh release create --notes-file ...` which is safe to re-run (it errors if the release already exists; manual fix is to delete the existing release first). |
+| OIDC token rejected by npm | Check the trusted-publisher config at <https://www.npmjs.com/package/taskplane/access>. The repo / workflow filename must match exactly (`HenryLach/taskplane` and `release.yml`). |
+
+---
+
+## Pre-release tags (beta / rc)
+
+The workflow doesn't currently special-case `--tag beta` or rc/alpha versions.
+For now, pre-release publishing is manual:
+
+```bash
+npm version prerelease --preid=beta    # e.g., 0.30.0-beta.0
+npm publish --tag beta
+```
+
+If pre-releases become regular, extend `release.yml` to read a dist-tag from
+the version string (e.g., publish under `--tag beta` if the version contains
+a `-` qualifier).
+
+---
+
+## Pre-release checklist
+
+- [ ] `main` is clean and synced
+- [ ] All content PRs that should ship are merged
+- [ ] Tests pass: `cd extensions && npm run test:fast`
+- [ ] CLI smoke: `node bin/taskplane.mjs help` and `node bin/taskplane.mjs doctor`
+- [ ] `npm pack --dry-run` reviewed (only intended files ship)
+- [ ] Hotfix scan: any commits on `main` since last `[Unreleased]` write that need entries?
+
+## Post-release checklist
+
+- [ ] `npm view taskplane version` reports the new version
+- [ ] `gh release view v<version>` shows the GitHub release with proper notes
+- [ ] Workflow run completed successfully (`gh run list --workflow=release.yml --limit 1`)
+- [ ] Optional install smoke test passed
 
 ---
 
 ## Notes
 
 - Taskplane currently ships as a single package.
-- `package.json#files` controls published file whitelist.
+- `package.json#files` controls the published file whitelist.
 - Keep templates generic and public-safe before publishing.
+- Trusted Publishing was set up in PRs #536 / #544 / #545 (the v0.28.5 release
+  cycle). Before that, releases used a manual `npm publish` against an `NPM_TOKEN`
+  secret. The workflow has been used continuously since v0.28.5 with no failures.

--- a/docs/maintainers/release-process.md
+++ b/docs/maintainers/release-process.md
@@ -102,6 +102,42 @@ node bin/taskplane.mjs help
 node bin/taskplane.mjs doctor
 ```
 
+#### Optional but strongly recommended: end-to-end smoke via local-build
+
+For releases that touch runtime behavior unit tests can't fully exercise
+— IPC handlers, path resolution, dashboard rendering, lane state machine,
+spawn-time error paths, mailbox / outbox semantics — deploy the merged
+`main` branch into your global npm install and exercise the changes in a
+real consumer project before tagging.
+
+From the project root:
+
+```bash
+node scripts/local-build.mjs
+```
+
+Options: `--force` (full copy ignoring mtime), `--dry` (preview only).
+After running, restart pi to load the new code.
+
+Then exercise the changes in a real consumer project. For polyrepo work,
+the 3-repo test workspace at `C:/dev/tp-test-workspace` (set up via the
+`polyrepo-smoke-test` skill) is the canonical pre-release verification
+— it shakes out cross-repo merge orchestration, lane allocation, and the
+full recovery-flow surface in a way that single-repo unit tests cannot.
+
+**Why this step is recommended even when the test suite is green:** it
+caught #559 (orchestrator IPC crash on first frame) and #560 (Pi
+`@earendil-works` rename break) before they shipped in v0.29.0. Both
+bugs passed every CI gate (3587 tests + Biome + smoke checks) but failed
+deterministically in real polyrepo workspaces. The classes of regression
+that slip past unit tests — module resolution, IPC closure scope,
+spawn-time errors, dashboard render keyed off live runtime state — are
+the exact classes that local-build + polyrepo smoke will catch.
+
+Skip this step only when the release is documentation-only or touches
+surfaces that are fully exercised by automated tests (e.g., pure
+refactors with no behavioral change). When in doubt, run it.
+
 ### 3) Create the release branch and update CHANGELOG
 
 ```bash
@@ -274,6 +310,9 @@ a `-` qualifier).
 - [ ] CLI smoke: `node bin/taskplane.mjs help` and `node bin/taskplane.mjs doctor`
 - [ ] `npm pack --dry-run` reviewed (only intended files ship)
 - [ ] Hotfix scan: any commits on `main` since last `[Unreleased]` write that need entries?
+- [ ] **Local-build + polyrepo smoke run** (strongly recommended for any release
+      that touches runtime behavior — IPC, path resolution, dashboard,
+      lane state machine, spawn paths, mailbox semantics)
 
 ## Post-release checklist
 

--- a/docs/specifications/cli/NPM-PUBLISHING.md
+++ b/docs/specifications/cli/NPM-PUBLISHING.md
@@ -1,5 +1,21 @@
 # NPM Publishing Guide for Taskplane
 
+> ### ⚠️ This document is historical / educational only.
+>
+> Taskplane releases are now **automated** via
+> [`.github/workflows/release.yml`](../../../.github/workflows/release.yml)
+> using [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers)
+> (OIDC, no `NPM_TOKEN` secret). Pushing a `v*` tag triggers the workflow,
+> which publishes to npm AND creates the GitHub release.
+>
+> **The canonical maintainer guide is** [`docs/maintainers/release-process.md`](../../maintainers/release-process.md).
+> Read that one when you actually need to cut a release. This document is kept
+> for the npm-fundamentals background it provides (registry mechanics, semver
+> reasoning, dist-tags, scoping) — but its concrete `npm publish` /
+> `npm login` instructions are no longer the operative flow and would bypass
+> tag↔version validation, provenance attestation, and the automated GitHub
+> release.
+
 > **Audience:** Taskplane maintainers  
 > **Prerequisites:** Node.js ≥ 20, git, a terminal  
 > **Related:** [CLI-SPEC.md](CLI-SPEC.md) — package structure and distribution model


### PR DESCRIPTION
Documents the actual release flow used for v0.28.5 → v0.29.0 (5 consecutive releases via tag-push to `.github/workflows/release.yml`). The previous docs described the legacy manual flow (`npm publish` locally, `gh release create` manually) which is no longer the operative path.

## Why this matters

Stale instructions in `AGENTS.md` are particularly risky because future AI sessions read it as their north star. An agent following the OLD sequence would:

1. Run `npm publish` locally → bypasses tag↔version validation, the test re-run, and provenance attestation
2. Run `gh release create` manually → either conflicts with the workflow's release or duplicates it
3. Use `--squash` or `--rebase` to merge the release PR → orphans the local tag (rewrites the version-bump commit's SHA)
4. Push the tag before the PR merges → tag references an unreachable commit

Updating these docs prevents that next-session footgun.

## Files

| File | Change |
|---|---|
| `AGENTS.md` | Full rewrite of `### Default release sequence` (8 steps now match the actual flow). Adds `What NOT to do` and `If the workflow fails` sections. Documents the OIDC / Trusted Publishing auth model. |
| `docs/maintainers/release-process.md` | Full rewrite. Adds "How automation works" section, mirrors AGENTS.md sequence, adds pre-release tag (beta/rc) note, cross-references the workflow file. |
| `docs/specifications/cli/NPM-PUBLISHING.md` | Banner at top redirecting to canonical guide. Body kept for npm-fundamentals background (registry mechanics, semver, dist-tags) but flagged as no-longer-operative for actual releases. |

## Validation

Pure docs change. No code, no tests, no version bump. CI (Biome lint + tests) should pass on main's pre-existing test suite as-is.