### PR TITLE
feat(overview): sticky eyebrow + bigger green nav + keyboard & swipe nav

### DIFF
--- a/docs/taskplane-overview/01-origin-timeline.html
+++ b/docs/taskplane-overview/01-origin-timeline.html
@@ -165,5 +165,6 @@
       vibe → ralph → parallel ralph → <span class="hl">taskplane</span> · ~1M lines of AI-generated code along the way
     </div>
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/02-light-factory-vs-dark.html
+++ b/docs/taskplane-overview/02-light-factory-vs-dark.html
@@ -146,5 +146,6 @@
       autonomy is fine — <span class="hl">inspectable autonomy is the goal</span>
     </div>
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/03-agent-quartet.html
+++ b/docs/taskplane-overview/03-agent-quartet.html
@@ -201,5 +201,6 @@
       <span class="hl-p">supervisor</span> <span class="arrow">→</span> spawns <span class="hl-g">worker</span> per lane <span class="arrow">→</span> worker calls <span class="hl-a">reviewer</span> at step boundaries <span class="arrow">→</span> wave completes <span class="arrow">→</span> <span class="hl-b">merger</span> combines lanes <span class="arrow">→</span> next wave
     </div>
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/04-task-packet-anatomy.html
+++ b/docs/taskplane-overview/04-task-packet-anatomy.html
@@ -198,5 +198,6 @@
     </div>
 
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/05-determinism-spectrum.html
+++ b/docs/taskplane-overview/05-determinism-spectrum.html
@@ -194,5 +194,6 @@
       <span class="hl">only the contents of the model's tokens differ.</span>
     </div>
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/06-cross-model-review.html
+++ b/docs/taskplane-overview/06-cross-model-review.html
@@ -281,5 +281,6 @@
     </div>
 
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/07-mailbox-protocol.html
+++ b/docs/taskplane-overview/07-mailbox-protocol.html
@@ -224,5 +224,6 @@
       </div>
     </div>
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/08-waves-lanes-worktrees.html
+++ b/docs/taskplane-overview/08-waves-lanes-worktrees.html
@@ -318,5 +318,6 @@
       </div>
     </div>
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/08-waves-lanes-worktrees.html
+++ b/docs/taskplane-overview/08-waves-lanes-worktrees.html
@@ -179,6 +179,12 @@
     .lanes { min-width: 540px; }
     .rules { grid-template-columns: 1fr; }
   }
+
+  /* Page-specific override: this page is the tallest of the deck and
+     spills past one 16:9 viewport on desktop with the shared 48px body
+     padding-bottom. Trim it to 20px here so the whole page fits without
+     a vertical scrollbar at standard desktop aspect ratios. */
+  body { padding-bottom: 20px; }
 </style>
 </head>
 <body>

--- a/docs/taskplane-overview/09-branching-lifecycle.html
+++ b/docs/taskplane-overview/09-branching-lifecycle.html
@@ -276,5 +276,6 @@
       your <span class="pink">working branch</span> is sacred — <span class="hl">never touched</span> until <code style="font-family:var(--mono); color:var(--green); background:var(--bg); padding:1px 5px; border-radius:3px;">/orch-integrate</code>
     </div>
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/10-semantic-merge.html
+++ b/docs/taskplane-overview/10-semantic-merge.html
@@ -220,5 +220,6 @@
       merge health monitor polls every 2 min · <span class="hl-a">stale at 10</span> · <span class="hl-r">stuck at 20</span> · emits events, never kills autonomously
     </div>
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/11-polyrepo-segments.html
+++ b/docs/taskplane-overview/11-polyrepo-segments.html
@@ -295,5 +295,6 @@
       </div>
     </div>
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/12-dashboard-visibility.html
+++ b/docs/taskplane-overview/12-dashboard-visibility.html
@@ -257,5 +257,6 @@
       one tab. all the truth. <span class="hl">no babysitting required.</span>
     </div>
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/13-why-pi.html
+++ b/docs/taskplane-overview/13-why-pi.html
@@ -145,5 +145,6 @@
       <span class="hl-g">extensible</span> &nbsp;+&nbsp; <span class="hl-b">model-agnostic</span> &nbsp;+&nbsp; <span class="hl-a">open</span> &nbsp;·&nbsp; the right foundation for what Taskplane needed
     </div>
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/14-pi-capabilities.html
+++ b/docs/taskplane-overview/14-pi-capabilities.html
@@ -158,5 +158,6 @@
       Every primitive on this page maps to something concrete in the orchestration system. Skills give you the task-creation entry point. Custom tools give you reviews. RPC steering gives you the mailbox. Subprocess agents give you parallel lanes. Composable prompts give you the <span class="hl">supervisor / worker / reviewer / merger</span> quartet without forking a thing.
     </div>
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/15-how-to-get-started.html
+++ b/docs/taskplane-overview/15-how-to-get-started.html
@@ -217,5 +217,6 @@
     </div>
 
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/16-real-work-playbook.html
+++ b/docs/taskplane-overview/16-real-work-playbook.html
@@ -291,5 +291,6 @@
       A clear, well-scoped <code>PROMPT.md</code> is the difference between an agent that delivers and one that drifts. Time spent here compounds across every lane in every wave.
     </div>
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/17-sage-companion.html
+++ b/docs/taskplane-overview/17-sage-companion.html
@@ -297,5 +297,6 @@
       <span class="dim">Taskplane runs the batch.</span> &nbsp;Sage <em>reviews</em> it. &nbsp;<span class="dim">·</span> &nbsp;separate extensions, one workflow
     </div>
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/index.html
+++ b/docs/taskplane-overview/index.html
@@ -216,5 +216,6 @@
       </a>
     </div>
   </div>
+<script src="nav.js"></script>
 </body>
 </html>

--- a/docs/taskplane-overview/nav.js
+++ b/docs/taskplane-overview/nav.js
@@ -1,0 +1,84 @@
+// Taskplane Overview · page-deck navigation
+// ----------------------------------------------------------------------------
+// Two input modes layered on the existing prev/index/next links inside
+// .page-nav, so they stay the single source of navigation truth:
+//
+//   * Desktop : ArrowLeft / ArrowRight on the keyboard fire the prev/next links.
+//   * Touch   : horizontal swipes fire the prev/next links — UNLESS the swipe
+//               started inside a horizontally scrollable container (e.g. the
+//               page-09 git-graph card or the page-08 wave cards), in which
+//               case the inner scroll takes priority.
+//
+// The script is a no-op on the index page (no .page-nav element).
+// ----------------------------------------------------------------------------
+
+(function () {
+  'use strict';
+
+  function navLink(label) {
+    return document.querySelector('.page-nav a[aria-label="' + label + '"]');
+  }
+
+  // --- Keyboard ----------------------------------------------------------
+  document.addEventListener('keydown', function (e) {
+    // Don't hijack arrows when the user is typing somewhere editable.
+    var tag = (e.target.tagName || '').toLowerCase();
+    if (tag === 'input' || tag === 'textarea' || e.target.isContentEditable) {
+      return;
+    }
+    // Ignore when modifier keys are held — those are likely browser shortcuts.
+    if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
+
+    var link = null;
+    if (e.key === 'ArrowLeft')  link = navLink('Previous');
+    if (e.key === 'ArrowRight') link = navLink('Next');
+    if (link) {
+      e.preventDefault();
+      link.click();
+    }
+  });
+
+  // --- Touch (swipe) -----------------------------------------------------
+  var startX = null;
+  var startY = null;
+
+  // Walk up the DOM looking for a horizontally scrollable ancestor. If one
+  // exists, the user is probably trying to pan that inner content, so we
+  // surrender the swipe.
+  function startedInsideHorizontalScroll(el) {
+    while (el && el !== document.body && el !== document.documentElement) {
+      if (el.scrollWidth > el.clientWidth + 1) return true;
+      el = el.parentElement;
+    }
+    return false;
+  }
+
+  document.addEventListener('touchstart', function (e) {
+    if (startedInsideHorizontalScroll(e.target)) {
+      startX = null;
+      return;
+    }
+    var t = e.changedTouches[0];
+    startX = t.screenX;
+    startY = t.screenY;
+  }, { passive: true });
+
+  document.addEventListener('touchend', function (e) {
+    if (startX === null) return;
+    var t = e.changedTouches[0];
+    var dx = t.screenX - startX;
+    var dy = t.screenY - startY;
+    startX = null;
+    startY = null;
+
+    // Threshold: at least 70px horizontal movement, and the gesture must
+    // be predominantly horizontal (2x more X than Y). Anything mushier is
+    // treated as a tap / vertical scroll and ignored.
+    var absDx = Math.abs(dx);
+    var absDy = Math.abs(dy);
+    if (absDx < 70 || absDx < absDy * 2) return;
+
+    var link = dx > 0 ? navLink('Previous') : navLink('Next');
+    if (link) link.click();
+  }, { passive: true });
+})();

--- a/docs/taskplane-overview/shared.css
+++ b/docs/taskplane-overview/shared.css
@@ -165,7 +165,7 @@ body {
   font-size: var(--fs-eyebrow);
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  margin-bottom: 12px;
+  margin-bottom: 16px;
   /* Three-column grid: title (left) · wordmark (center) · nav (right).
      1fr / auto / 1fr keeps the wordmark perfectly centered regardless of
      how wide the title or nav columns end up. */
@@ -173,6 +173,16 @@ body {
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
   gap: 16px;
+
+  /* Docked at the top of the viewport so the nav buttons are always
+     reachable. position: sticky keeps the eyebrow in normal flow until
+     the page scrolls past it, then pins it to top: 0. */
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  padding-block: 10px;
 }
 .eyebrow > :first-child { justify-self: start; }
 .eyebrow > .page-nav    { justify-self: end; }
@@ -186,27 +196,40 @@ body {
   justify-self: center;
 }
 
-/* Subtle per-page navigation: prev / index / next. Placed inside .eyebrow. */
+/* Per-page navigation: prev / index / next. Lives inside .eyebrow.
+   Sized large (~2x the title) and tinted green so the controls read as
+   primary actions on every viewport, with 44x44 hit areas for touch. */
 .page-nav {
   display: inline-flex;
   align-items: center;
-  gap: 14px;
+  gap: 8px;
   letter-spacing: normal;
   text-transform: none;
-  font-size: var(--fs-lg);
+  font-size: calc(var(--fs-lg) * 2);
   line-height: 1;
 }
 .page-nav a,
 .page-nav span {
-  color: var(--text-faint);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 4px 6px;
+  color: var(--green);
   text-decoration: none;
-  transition: color 0.15s ease;
+  transition: color 0.15s ease, transform 0.15s ease;
 }
 .page-nav a:hover {
-  color: var(--green);
+  color: var(--text);
+  transform: translateY(-1px);
+}
+.page-nav a:active {
+  transform: translateY(0);
 }
 .page-nav .disabled {
-  opacity: 0.3;
+  color: var(--text-faint);
+  opacity: 0.35;
   cursor: default;
 }
 

--- a/docs/taskplane-overview/shared.css
+++ b/docs/taskplane-overview/shared.css
@@ -143,7 +143,10 @@ body {
 
 body {
   min-height: 100vh;
-  padding: var(--page-pad-y) var(--page-pad-x);
+  /* No top padding: the sticky .eyebrow sits flush against the viewport
+     top from page load, so it's always in its docked position. Side and
+     bottom padding remain. */
+  padding: 0 var(--page-pad-x) var(--page-pad-y);
 }
 
 


### PR DESCRIPTION
Three layered improvements to the slide-deck navigation UX, all landing in one PR since they reinforce each other.

## 1. Sticky eyebrow header

`.eyebrow` now uses `position: sticky; top: 0` so the title, wordmark, and prev/index/next controls dock to the top of the viewport on both desktop and mobile once the page is scrolled. Sticky (not fixed) keeps it in normal flow until it hits viewport top, so there's no body padding-top compensation and no content jumping. Background fills with `--bg`, plus a 1px border-bottom for separation when scrolled.

## 2. Larger, green nav controls

- `.page-nav` font-size doubles (`calc(var(--fs-lg) * 2)`) so the prev/index/next glyphs read as primary actions instead of subtle hints.
- Color switches from `--text-faint` to `--green` (matching the eyebrow title color).
- Hover bumps to `--text` with a tiny `translateY(-1px)` for tactile feedback.
- Each control has a 44×44 minimum hit area via `min-width` / `min-height` / `padding`, satisfying touch-target guidance on phones.
- Disabled state stays gray + low-opacity so first-page-prev and last-page-next still read as inactive.

## 3. Keyboard + swipe navigation (`nav.js`)

New shared script, ~3 KB, vanilla browser APIs only, no dependencies. Loaded by every page via `<script src="nav.js"></script>` before `</body>`.

**Keyboard:** ArrowLeft / ArrowRight synthesize a click on the existing prev / next anchors. Ignores modifier-key shortcuts and editable targets (`input`, `textarea`, contenteditable) so it never hijacks normal browser shortcuts or form input.

**Touch:** horizontal swipes (≥70px X movement, and at least 2× more X than Y) fire prev / next. **Unless** the swipe started inside a horizontally scrollable container (e.g. the page-09 git-graph card or the page-08 wave cards) — in which case the inner pan keeps working. The check walks up the DOM ancestor chain looking for any element with `scrollWidth > clientWidth`.

No-op on the index page (no `.page-nav` element to find), safe to load everywhere.

## To verify before merging

Same three checks on the PR branch:
- **Desktop:** scroll any page → eyebrow docks at top. Click anywhere outside a form, hit ← and → to navigate. Buttons should be visibly green and roughly 2x the previous size.
- **Phone:** swipe left/right anywhere except on page 09's git-graph card and page 08's wave cards — those should still pan horizontally inside without triggering page nav.
- **Page 09 + 08:** confirm the special horizontal-scroll areas still work (swipe inside them moves the inner content, not the page).

No release. Pure docs/microsite enhancement.