### PR TITLE
release: v0.30.0 — Code-quality gates (TP-191..195) + 0.29.x carryover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0] - 2026-05-10
+
 ### Fixed
 
 - **Preflight cleanup feature now actually runs (TP-195):** `runOrchBatch`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.29.2",
+      "version": "0.30.0",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
**Minor release** capping the entire code-quality-gates sequence — the moment Taskplane graduates to enforcing typecheck, lint, and format:check at PR time.

## Why minor (not patch)

- **Observable CI surface change** — `continue-on-error: true` removed from lint; `Typecheck` and `Format check (Biome)` added as required steps. Anyone watching the repo sees the quality bar move.
- **Behavior changes from TP-195 bug fixes** — three real bugs uncovered by typecheck cleanup are now fixed:
  - Preflight cleanup Layers 2-5 now actually run (silently broken since TP-065)
  - `max_worker_minutes` config now honored (was silently ignored due to camelCase typo)
  - Resume-path failure alerts now carry segment metadata (was always blank due to non-existent-field lookup)
- **New `lint:fix` script** in `package.json` (DX-positive bonus from TP-194)

Per semver, these warrant a minor bump (0.29.x → 0.30.0).

## What ships

### Code-quality gates (the headline)
- **TP-191** Prep: scripts (`typecheck` / `lint` / `format` / `format:check` / `lint:fix`), pinned dev deps (Biome 2.4.15, TypeScript 5.6.3, @types/node), `pi-shims.d.ts` for both `@earendil-works/*` and `@mariozechner/*` scopes, `tsconfig.ci.json`, modernized `biome.json` (deprecated `experimentalScannerIgnores` migrated)
- **TP-192** Lint cleanup: 9 Biome errors fixed cleanly (`noRedeclare` ×2, `noImplicitAnyLet` ×5, `noControlCharactersInRegex` ×1, `noUnsafeFinally` ×1) — no `biome-ignore` suppressions
- **TP-193** Format adoption: `biome format --write` applied across 166 files; `.git-blame-ignore-revs` preserves blame archaeology; `.gitattributes` enforces LF line endings on all platforms (Windows `core.autocrlf` was masking format consistency)
- **TP-195** Typecheck cleanup: 264 errors → 0 across runtime source + tests; introduced `makeOrchestratorConfig()` / `makeTaskRunnerConfig()` test helpers; pi-shim extended for typed `ui.custom<T>()`. Plus the 3 bug fixes called out above.
- **TP-194** Gate flip: `continue-on-error: true` removed; `Typecheck` + `Format check (Biome)` added as required CI steps; TP-188 reviewer-agent quality-check downgrade rule now unconditional; documentation augmented across AGENTS.md / release-process.md / development-setup.md.

### Carried over from 0.29.x [Unreleased]
- **#560 + TP-190 / #561 (already shipped as v0.29.1)** spawn-failure visibility + scope-tolerant Pi CLI resolution
- **v0.29.2 peerDependencies migration** to `@earendil-works/*` with `peerDependenciesMeta.optional` (kills npm deprecation warnings on `pi update`)

### Spec
- `docs/specifications/taskplane/code-quality-gates.md` — full 5-packet design rationale, sage review consultation summary, Tier-2 deferred items (coverage, pre-commit hooks, etc.) explicitly tracked

## Validation

- **Tests:** 3627 passing / 1 skipped / 0 failed (Windows local Node 24.15.0)
- **Typecheck:** exit 0 (TP-195 drove 264 → 0)
- **Lint:** exit 0 (TP-192 drove 9 errors → 0)
- **Format check:** exit 0 (TP-193 applied formatter universally)
- **Polyrepo end-to-end:** ✅ verified by operator on real workspace post-TP-195 (the 3 bug fixes don't regress polyrepo flows)
- **All 5 packets merged in sequence:** TP-191 → TP-192 → TP-193 → TP-195 → TP-194
- **2 sage post-merge folds applied:** TP-193's slice-window-bump + .gitattributes line-endings, TP-195's behavior-change risk assessment
- **This release PR runs under the NEW hard gates** — first PR ever to be enforced by typecheck + lint + format:check at PR time

## Issues closed

(none directly — this release bundles infrastructure work; the bug-fix issues from prior code-quality work plus #559/#560/#561 from TP-187/188/189/190 are already closed in their respective patch releases)

## Tag

`v0.30.0` will be pushed AFTER this PR merges. Use `--merge` mode to preserve the version-bump commit so the tag references it correctly.