### PR TITLE
docs(overview): clarify Pi attribution + add Sage usage tip

### DIFF
--- a/docs/taskplane-overview/03-agent-quartet.html
+++ b/docs/taskplane-overview/03-agent-quartet.html
@@ -145,7 +145,7 @@
           <li>orch_* tool calls</li>
           <li>failure triage</li>
         </ul>
-        <div class="model-line"><span class="mk">model →</span> <span class="mv">your session model</span></div>
+        <div class="model-line"><span class="mk">model →</span> <span class="mv">your Pi session's model</span></div>
       </div>
 
       <div class="agent worker">

--- a/docs/taskplane-overview/17-sage-companion.html
+++ b/docs/taskplane-overview/17-sage-companion.html
@@ -222,7 +222,7 @@
       </nav>
     </div>
     <h1>Sage — the post-batch quality gate</h1>
-    <p class="subtitle">Sage is a separate pi extension from Taskplane — but the two pair so well I treat them as one workflow. Per-step reviews catch problems inside a task. Sage catches problems <em>across</em> tasks. Every batch I ship gets a Sage pass before I merge.</p>
+    <p class="subtitle">Sage is a separate pi extension from Taskplane (also created by me) — but the two pair so well I treat them as one workflow. Per-step reviews catch problems inside a task. Sage catches problems <em>across</em> tasks. Every batch I ship gets a Sage pass before I merge. (Tip: I use Sage for almost everything I do in pi, not just when I'm using Taskplane.)</p>
 
     <div class="cards">
       <!-- Card 1: What Sage is -->

--- a/docs/taskplane-overview/index.html
+++ b/docs/taskplane-overview/index.html
@@ -125,7 +125,7 @@
       <img class="eyebrow-logo" src="taskplane-word-white.svg" alt="Taskplane">
     </div>
     <h1>Table of Contents</h1>
-    <p class="subtitle">These 17 pages provide an overview of how Taskplane dramatically improves AI agent coding outcomes for long-running multi-task orchestration.</p>
+    <p class="subtitle">These 17 pages provide an overview of how Taskplane with Pi dramatically improves AI agent coding outcomes for long-running multi-task orchestration.</p>
 
     <div class="grid">
       <a class="card c1 start-here" href="01-origin-timeline.html">


### PR DESCRIPTION
Three one-line copy edits to the Taskplane Overview microsite:

- **`index.html`** — subtitle now reads 'Taskplane **with Pi**' to surface the two-piece foundation on the landing page.
- **`03-agent-quartet.html`** — supervisor agent's model line: 'your session model' → 'your **Pi** session's model' for unambiguous attribution.
- **`17-sage-companion.html`** — subtitle expanded to note that Sage is also authored by the same person (so the recommendation reads as authorial rather than third-party endorsement), and adds a closing tip that Sage is useful for everything in pi, not just Taskplane workflows.

No release. Pure microsite content.