### PR TITLE
docs: extend intro-video visuals with pages 13-17

### DIFF
--- a/docs/video/visuals/08-waves-lanes-worktrees.html
+++ b/docs/video/visuals/08-waves-lanes-worktrees.html
@@ -166,10 +166,6 @@
     border-radius: 3px;
     font-size: var(--fs-sm);
   }
-  /* Let the subtitle span the full frame width instead of the shared 820px cap. */
-  .subtitle {
-    max-width: 100%;
-  }
 </style>
 </head>
 <body>

--- a/docs/video/visuals/12-dashboard-visibility.html
+++ b/docs/video/visuals/12-dashboard-visibility.html
@@ -197,10 +197,6 @@
     color: var(--text-dim);
   }
   .footer .hl { color: var(--green); }
-  /* Let the subtitle span the full frame width instead of the shared 820px cap. */
-  .subtitle {
-    max-width: 100%;
-  }
 </style>
 </head>
 <body>
@@ -210,7 +206,7 @@
       <nav class="page-nav" aria-label="Page navigation">
         <a href="11-polyrepo-segments.html" aria-label="Previous">&larr;</a>
         <a href="index.html" aria-label="Index">&#9675;</a>
-        <span class="disabled" aria-label="Next (none)">&rarr;</span>
+        <a href="13-why-pi.html" aria-label="Next">&rarr;</a>
       </nav>
     </div>
     <h1>Why a web dashboard, not a CLI</h1>

--- a/docs/video/visuals/13-why-pi.html
+++ b/docs/video/visuals/13-why-pi.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>V13 — Why pi</title>
+<link rel="stylesheet" href="_shared.css">
+<style>
+  .reasons {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 24px;
+    margin-bottom: 40px;
+  }
+  .reason {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 28px 26px;
+    border-top: 3px solid currentColor;
+    display: flex;
+    flex-direction: column;
+  }
+  .reason.r1 { color: var(--green); }
+  .reason.r2 { color: var(--blue); }
+  .reason.r3 { color: var(--amber); }
+  .reason-num {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    margin-bottom: 10px;
+    color: currentColor;
+  }
+  .reason-title {
+    font-family: var(--mono);
+    font-size: var(--fs-2xl);
+    color: var(--text);
+    margin-bottom: 8px;
+    font-weight: 600;
+  }
+  .reason-tagline {
+    font-size: var(--fs-lg);
+    color: var(--text-dim);
+    margin-bottom: 20px;
+    line-height: 1.45;
+  }
+  .reason-body {
+    font-size: var(--fs-md);
+    color: var(--text-dim);
+    line-height: 1.65;
+    margin-bottom: 22px;
+    flex: 1;
+  }
+  .reason-tag {
+    margin-top: auto;
+    padding: 14px 16px;
+    background: var(--surface-2);
+    border-left: 3px solid currentColor;
+    border-radius: 4px;
+    font-family: var(--mono);
+    font-size: var(--fs-sm);
+    color: var(--text);
+    line-height: 1.6;
+  }
+  .reason-tag .lk {
+    display: block;
+    color: currentColor;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: var(--fs-xs);
+    margin-bottom: 6px;
+  }
+  .closing {
+    padding: 22px 26px;
+    background: var(--surface-2);
+    border: 1px dashed var(--border);
+    border-radius: 8px;
+    font-family: var(--mono);
+    font-size: var(--fs-md);
+    color: var(--text-dim);
+    text-align: center;
+    line-height: 1.65;
+  }
+  .closing .hl-g { color: var(--green); }
+  .closing .hl-b { color: var(--blue); }
+  .closing .hl-a { color: var(--amber); }
+</style>
+</head>
+<body>
+  <div class="frame">
+    <div class="eyebrow">
+      <span>13 · The foundation</span>
+      <nav class="page-nav" aria-label="Page navigation">
+        <a href="12-dashboard-visibility.html" aria-label="Previous">&larr;</a>
+        <a href="index.html" aria-label="Index">&#9675;</a>
+        <a href="14-pi-capabilities.html" aria-label="Next">&rarr;</a>
+      </nav>
+    </div>
+    <h1>Why pi?</h1>
+    <p class="subtitle">Taskplane runs on top of pi. Three properties made it the obvious foundation — the same three properties that let other projects (like OpenClaw) build very different agents on the same base.</p>
+
+    <div class="reasons">
+      <div class="reason r1">
+        <div class="reason-num">01 · what won me over</div>
+        <div class="reason-title">Truly extensible</div>
+        <div class="reason-tagline">Build whatever you want on top of pi. The runtime that powers Taskplane is just one possible build.</div>
+        <div class="reason-body">pi is extension-first. Extensions register commands, tools, and behaviors. Nothing is hardcoded that you can't replace. The same architecture that lets OpenClaw layer its own agent on top is what lets Taskplane add an entire orchestration engine — without forking pi.</div>
+        <div class="reason-tag">
+          <span class="lk">For Taskplane</span>
+          /orch* commands, the review_step + wait_for_review tools, mailbox handlers, agent spawning — all live in extensions/taskplane/*. Upgrades flow through pi update with zero rewrites.
+        </div>
+      </div>
+
+      <div class="reason r2">
+        <div class="reason-num">02 · the deal-maker</div>
+        <div class="reason-title">Model agnostic</div>
+        <div class="reason-tagline">Anthropic, OpenAI, Bedrock, Vertex, Gemini, local Ollama — pi treats them the same. Swap any agent's model with a string.</div>
+        <div class="reason-body">Provider abstraction is built in. Models are configured per agent as <code>provider/model-name</code> strings. No SDK glue code, no routing layer, no fork-per-vendor. Per agent, per task, per command — different models can light up the same execution path.</div>
+        <div class="reason-tag">
+          <span class="lk">For Taskplane</span>
+          Cross-model reviews are non-negotiable. Worker on Opus, reviewer on GPT, merger on a third. Without pi's abstraction this means writing three SDK adapters and an in-house routing layer — and maintaining it.
+        </div>
+      </div>
+
+      <div class="reason r3">
+        <div class="reason-num">03 · the ethos match</div>
+        <div class="reason-title">Open source</div>
+        <div class="reason-tagline">MIT-licensed. The whole stack is inspectable. The only cost is your token bill.</div>
+        <div class="reason-body">No SaaS layer. No per-seat fees. No enterprise tier behind a paywall. You bring your own keys, your own machine, your own data. The full source for the agent runtime is right there if you want to read it, fork it, or patch it.</div>
+        <div class="reason-tag">
+          <span class="lk">For Taskplane</span>
+          Taskplane is also open source. The two together cost users nothing beyond tokens. A closed harness on top of an open agent framework would have defeated the point — pi shares the ethos.
+        </div>
+      </div>
+    </div>
+
+    <div class="closing">
+      <span class="hl-g">extensible</span> &nbsp;+&nbsp; <span class="hl-b">model-agnostic</span> &nbsp;+&nbsp; <span class="hl-a">open</span> &nbsp;·&nbsp; the right foundation for what Taskplane needed
+    </div>
+  </div>
+</body>
+</html>

--- a/docs/video/visuals/14-pi-capabilities.html
+++ b/docs/video/visuals/14-pi-capabilities.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>V14 — Pi capabilities</title>
+<link rel="stylesheet" href="_shared.css">
+<style>
+  .capabilities {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 18px;
+    margin-bottom: 32px;
+  }
+  .cap {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 22px;
+    border-top: 3px solid currentColor;
+    display: flex;
+    flex-direction: column;
+  }
+  .cap.c1 { color: var(--green); }
+  .cap.c2 { color: var(--blue); }
+  .cap.c3 { color: var(--amber); }
+  .cap.c4 { color: var(--purple); }
+  .cap.c5 { color: var(--pink); }
+  .cap.c6 { color: var(--red); }
+  .cap-tag {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: currentColor;
+    margin-bottom: 10px;
+  }
+  .cap-title {
+    font-family: var(--mono);
+    font-size: var(--fs-xl);
+    color: var(--text);
+    margin-bottom: 8px;
+    font-weight: 600;
+  }
+  .cap-desc {
+    font-size: var(--fs-md);
+    color: var(--text-dim);
+    line-height: 1.6;
+    margin-bottom: 16px;
+    flex: 1;
+  }
+  .cap-example {
+    font-family: var(--mono);
+    font-size: var(--fs-sm);
+    background: var(--surface-2);
+    padding: 10px 14px;
+    border-radius: 4px;
+    color: var(--text);
+    border-left: 2px solid currentColor;
+    margin-top: auto;
+  }
+  .cap-example .com { color: var(--text-faint); }
+  .cap-example .kw  { color: currentColor; }
+
+  .for-tp-band {
+    padding: 20px 26px;
+    background: var(--surface-2);
+    border: 1px dashed var(--border);
+    border-radius: 8px;
+    font-family: var(--mono);
+    font-size: var(--fs-md);
+    color: var(--text-dim);
+    line-height: 1.7;
+  }
+  .for-tp-band .tag {
+    display: inline-block;
+    color: var(--green);
+    font-size: var(--fs-xs);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    margin-right: 12px;
+    padding: 4px 10px;
+    border: 1px solid var(--green);
+    border-radius: 4px;
+    vertical-align: middle;
+  }
+  .for-tp-band .hl { color: var(--text); }
+</style>
+</head>
+<body>
+  <div class="frame">
+    <div class="eyebrow">
+      <span>14 · The engineering surface</span>
+      <nav class="page-nav" aria-label="Page navigation">
+        <a href="13-why-pi.html" aria-label="Previous">&larr;</a>
+        <a href="index.html" aria-label="Index">&#9675;</a>
+        <a href="15-how-to-get-started.html" aria-label="Next">&rarr;</a>
+      </nav>
+    </div>
+    <h1>What pi actually gives you</h1>
+    <p class="subtitle">Beyond the three big reasons in V13, here's the concrete engineering surface Taskplane builds on. Each of these is a primitive that another agent project could use just as easily.</p>
+
+    <div class="capabilities">
+      <div class="cap c1">
+        <div class="cap-tag">runtime</div>
+        <div class="cap-title">Local-first execution</div>
+        <div class="cap-desc">Runs in your terminal. Your keys, your machine, your filesystem. No cloud service, no telemetry pipeline, no shared backplane. The entire agent loop is observable from your own disk and your own process tree.</div>
+        <div class="cap-example"><span class="com"># install once, run anywhere</span><br><span class="kw">pi install</span> npm:taskplane</div>
+      </div>
+
+      <div class="cap c2">
+        <div class="cap-tag">capability packaging</div>
+        <div class="cap-title">Skills as folders</div>
+        <div class="cap-desc">A "skill" is a folder with a SKILL.md manifest plus any supporting files the agent needs. pi auto-discovers them and exposes them via natural-language triggers. Taskplane's create-taskplane-task skill is one of these — totally portable.</div>
+        <div class="cap-example"><span class="com"># skill = folder + manifest</span><br>skills/create-taskplane-task/<br>&nbsp;&nbsp;<span class="kw">SKILL.md</span></div>
+      </div>
+
+      <div class="cap c3">
+        <div class="cap-tag">extensibility</div>
+        <div class="cap-title">Custom tool registration</div>
+        <div class="cap-desc">Extensions declare tools. Agents call them the same way they call read or write. Taskplane registers review_step, wait_for_review, send_agent_message, broadcast_message, and the entire orch_* family this way.</div>
+        <div class="cap-example"><span class="kw">registerTool</span>(<br>&nbsp;&nbsp;<span class="kw">'review_step'</span>,<br>&nbsp;&nbsp;reviewStepHandler<br>)</div>
+      </div>
+
+      <div class="cap c4">
+        <div class="cap-tag">control plane</div>
+        <div class="cap-title">RPC steering</div>
+        <div class="cap-desc">The steer RPC injects a user-turn message into a running agent's context without killing the session. This is the primitive Taskplane's mailbox layers on top of — and what makes mid-flight course-correction possible at all.</div>
+        <div class="cap-example"><span class="com"># inject mid-conversation</span><br><span class="kw">rpc.steer</span>(session, msg)</div>
+      </div>
+
+      <div class="cap c5">
+        <div class="cap-tag">process model</div>
+        <div class="cap-title">Direct child processes</div>
+        <div class="cap-desc">Agents run as ordinary OS subprocesses of pi. No tmux dependency, no daemon, no message broker. A process registry tracks PIDs and liveness. Worker threads keep the engine non-blocking. Standard OS primitives all the way down.</div>
+        <div class="cap-example"><span class="kw">processRegistry</span><br>&nbsp;&nbsp;.spawn(agent, opts)<br>&nbsp;&nbsp;.track(pid)</div>
+      </div>
+
+      <div class="cap c6">
+        <div class="cap-tag">configurability</div>
+        <div class="cap-title">Composable agent prompts</div>
+        <div class="cap-desc">Every agent role is a markdown file with frontmatter — model, tools, standalone flag. Project-specific guidance composes on top of the base prompts shipped by extensions. Versionable, diff-able, reviewable.</div>
+        <div class="cap-example"><span class="com"># composes with base</span><br>.pi/agents/<br>&nbsp;&nbsp;<span class="kw">task-worker.md</span></div>
+      </div>
+    </div>
+
+    <div class="for-tp-band">
+      <span class="tag">For Taskplane</span>
+      Every primitive on this page maps to something concrete in the orchestration system. Skills give you the task-creation entry point. Custom tools give you reviews. RPC steering gives you the mailbox. Subprocess agents give you parallel lanes. Composable prompts give you the <span class="hl">supervisor / worker / reviewer / merger</span> quartet without forking a thing.
+    </div>
+  </div>
+</body>
+</html>

--- a/docs/video/visuals/15-how-to-get-started.html
+++ b/docs/video/visuals/15-how-to-get-started.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>V15 — Getting started: install and test</title>
+<link rel="stylesheet" href="_shared.css">
+<style>
+  .steps {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 18px;
+    margin-bottom: 0px;
+  }
+  .step {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 22px;
+    border-top: 3px solid currentColor;
+    display: flex;
+    flex-direction: column;
+  }
+  .step.s1 { color: var(--green); }
+  .step.s2 { color: var(--amber); }
+  .step.s3 { color: var(--blue); }
+  .step.s4 { color: var(--purple); }
+  .step.s5 { color: var(--pink); }
+  .step.s6 { color: var(--red); }
+  .step.s7 { color: var(--green); }
+  .step.s8 { color: var(--amber); }
+  .step.s9 { color: var(--blue); }
+
+  .step-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 10px;
+  }
+  .step-num {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: currentColor;
+  }
+  .step-where {
+    font-family: var(--mono);
+    font-size: var(--fs-2xs);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 2px 7px;
+  }
+  .step-title {
+    font-family: var(--mono);
+    font-size: var(--fs-xl);
+    color: var(--text);
+    margin-bottom: 8px;
+    font-weight: 600;
+  }
+  .step-desc {
+    font-size: var(--fs-md);
+    color: var(--text-dim);
+    line-height: 1.6;
+    margin-bottom: 16px;
+    flex: 1;
+  }
+  .step-cmd {
+    font-family: var(--mono);
+    font-size: var(--fs-sm);
+    background: var(--surface-2);
+    padding: 10px 14px;
+    border-radius: 4px;
+    color: var(--text);
+    border-left: 2px solid currentColor;
+    margin-top: auto;
+    line-height: 1.7;
+    overflow-wrap: anywhere;
+  }
+  .step-cmd .prompt { color: var(--text-faint); }
+  .step-cmd .com    { color: var(--text-faint); }
+  .step-cmd .kw     { color: currentColor; }
+  .step-cmd .slash  { color: currentColor; }
+
+  .footer-band {
+    padding: 20px 26px;
+    background: var(--surface-2);
+    border: 1px dashed var(--border);
+    border-radius: 8px;
+    font-family: var(--mono);
+    font-size: var(--fs-md);
+    color: var(--text-dim);
+    line-height: 1.7;
+    text-align: center;
+  }
+  .footer-band .hl-g { color: var(--green); }
+  .footer-band .hl-b { color: var(--blue); }
+  .footer-band .hl-a { color: var(--amber); }
+</style>
+</head>
+<body>
+  <div class="frame">
+    <div class="eyebrow">
+      <span>15 · Your first batch</span>
+      <nav class="page-nav" aria-label="Page navigation">
+        <a href="14-pi-capabilities.html" aria-label="Previous">&larr;</a>
+        <a href="index.html" aria-label="Index">&#9675;</a>
+        <a href="16-real-work-playbook.html" aria-label="Next">&rarr;</a>
+      </nav>
+    </div>
+    <h1>Getting started: install and test</h1>
+    <p class="subtitle">Nine steps from zero to a running orchestrated batch. Everything is local — your machine, your keys, your filesystem. The only ongoing cost is your model token bill.</p>
+
+    <div class="steps">
+      <div class="step s1">
+        <div class="step-head">
+          <div class="step-num">01 · install</div>
+          <div class="step-where">shell</div>
+        </div>
+        <div class="step-title">Get Node and pi</div>
+        <div class="step-desc">Install Node (LTS or newer) however you prefer — mise, nvm, or the official installer — then install pi globally from npm. pi is the agent runtime that hosts Taskplane.</div>
+        <div class="step-cmd"><span class="com"># Node first (any installer)</span><br><span class="prompt">$</span> <span class="kw">npm install -g</span> @earendil-works/pi-coding-agent</div>
+      </div>
+
+      <div class="step s2">
+        <div class="step-head">
+          <div class="step-num">02 · configure</div>
+          <div class="step-where">in pi</div>
+        </div>
+        <div class="step-title">Add a model provider</div>
+        <div class="step-desc">Launch pi and configure at least one provider (two is better) — Anthropic, OpenAI, Bedrock, Vertex, Gemini, or local Ollama. pi will prompt you for keys and save them to your user profile.</div>
+        <div class="step-cmd"><span class="prompt">$</span> <span class="kw">pi</span><br><span class="slash">/providers</span> <span class="com"># add at least one, two if possible</span></div>
+      </div>
+
+      <div class="step s3">
+        <div class="step-head">
+          <div class="step-num">03 · install</div>
+          <div class="step-where">shell</div>
+        </div>
+        <div class="step-title">Install Taskplane</div>
+        <div class="step-desc">Install Taskplane globally so pi can discover it as an extension. From this point on, every pi session in any project has access to <code>/orch</code> and the supervisor agent.</div>
+        <div class="step-cmd"><span class="prompt">$</span> <span class="kw">npm install -g</span> taskplane</div>
+      </div>
+
+      <div class="step s4">
+        <div class="step-head">
+          <div class="step-num">04 · project</div>
+          <div class="step-where">shell</div>
+        </div>
+        <div class="step-title">Make a fresh repo</div>
+        <div class="step-desc">Taskplane needs a git repository — lanes commit to branches and worktrees, so git history is the substrate. An empty new repo is the simplest starting point.</div>
+        <div class="step-cmd"><span class="prompt">$</span> <span class="kw">mkdir</span> my-first-batch<br><span class="prompt">$</span> <span class="kw">cd</span> my-first-batch<br><span class="prompt">$</span> <span class="kw">git init</span></div>
+      </div>
+
+      <div class="step s5">
+        <div class="step-head">
+          <div class="step-num">05 · scaffold</div>
+          <div class="step-where">shell</div>
+        </div>
+        <div class="step-title">Initialize Taskplane</div>
+        <div class="step-desc">Drops project scaffolding: a <code>.pi/</code> directory with config, the supervisor agent prompt, a sample task area, and a starter batch you can run end-to-end without writing a single task by hand.</div>
+        <div class="step-cmd"><span class="prompt">$</span> <span class="kw">taskplane init</span></div>
+      </div>
+
+      <div class="step s6">
+        <div class="step-head">
+          <div class="step-num">06 · verify</div>
+          <div class="step-where">shell</div>
+        </div>
+        <div class="step-title">Run doctor</div>
+        <div class="step-desc">Sanity checks: pi version, Node version, Taskplane install path, providers configured, git repo health, scaffolded files present. Fix anything red before you launch a batch.</div>
+        <div class="step-cmd"><span class="prompt">$</span> <span class="kw">taskplane doctor</span></div>
+      </div>
+
+      <div class="step s7">
+        <div class="step-head">
+          <div class="step-num">07 · review</div>
+          <div class="step-where">in pi</div>
+        </div>
+        <div class="step-title">Set a reviewer model</div>
+        <div class="step-desc">Cross-model review is Taskplane's quality gate. Pick a provider/model different from your worker (e.g. worker on Claude, reviewer on GPT). If you only have one provider, skip — you can revisit anytime.</div>
+        <div class="step-cmd"><span class="prompt">$</span> <span class="kw">pi</span><br><span class="slash">/taskplane-settings</span></div>
+      </div>
+
+      <div class="step s8">
+        <div class="step-head">
+          <div class="step-num">08 · run</div>
+          <div class="step-where">in pi</div>
+        </div>
+        <div class="step-title">Launch the sample batch</div>
+        <div class="step-desc">From inside pi, kick off every task in the sample area. Taskplane discovers the DAG, plans waves, spawns lanes in parallel worktrees, runs reviews, and merges wave by wave — all autonomously.</div>
+        <div class="step-cmd"><span class="slash">/orch</span> all</div>
+      </div>
+
+      <div class="step s9">
+        <div class="step-head">
+          <div class="step-num">09 · watch</div>
+          <div class="step-where">shell</div>
+        </div>
+        <div class="step-title">Open the dashboard</div>
+        <div class="step-desc">In a <em>second</em> terminal, launch the live dashboard. Read-only view over disk: lane progress, merge agents, supervisor events, mailbox traffic. Refreshes via SSE. Cannot lie, cannot decide.</div>
+        <div class="step-cmd"><span class="com"># new terminal, same repo</span><br><span class="prompt">$</span> <span class="kw">taskplane dashboard</span></div>
+      </div>
+    </div>
+
+  </div>
+</body>
+</html>

--- a/docs/video/visuals/16-real-work-playbook.html
+++ b/docs/video/visuals/16-real-work-playbook.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>V16 — How to get started on real work</title>
+<link rel="stylesheet" href="_shared.css">
+<style>
+  .steps {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 18px;
+    margin-bottom: 28px;
+  }
+  .step {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 22px;
+    border-top: 3px solid currentColor;
+    display: flex;
+    flex-direction: column;
+  }
+  .step.s1 { color: var(--green); }
+  .step.s2 { color: var(--amber); }
+  .step.s3 { color: var(--blue); }
+  .step.s4 { color: var(--purple); }
+  .step.s5 { color: var(--green); }   /* the critical step */
+  .step.s6 { color: var(--red); }
+
+  /* The critical step — distinct background + star badge. */
+  .step.critical {
+    background: var(--surface-2);
+    border: 1px solid var(--green);
+    border-top: 3px solid var(--green);
+    box-shadow: 0 0 0 1px rgba(126, 231, 135, 0.15) inset;
+    position: relative;
+  }
+  .step.critical .star-badge {
+    position: absolute;
+    top: -10px;
+    right: 14px;
+    background: var(--green);
+    color: var(--bg);
+    font-family: var(--mono);
+    font-size: var(--fs-2xs);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 3px 9px;
+    border-radius: 4px;
+    font-weight: 600;
+  }
+
+  .step-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 10px;
+  }
+  .step-num {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: currentColor;
+  }
+  .step-where {
+    font-family: var(--mono);
+    font-size: var(--fs-2xs);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 2px 7px;
+  }
+  .step-title {
+    font-family: var(--mono);
+    font-size: var(--fs-xl);
+    color: var(--text);
+    margin-bottom: 6px;
+    font-weight: 600;
+    line-height: 1.25;
+  }
+  .step-tagline {
+    font-size: var(--fs-md);
+    color: currentColor;
+    margin-bottom: 12px;
+    line-height: 1.45;
+    font-style: italic;
+    opacity: 0.95;
+  }
+  .step-desc {
+    font-size: var(--fs-sm);
+    color: var(--text-dim);
+    line-height: 1.6;
+    margin-bottom: 14px;
+    flex: 1;
+  }
+  .step-desc code,
+  .step-cmd code {
+    font-family: var(--mono);
+    background: var(--bg);
+    color: var(--text);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 0.92em;
+  }
+
+  /* Doc-type chips inside step 3. */
+  .doc-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: auto;
+  }
+  .doc-chips .chip {
+    font-family: var(--mono);
+    font-size: var(--fs-2xs);
+    color: var(--text);
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-left: 2px solid currentColor;
+    border-radius: 3px;
+    padding: 4px 8px;
+    letter-spacing: 0.02em;
+  }
+
+  .step-cmd {
+    font-family: var(--mono);
+    font-size: var(--fs-sm);
+    background: var(--bg);
+    padding: 10px 14px;
+    border-radius: 4px;
+    color: var(--text);
+    border-left: 2px solid currentColor;
+    margin-top: auto;
+    line-height: 1.7;
+    overflow-wrap: anywhere;
+  }
+  .step-cmd .prompt { color: var(--text-faint); }
+  .step-cmd .com    { color: var(--text-faint); }
+  .step-cmd .kw     { color: currentColor; }
+  .step-cmd .slash  { color: currentColor; }
+  .step-cmd .nl     { color: var(--text-dim); font-style: italic; }
+
+  /* The critical step gets a heavier callout below the body. */
+  .crit-quote {
+    margin-top: 10px;
+    padding: 12px 14px;
+    background: var(--bg);
+    border-left: 3px solid var(--green);
+    border-radius: 4px;
+    font-family: var(--mono);
+    font-size: var(--fs-sm);
+    color: var(--text);
+    line-height: 1.55;
+  }
+  .crit-quote .lk {
+    display: block;
+    color: var(--green);
+    font-size: var(--fs-2xs);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    margin-bottom: 4px;
+  }
+
+  .footer-band {
+    padding: 20px 26px;
+    background: var(--surface-2);
+    border: 1px dashed var(--border);
+    border-radius: 8px;
+    font-family: var(--mono);
+    font-size: var(--fs-md);
+    color: var(--green);   /* match step 05 critical-callout accent */
+    line-height: 1.7;
+    text-align: center;
+  }
+  .footer-band .hl-g { color: var(--green); }
+  .footer-band .hl-b { color: var(--blue); }
+  .footer-band .hl-a { color: var(--amber); }
+  .footer-band .hl-p { color: var(--purple); }
+</style>
+</head>
+<body>
+  <div class="frame">
+    <div class="eyebrow">
+      <span>16 · Real work</span>
+      <nav class="page-nav" aria-label="Page navigation">
+        <a href="15-how-to-get-started.html" aria-label="Previous">&larr;</a>
+        <a href="index.html" aria-label="Index">&#9675;</a>
+        <a href="17-sage-companion.html" aria-label="Next">&rarr;</a>
+      </nav>
+    </div>
+    <h1>How to get started on real work</h1>
+    <p class="subtitle">Page 15 was the sample batch. Here's the playbook for your own project — where the planning matters more than the running, and the 30 minutes you spend up front decides whether the 8-hour batch produces code you'll keep.</p>
+
+    <div class="steps">
+      <!-- Step 1: write spec -->
+      <div class="step s1">
+        <div class="step-head">
+          <div class="step-num">01 · spec</div>
+          <div class="step-where">in LLM chat</div>
+        </div>
+        <div class="step-title">Start with a spec</div>
+        <div class="step-tagline">Bring rough ideas. Walk out with structured docs.</div>
+        <div class="step-desc">Modern LLMs are excellent at turning handwavy intent into clear specifications tailored for AI coding agents. Keep specs <em>atomic</em>: one concern per document, organized so an agent can pull only what it needs for the task at hand — not the whole corpus on every prompt.</div>
+        <div class="step-cmd"><span class="com"># in your favorite chat UI</span><br><span class="nl">"Turn these notes into spec docs for an AI coding agent."</span></div>
+      </div>
+
+      <!-- Step 2: cross-review spec -->
+      <div class="step s2">
+        <div class="step-head">
+          <div class="step-num">02 · review</div>
+          <div class="step-where">different LLM</div>
+        </div>
+        <div class="step-title">Cross-review the spec</div>
+        <div class="step-tagline">A different model finds different issues. It always finds issues.</div>
+        <div class="step-desc">Hand the draft to a <em>different</em> LLM — if Claude wrote it, ask GPT to critique, or vice versa. Have it flag gaps, ambiguities, contradictions, and missing context. Apply its corrections. <em>Then</em> read it yourself; you'll catch what both models missed. Thirty minutes here saves an 8-hour batch from going sideways.</div>
+        <div class="step-cmd"><span class="nl">"Review this spec for gaps, contradictions,</span><br><span class="nl">and assumptions an AI coding agent would miss."</span></div>
+      </div>
+
+      <!-- Step 3: supporting docs -->
+      <div class="step s3">
+        <div class="step-head">
+          <div class="step-num">03 · context</div>
+          <div class="step-where">editor</div>
+        </div>
+        <div class="step-title">Add supporting docs</div>
+        <div class="step-tagline">Spec is "what to build". These are "how we build here".</div>
+        <div class="step-desc">Around the spec, write the project-context docs every agent will reach for. Keep each focused; agents read selectively when files are well-named and single-purpose.</div>
+        <div class="doc-chips">
+          <span class="chip">tech-stack.md</span>
+          <span class="chip">coding-standards.md</span>
+          <span class="chip">architecture/ADRs</span>
+          <span class="chip">project-structure.md</span>
+          <span class="chip">test-strategy.md</span>
+          <span class="chip">glossary.md</span>
+        </div>
+      </div>
+
+      <!-- Step 4: AGENTS.md -->
+      <div class="step s4">
+        <div class="step-head">
+          <div class="step-num">04 · north star</div>
+          <div class="step-where">editor</div>
+        </div>
+        <div class="step-title">Write AGENTS.md</div>
+        <div class="step-tagline">The first file every agent reads.</div>
+        <div class="step-desc">A single top-level <code>AGENTS.md</code> orients any agent that lands in the repo: what the project is, where major areas live, links to the docs above (relative paths!), and a "<strong>what NOT to do</strong>" section. If an agent only has time to read one file, this is it. Treat it as living documentation — update it whenever conventions shift.</div>
+        <div class="step-cmd"><span class="com"># top of repo, alongside README.md</span><br><span class="kw">AGENTS.md</span>  <span class="com">· purpose, layout, rules, links</span></div>
+      </div>
+
+      <!-- Step 5: CRITICAL — create task packets -->
+      <div class="step s5 critical">
+        <div class="star-badge">★ The critical step</div>
+        <div class="step-head">
+          <div class="step-num">05 · tasks</div>
+          <div class="step-where">in pi</div>
+        </div>
+        <div class="step-title">Turn the spec into task packets</div>
+        <div class="step-tagline">This is the step that decides whether your batch produces quality code.</div>
+        <div class="step-desc">Use the <code>create-taskplane-task</code> skill. It scaffolds one folder per task, each with <code>PROMPT.md</code> (the contract) and <code>STATUS.md</code> (the agent's persistent memory). The number of packets follows the spec's complexity — smaller, atomic tasks are easier to scope, review, and merge than big-bang ones. Read every generated <code>PROMPT.md</code> and tighten it. This is your last write-time investment before tokens get spent on code.</div>
+        <div class="step-cmd"><span class="prompt">$</span> <span class="kw">pi</span><br><span class="nl">"Create taskplane tasks from the spec in docs/spec/"</span></div>
+      </div>
+
+      <!-- Step 6: orch-plan -->
+      <div class="step s6">
+        <div class="step-head">
+          <div class="step-num">06 · preview</div>
+          <div class="step-where">in pi</div>
+        </div>
+        <div class="step-title">Preview with /orch-plan</div>
+        <div class="step-tagline">See the staging before you spend a single token on code.</div>
+        <div class="step-desc">Runs discovery and the wave planner without spawning workers. Prints the wave structure, lane assignment, dependency graph, and (for polyrepo) segment groupings. Catch ordering mistakes, lane skew, and packet-size surprises here — before they cost you the batch.</div>
+        <div class="step-cmd"><span class="slash">/orch-plan</span> all</div>
+      </div>
+    </div>
+
+    <div class="footer-band">
+      A clear, well-scoped <code>PROMPT.md</code> is the difference between an agent that delivers and one that drifts. Time spent here compounds across every lane in every wave.
+    </div>
+  </div>
+</body>
+</html>

--- a/docs/video/visuals/17-sage-companion.html
+++ b/docs/video/visuals/17-sage-companion.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>V17 — Sage: the post-batch quality gate</title>
+<link rel="stylesheet" href="_shared.css">
+<style>
+  .cards {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 18px;
+    margin-bottom: 24px;
+  }
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 22px;
+    border-top: 3px solid currentColor;
+    display: flex;
+    flex-direction: column;
+  }
+  .card.c1 { color: var(--green); }
+  .card.c2 { color: var(--amber); }
+  .card.c3 { color: var(--blue); }
+
+  /* The flagship Taskplane use case — distinct treatment, full-width row. */
+  .card.flagship {
+    grid-column: 1 / -1;
+    background: var(--surface-2);
+    border: 1px solid var(--pink);
+    border-top: 3px solid var(--pink);
+    box-shadow: 0 0 0 1px rgba(255, 155, 184, 0.15) inset;
+    color: var(--pink);
+    position: relative;
+  }
+  .card.flagship .star-badge {
+    position: absolute;
+    top: -10px;
+    right: 16px;
+    background: var(--pink);
+    color: var(--bg);
+    font-family: var(--mono);
+    font-size: var(--fs-2xs);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 3px 9px;
+    border-radius: 4px;
+    font-weight: 600;
+  }
+
+  .card-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 10px;
+  }
+  .card-num {
+    font-family: var(--mono);
+    font-size: var(--fs-xs);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: currentColor;
+  }
+  .card-where {
+    font-family: var(--mono);
+    font-size: var(--fs-2xs);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 2px 7px;
+  }
+  .card-title {
+    font-family: var(--mono);
+    font-size: var(--fs-xl);
+    color: var(--text);
+    margin-bottom: 6px;
+    font-weight: 600;
+    line-height: 1.25;
+  }
+  .card-tagline {
+    font-size: var(--fs-md);
+    color: currentColor;
+    margin-bottom: 12px;
+    line-height: 1.45;
+    font-style: italic;
+    opacity: 0.95;
+  }
+  .card-desc {
+    font-size: var(--fs-sm);
+    color: var(--text-dim);
+    line-height: 1.6;
+    margin-bottom: 14px;
+    flex: 1;
+  }
+  .card-desc code,
+  .card-cmd code {
+    font-family: var(--mono);
+    background: var(--bg);
+    color: var(--text);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 0.92em;
+  }
+
+  /* Trigger-chip list inside card 3. */
+  .trigger-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 0;
+    margin-bottom: 14px;
+  }
+  .trigger-chips .chip {
+    font-family: var(--mono);
+    font-size: var(--fs-2xs);
+    color: var(--text);
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-left: 2px solid currentColor;
+    border-radius: 3px;
+    padding: 4px 8px;
+    letter-spacing: 0.02em;
+  }
+
+  .card-cmd {
+    font-family: var(--mono);
+    font-size: var(--fs-sm);
+    background: var(--bg);
+    padding: 10px 14px;
+    border-radius: 4px;
+    color: var(--text);
+    border-left: 2px solid currentColor;
+    margin-top: auto;
+    line-height: 1.7;
+    overflow-wrap: anywhere;
+  }
+  .card-cmd .prompt { color: var(--text-faint); }
+  .card-cmd .com    { color: var(--text-faint); }
+  .card-cmd .kw     { color: currentColor; }
+  .card-cmd .slash  { color: currentColor; }
+  .card-cmd .nl     { color: var(--text-dim); font-style: italic; }
+
+  /* Flagship card uses a 2-column inner layout: body + example. */
+  .flagship-inner {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr;
+    gap: 22px;
+    align-items: stretch;
+  }
+  .flagship-callout {
+    padding: 14px 16px;
+    background: var(--bg);
+    border-left: 3px solid var(--pink);
+    border-radius: 4px;
+    font-family: var(--mono);
+    font-size: var(--fs-sm);
+    color: var(--text);
+    line-height: 1.6;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+  .flagship-callout .lk {
+    display: block;
+    color: var(--pink);
+    font-size: var(--fs-2xs);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+  }
+  .flagship-callout .pull {
+    font-size: var(--fs-md);
+    color: var(--text);
+    line-height: 1.5;
+    margin-bottom: 12px;
+  }
+  .flagship-callout .pull em { color: var(--pink); font-style: normal; }
+
+  .footer-band {
+    padding: 18px 26px;
+    background: var(--surface-2);
+    border: 1px dashed var(--border);
+    border-radius: 8px;
+    font-family: var(--mono);
+    font-size: var(--fs-md);
+    color: var(--pink);
+    line-height: 1.7;
+    text-align: center;
+  }
+  .footer-band .hl-g { color: var(--green); }
+  .footer-band .hl-b { color: var(--blue); }
+  .footer-band .dim  { color: var(--text-dim); }
+</style>
+</head>
+<body>
+  <div class="frame">
+    <div class="eyebrow">
+      <span>17 · The companion</span>
+      <nav class="page-nav" aria-label="Page navigation">
+        <a href="16-real-work-playbook.html" aria-label="Previous">&larr;</a>
+        <a href="index.html" aria-label="Index">&#9675;</a>
+        <span class="disabled" aria-label="Next (none)">&rarr;</span>
+      </nav>
+    </div>
+    <h1>Sage — the post-batch quality gate</h1>
+    <p class="subtitle">Sage is a separate pi extension from Taskplane — but the two pair so well I treat them as one workflow. Per-step reviews catch problems inside a task. Sage catches problems <em>across</em> tasks. Every batch I ship gets a Sage pass before I merge.</p>
+
+    <div class="cards">
+      <!-- Card 1: What Sage is -->
+      <div class="card c1">
+        <div class="card-head">
+          <div class="card-num">01 · concept</div>
+          <div class="card-where">advisory</div>
+        </div>
+        <div class="card-title">A high-reasoning second opinion</div>
+        <div class="card-tagline">Ad-hoc <em>and</em> agentic cross-model review.</div>
+        <div class="card-desc">Sage is an isolated subagent: a separate <code>pi</code> process running a different model, with its own context, its own tool profile, and a strict advisory mandate. It analyses and recommends — it never edits files or runs your code. You can ask for it conversationally, and pi can also decide on its own that a question warrants a second opinion.</div>
+        <div class="card-cmd"><span class="com"># separate extension from Taskplane</span><br><span class="kw">pi-sage</span>  <span class="com">· github.com/&hellip;/pi-sage</span></div>
+      </div>
+
+      <!-- Card 2: Install & configure -->
+      <div class="card c2">
+        <div class="card-head">
+          <div class="card-num">02 · install</div>
+          <div class="card-where">shell + in pi</div>
+        </div>
+        <div class="card-title">Install and pick a different model</div>
+        <div class="card-tagline">The whole point is a model that <em>isn't</em> your primary.</div>
+        <div class="card-desc">One global install, then configure once. In <code>/sage-settings</code>, choose a model from a provider you don't use for your primary pi session — that's where the cross-model value comes from. Different family, different blind spots, different second opinion.</div>
+        <div class="card-cmd"><span class="prompt">$</span> <span class="kw">pi install</span> npm:pi-sage<br><span class="com"># then, inside pi:</span><br><span class="slash">/sage-settings</span></div>
+      </div>
+
+      <!-- Card 3: Invoke -->
+      <div class="card c3">
+        <div class="card-head">
+          <div class="card-num">03 · invoke</div>
+          <div class="card-where">in pi</div>
+        </div>
+        <div class="card-title">Two ways to summon Sage</div>
+        <div class="card-tagline">Ask out loud, or let pi decide.</div>
+        <div class="card-desc"><strong>Conversational:</strong> just say "use Sage" or "get a second opinion." No slash command exists — natural language is the interface. <strong>Autonomous:</strong> pi will reach for Sage on its own when the situation warrants it.</div>
+        <div class="trigger-chips">
+          <span class="chip">ambiguous root-cause</span>
+          <span class="chip">risky architecture trade-off</span>
+          <span class="chip">conflicting evidence</span>
+          <span class="chip">high-impact refactor</span>
+        </div>
+        <div class="card-cmd"><span class="nl">"Use Sage to check this approach."</span></div>
+      </div>
+
+      <!-- Card 4: FLAGSHIP — post-batch review -->
+      <div class="card flagship">
+        <div class="star-badge">★ Why Taskplane users care</div>
+        <div class="card-head">
+          <div class="card-num">04 · taskplane use case</div>
+          <div class="card-where">after every batch</div>
+        </div>
+        <div class="card-title">Run Sage on the whole batch when it's done</div>
+        <div class="card-tagline">Cross-task consistency is something per-step review simply can't see.</div>
+        <div class="flagship-inner">
+          <div class="card-desc">
+            Taskplane's built-in reviewer agent reviews <strong>each step of each task</strong> as the worker writes it. That gate is excellent at what it does — catching defects, missing tests, drift from the prompt — but it sees one step at a time, in isolation.
+            <br><br>
+            After the batch lands, a different question matters: <em>does the whole thing hang together?</em> Are interfaces consistent across tasks? Did lane 2's refactor leave lane 5's call site broken? Did the same concern get solved three different ways in three different lanes? Is the testing strategy coherent end-to-end?
+            <br><br>
+            That's the gap Sage fills. Point it at the merged diff between your working branch and the orch branch (or the integration commit), and ask for a full code review. It's the quality gate I run on every Taskplane batch before I push.
+          </div>
+          <div class="flagship-callout">
+            <div class="pull">Per-step reviews verify <em>steps.</em><br>Sage verifies <em>the whole.</em></div>
+            <span class="lk">Typical invocation</span>
+            <div class="card-cmd" style="margin-top:0;"><span class="nl">"Use Sage to review the diff between</span><br><span class="nl">develop and the orch branch."</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="footer-band">
+      <span class="dim">Taskplane runs the batch.</span> &nbsp;Sage <em>reviews</em> it. &nbsp;<span class="dim">·</span> &nbsp;separate extensions, one workflow
+    </div>
+  </div>
+</body>
+</html>

--- a/docs/video/visuals/_shared.css
+++ b/docs/video/visuals/_shared.css
@@ -199,6 +199,7 @@ h1 {
   color: var(--text-dim);
   font-size: var(--fs-subtitle);
   margin-bottom: var(--subtitle-mb);
-  max-width: calc(820px * var(--scale));
+  /* Subtitle spans the full frame width — no soft cap. */
+  max-width: 100%;
   line-height: 1.55;
 }

--- a/docs/video/visuals/index.html
+++ b/docs/video/visuals/index.html
@@ -34,6 +34,11 @@
   a.card.c10 { color: var(--amber); }
   a.card.c11 { color: var(--blue); }
   a.card.c12 { color: var(--purple); }
+  a.card.c13 { color: var(--green); }
+  a.card.c14 { color: var(--amber); }
+  a.card.c15 { color: var(--blue); }
+  a.card.c16 { color: var(--purple); }
+  a.card.c17 { color: var(--pink); }
   .num {
     font-family: var(--mono);
     font-size: var(--fs-xs);
@@ -82,7 +87,7 @@
   <div class="frame">
     <div class="eyebrow">Introduction to Taskplane</div>
     <h1>Visual Overview</h1>
-    <p class="subtitle">These 12 pages provide a overview of how Taskplane dramatically improves AI agent coding outcomes for long-running multi-task orchestration.</p>
+    <p class="subtitle">These 17 pages provide an overview of how Taskplane dramatically improves AI agent coding outcomes for long-running multi-task orchestration.</p>
 
     <div class="grid">
       <a class="card c1" href="01-origin-timeline.html">
@@ -144,6 +149,31 @@
         <div class="num">12</div>
         <div class="title">Dashboard visibility map</div>
         <div class="desc">A view over disk. Read-only. Cannot lie. Cannot decide.</div>
+      </a>
+      <a class="card c13" href="13-why-pi.html">
+        <div class="num">13</div>
+        <div class="title">Why pi?</div>
+        <div class="desc">Three reasons pi is the right foundation: extensible, model-agnostic, open source.</div>
+      </a>
+      <a class="card c14" href="14-pi-capabilities.html">
+        <div class="num">14</div>
+        <div class="title">Pi capabilities</div>
+        <div class="desc">Engineering surface Taskplane builds on: skills, tools, RPC steering, subprocess agents.</div>
+      </a>
+      <a class="card c15" href="15-how-to-get-started.html">
+        <div class="num">15</div>
+        <div class="title">Getting started: install and test</div>
+        <div class="desc">Nine steps from zero to a running batch: install pi + Taskplane, init, doctor, /orch all, dashboard.</div>
+      </a>
+      <a class="card c16" href="16-real-work-playbook.html">
+        <div class="num">16</div>
+        <div class="title">Real-work playbook</div>
+        <div class="desc">Spec → cross-LLM review → supporting docs → AGENTS.md → task packets → /orch-plan. The 30 minutes that decide your batch.</div>
+      </a>
+      <a class="card c17" href="17-sage-companion.html">
+        <div class="num">17</div>
+        <div class="title">Sage — the companion</div>
+        <div class="desc">Ad-hoc and agentic cross-model second opinions. The post-batch quality gate per-step reviews can't deliver.</div>
       </a>
     </div>
   </div>


### PR DESCRIPTION
Continuation of #580. Extends the 'Introduction to Taskplane' video deck with five additional supporting visuals plus a small shared-CSS tweak.

## New pages

| # | Title | Purpose |
|---|---|---|
| 13 | Why pi? | The foundation: extensible, model-agnostic, OSS |
| 14 | Pi capabilities | Engineering surface Taskplane builds on |
| 15 | Getting started | Install + sample batch — nine steps |
| 16 | Real-work playbook | spec → review → tasks → /orch-plan |
| 17 | Sage companion | Cross-model post-batch review |

13 and 14 were authored by a parallel agent; their nav controls were normalized to the house style (icon-only `←` / `○` / `→` with aria-labels, title in `<span>`, no `V` prefix on the number).

## Other changes

- **`_shared.css`**: `.subtitle { max-width: 100% }` is now the default (the 820px soft cap was being overridden on enough pages that flipping the default was simpler). Drops three per-page overrides (`08`, `12`, `index`).
- **`index.html`**: cards added for 13-17, page-count bumped from 14 → 17, and the pre-existing typo 'a overview' fixed to 'an overview'.
- **`12-dashboard-visibility.html`**: next arrow re-enabled (now links to page 13).

## Why no release

Pure docs/asset addition — no runtime, CLI, config, or schema changes. No CHANGELOG entry needed under 'Docs' since these aren't user-facing reference docs (they're video-production artifacts under `docs/video/`).

## Validation

- No code touched → typecheck / lint / format / tests not relevant.
- Manually walked 1 → 17 → index → back; nav arrows all correct (page 1 prev disabled, page 17 next disabled).
- Each visual opens standalone in a browser; `_shared.css` loads relatively.