### PR TITLE
release: v0.29.1 — Runtime V2 spawn failure visibility (#561)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.1] - 2026-05-10
+
 ### Fixed
 
 - **Runtime V2 spawn failures now visible (TP-190, #561):** Previously,
@@ -44,6 +46,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `extensions/tests/spawn-failure-visibility.test.ts`; full fast suite
   3620 pass / 1 skipped / 0 failed (+33 from baseline 3587);
   cross-platform Node 24 CI.
+
+  **Sage post-merge fold:** two important correctness issues caught by
+  sage's review of the merged TP-190 work, both folded before public
+  release. (a) **Residual hang on snapshot-write failure**: the spawn-
+  failure catch's `writeLaneSnapshot()` is best-effort, but the original
+  comment claimed a 30-second staleness fallback would recover — not
+  true when `snap == null` (no file at all), because `snap?.updatedAt`
+  is `undefined` so `staleMs == 0` and the 30-second check never fires.
+  Snapshot-write failure (disk full, permission, transient I/O) would
+  have left `sessionAlive = true` indefinitely, reintroducing the same
+  #561 hang. Fix: added a null-snapshot tracker-age fallback in
+  `resolveTaskMonitorState` — when `snap == null` AND the tracker has
+  observed the task for ≥ 60s (past startup grace), consult the
+  registry liveness check instead of defaulting to alive. (b)
+  **Multi-segment edge in `isAllLanesSpawnFailedWave`**: the
+  `succeededTaskIds.length !== 0` gate was the *terminal* completion
+  projection, populated only when a multi-segment task reaches its
+  final segment. A wave with a multi-segment task succeeding on
+  segment 1 (with continuation scheduled) plus a single-segment task
+  spawn-failing would have falsely tripped phase=failed, burying real
+  progress. Fix: the helper now optionally accepts `laneResults` and
+  scans per-task outcomes for any `status === "succeeded"`. 4 new
+  sage-fold tests in `spawn-failure-visibility.test.ts` cover both
+  edge cases. Final test count: 3624 passing (+4 over the 3620
+  worker-batch baseline).
+
+  **Polyrepo end-to-end verified by operator** in
+  `C:/dev/tp-test-workspace`. The bug class that previously left
+  lanes silently "running" forever now surfaces immediately as a
+  visible failure with a meaningful `phase=failed` and `task-failure`
+  IPC alert.
 
 ## [0.29.0] - 2026-05-09
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.29.0",
+      "version": "0.29.1",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.29.0",
+  "version": "0.29.1",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Patch release for TP-190 (issue #561). Bug-fix only.

## What ships

**TP-190 / #561** — Runtime V2 spawn failures now surface as failed lanes instead of leaving the orchestrator polling indefinitely with green/running lane indicators.

Four-part fix:
1. State-transition wiring (synthetic terminal lane snapshot + new `spawn_failure` ExitClassification)
2. No-retry policy (`spawn_failure` excluded from tier-0 retry budget)
3. Phase transition (all-lanes-spawn-failed → `phase = "failed"`)
4. Behavioral regression test (823 LOC, 37 cases including 4 sage-fold edge cases)

Plus sage post-merge fold (commit `f232913b`):
- Residual hang on snapshot-write failure → null-snapshot tracker-age fallback in `resolveTaskMonitorState`
- Multi-segment edge case in `isAllLanesSpawnFailedWave` → laneResults scan for any per-task success

## Validation

- **Tests:** 3624 passing / 1 skipped / 0 failed (Windows local Node 24.15.0)
- **CI:** ✅ green on the merge commit
- **Polyrepo end-to-end:** ✅ verified by operator on a 6-wave multi-repo batch in `tp-test-workspace`

## Issues closed

- #561 — Runtime V2 lane spawn errors are silent

## Tag

`v0.29.1` will be pushed AFTER this PR merges. `--merge` mode preserves the version-bump commit so the tag references it correctly.