### PR TITLE
release: v0.29.2 — peerDependencies → @earendil-works/* (kill npm deprecation warnings on pi update)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.2] - 2026-05-10
+
+### Internal
+
+- **Migrate `peerDependencies` from `@mariozechner/*` to `@earendil-works/*` and mark them optional:** every `pi update` was printing four `npm warn deprecated` lines (one for each `@mariozechner/pi-*` package the new pi packages tell npm they are deprecating). Pi v0.74.0+ ships under the `@earendil-works` scope; the legacy `@mariozechner` peer-dep entries in taskplane's `package.json` made npm resolve the deprecated packages and surface the warnings on every install. Fix: switch the four pi-related entries in `peerDependencies` to `@earendil-works/pi-coding-agent`, `@earendil-works/pi-tui`, `@earendil-works/pi-ai` (kept `@sinclair/typebox` unchanged — not pi-managed); add a `peerDependenciesMeta` block marking all three pi packages `optional: true` so npm doesn't generate unmet-peer warnings for users in transitional setups, and so we don't tell users they MUST have pi globally installed at npm-install time (pi is the runtime, not a strict install-time peer).
+
+  **No source-code changes.** The `import` statements in `extensions/*.ts` continue to reference `@mariozechner/*` because Pi's runtime extension loader (`<pi>/dist/core/extensions/loader.js`) bundles aliases for BOTH scopes — imports resolve identically regardless of which scope name is used. Changing the import statements would break compat for users still on Pi < v0.74.0 (the alias map was added in v0.74.0). The `peerDependencies` declaration is informational only; the runtime resolution is unaffected by either approach.
+
+  **No tests changed; no behavior changed.** Tests pass at the v0.29.1 baseline (3624 passing / 1 skipped / 0 failed).
+
 ## [0.29.1] - 2026-05-10
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",
@@ -41,9 +41,15 @@
     "@sinclair/typebox": "*"
   },
   "peerDependenciesMeta": {
-    "@earendil-works/pi-coding-agent": { "optional": true },
-    "@earendil-works/pi-tui": { "optional": true },
-    "@earendil-works/pi-ai": { "optional": true }
+    "@earendil-works/pi-coding-agent": {
+      "optional": true
+    },
+    "@earendil-works/pi-tui": {
+      "optional": true
+    },
+    "@earendil-works/pi-ai": {
+      "optional": true
+    }
   },
   "dependencies": {
     "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -35,10 +35,15 @@
     "templates/"
   ],
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
-    "@mariozechner/pi-tui": "*",
-    "@mariozechner/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
+    "@earendil-works/pi-ai": "*",
     "@sinclair/typebox": "*"
+  },
+  "peerDependenciesMeta": {
+    "@earendil-works/pi-coding-agent": { "optional": true },
+    "@earendil-works/pi-tui": { "optional": true },
+    "@earendil-works/pi-ai": { "optional": true }
   },
   "dependencies": {
     "jiti": "^2.6.1",


### PR DESCRIPTION
Patch release. Tiny package.json cleanup that eliminates the four `npm warn deprecated` lines every `pi update` was printing.

## Why minor not patch?

This IS a patch. No new features, no behavior changes, just a package.json cleanup so npm stops shouting about deprecated peer-deps.

## What ships

**Internal:** `peerDependencies` migrated from `@mariozechner/pi-coding-agent`, `@mariozechner/pi-tui`, `@mariozechner/pi-ai` to their `@earendil-works/*` equivalents. New `peerDependenciesMeta` marks all three as `optional: true`.

**Not changed:**
- Source-code imports in `extensions/*.ts` keep referencing `@mariozechner/*` (Pi's runtime extension loader bundles aliases for both scopes; changing imports would break compat for users on Pi < v0.74.0)
- `@sinclair/typebox` peerDep stays as-is (not pi-managed)
- No tests, no behavior, no version-bumped functionality

## Validation

- **Tests:** 3624 passing / 1 skipped / 0 failed (unchanged from v0.29.1 baseline)
- **`npm pack --dry-run`:** 77 files, 665 kB — clean
- **CLI smoke:** `taskplane help` + `taskplane doctor` clean (`pi installed (0.74.0)` confirmed working)
- **Manual trial install (post-merge):** every `pi update` from this point should print zero `npm warn deprecated` lines for the pi packages

## Tag

`v0.29.2` will be pushed AFTER this PR merges. `--merge` mode preserves the version-bump commit so the tag references it correctly.