### PR TITLE
chore(ci): add GitHub Pages workflow for Taskplane Overview microsite

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,53 @@
+name: Deploy Taskplane Overview to GitHub Pages
+
+# Deploys docs/taskplane-overview/ to GitHub Pages whenever its contents
+# (or this workflow) change on main. Other docs/ subfolders are NOT served.
+#
+# To broaden the site later: change the `path:` value on the
+# upload-pages-artifact step. To switch to a /docs-wide branch deploy,
+# change Settings -> Pages source to "Deploy from a branch" and delete
+# this workflow.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/taskplane-overview/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+# Standard Pages permissions: read repo, write Pages, write id-token
+# (required by deploy-pages for OIDC attestation).
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Don't cancel an in-flight deploy if a second push arrives; finish
+# the current one and queue the next. Pages serves the latest
+# successful deploy regardless of order.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Taskplane Overview artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/taskplane-overview
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Adds `.github/workflows/pages.yml` to deploy `docs/taskplane-overview/` to GitHub Pages.

## Scope

Only the Overview deck is served — not the rest of `docs/`. To broaden the site later, change the `path:` value on the `upload-pages-artifact` step. To switch to a `/docs`-wide branch deploy, change Settings → Pages source to 'Deploy from a branch' and delete this workflow.

## Workflow details

- **Trigger:** pushes to `main` that touch `docs/taskplane-overview/**` or the workflow itself, plus manual `workflow_dispatch`.
- **Permissions:** standard Pages set (`contents:read`, `pages:write`, `id-token:write`).
- **Concurrency:** `group: pages`, `cancel-in-progress: false` — in-flight deploys finish before the next one starts.
- **Environment:** `github-pages` (auto-created when Pages is enabled).
- **Actions used:** `actions/checkout@v4`, `actions/configure-pages@v5`, `actions/upload-pages-artifact@v3`, `actions/deploy-pages@v4` (all official, pinned to current majors).

## One-time setup required

Before this workflow's first run will succeed, repo **Settings → Pages → Source must be set to 'GitHub Actions'**. That enables Pages on the repo and creates the `github-pages` environment that this workflow targets. Until that's done, the workflow will fail on the `configure-pages` step with a 404.

## Why no release

Adds infra/automation, no runtime/CLI/config/schema change.