### PR TITLE
chore: ignore .claude/ and .sage-tmp/ scratch directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Thumbs.db
 .vscode/
 .idea/
 .claude/
+.sage-tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Thumbs.db
 *~
 .vscode/
 .idea/
+.claude/


### PR DESCRIPTION
Adds two local-only scratch directories to `.gitignore`:

- **`.claude/`** — Claude Code IDE config (`settings.json`, `settings.local.json`)
- **`.sage-tmp/`** — Sage consultation scratch (patches, source snapshots passed as context)

Both were showing up as untracked directories on every `git status`. Neither should be tracked.

Drive-by housekeeping while working on #580. Trivial — no runtime impact.