### PR TITLE
release: v0.30.1 — TP-196 segment-engine hardening + TP-197 dashboard segment indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.1] - 2026-05-11
+
 ### Enhanced
 
 - **Dashboard segment-level progress indicators (TP-197, #464):** Multi-segment

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Patch release. Bundles two segment-related task packets + three post-merge folds caught during operator polyrepo testing.

## What ships

### TP-196 — Multi-segment engine hardening
Closes **#462, #502, #503, #508** in one coherent hardening pass:
- **#502** SegmentScopeMode promoted to first-class type; gates env vars, tool registration, and execution branches on one flag (was scattered conditions)
- **#462** Three defense-in-depth `.DONE` guards: monitor (resolveTaskMonitorState), resume (collectDoneTaskIdsForResume), discovery (sanity warning) — prevent premature task completion in non-final-segment edge cases
- **#508** Early-exit optimization: lane-runner pre-spawn segment-completion check skips wasted iteration when checkboxes are already done
- **#503** 855-LOC regression test file locks down SegmentScopeMode prompt-injection (FULL_TASK / SEGMENT_SCOPED / single-segment polyrepo / legacy fallback)

### TP-197 — Dashboard segment-level progress indicators
Closes **#464**:
- Per-segment status pills (✅ done / ⏳ active / ⬚ pending) in lane rows
- Segment-aware progress bar reflects current segment progress
- Single-segment / single-repo tasks render IDENTICALLY to pre-TP-197

### 3 post-merge folds caught during operator polyrepo testing
1. **CSS grid-layout opt-in via `.has-segments` class** — sage caught that the in-batch implementation changed `.task-row` to a 3-row grid unconditionally, adding 8px phantom row-gap for non-segmented tasks
2. **Wave-chip lane parallelization across all waves** — user observed the `|` (parallel) / `→` (serial) separators flickering as active wave changed. Fix derives from `batch.tasks[].laneNumber` (persisted) with sentinel-0 handling for pending tasks
3. **Merge-agents panel cleanup** — removed dead SESSION ID + DETAILS columns (always `—`) and bumped header contrast from `--text-faint` to `--text-muted`

## Validation

| Gate | Result |
|---|---|
| `npm run typecheck` | exit 0 |
| `npm run lint` | exit 0 / 286 warnings / 671 infos |
| `npm run format:check` | exit 0 |
| `npm run test:fast` | **3703 passing** / 1 skipped / 0 failed (+76 from v0.30.0 baseline 3627) |
| **Second release under post-TP-194 hard gates** | ✅ All four gates required at PR time, all green |

## Polyrepo verification

Operator ran live polyrepo tests during PR review and caught all three folds via the actual dashboard. This is the testing pattern paying compounding dividends — code-quality gates catch the static-analysis class of bugs; polyrepo testing catches the rendering/UX/state class of bugs that unit tests can't fully exercise.

## Issues closed

- #462 — Harden `.DONE` authority for multi-segment tasks
- #464 — Dashboard segment-level progress indicators
- #502 — SegmentScopeMode single enum gating all signals
- #503 — Regression tests for SegmentScopeMode prompt injection
- #508 — Lane-runner segment completion check before respawn

## Tag

`v0.30.1` will be pushed AFTER this PR merges. `--merge` mode preserves the version-bump commit so the tag references it correctly.