### PR TITLE
fix(#562): align merge_success counter denominator with segment-level numerator

### DIFF
--- a/extensions/taskplane/engine.ts
+++ b/extensions/taskplane/engine.ts
@@ -4225,14 +4225,23 @@ export async function executeOrchBatch(
 						"info",
 					);
 
-					// TP-040: Emit merge_success event
+					// TP-040: Emit merge_success event.
+					//
+					// `waveIndex` is the segment-round index (0-based), and the supervisor
+					// formatter renders the (N/M) counter using `waveIndex + 1` for N.
+					// For unit consistency we therefore pair it with the segment-level
+					// `batchState.totalWaves` (segment-expanded round count), not
+					// `taskLevelWaveCount` (pre-expansion). Using the task-level count as
+					// the denominator while the numerator counts segment rounds produced
+					// `(4/3)`, `(5/3)`, `(6/3)` style overflow once segments expanded —
+					// see issue #562.
 					emitEvent(
 						stateRoot,
 						{
 							...buildEngineEventBase("merge_success", batchState.batchId, waveIdx, batchState.phase),
 							laneCount: mergedCount,
 							durationMs: mergeResult.totalDurationMs,
-							totalWaves: taskLevelWaveCount,
+							totalWaves: batchState.totalWaves,
 						},
 						onEngineEvent,
 					);

--- a/extensions/tests/supervisor.test.ts
+++ b/extensions/tests/supervisor.test.ts
@@ -924,6 +924,33 @@ describe("5.x — formatEventNotification", () => {
 		expect(text).toContain("42");
 	});
 
+	it("5.8a: merge_success counter denominator stays >= numerator across segment-expanded waves (regression for #562)", () => {
+		// Polyrepo scenario from #562: 3 task-level waves expand into 6
+		// segment-level merge rounds. The engine emits one merge_success
+		// per segment round, with waveIndex = segment-round index (0..5)
+		// and totalWaves = segment-expanded round count (6). The formatter
+		// must therefore render (1/6) through (6/6), never (4/3), (5/3),
+		// or (6/3) as observed in the bug report.
+		const denominator = 6;
+		for (let waveIdx = 0; waveIdx < denominator; waveIdx++) {
+			const event = {
+				timestamp: "t",
+				type: "merge_success" as any,
+				batchId: "b",
+				waveIndex: waveIdx,
+				totalWaves: denominator,
+			};
+			const text = formatEventNotification(event, "supervised");
+			const expectedNumerator = waveIdx + 1;
+			expect(text).toContain(`(${expectedNumerator}/${denominator})`);
+			// Belt-and-suspenders: the bug surfaced as a numerator that
+			// exceeded the denominator. Pin that the rendered text never
+			// contains `(N/3)` for any N — the only valid denominator in
+			// the segment-expanded case is the segment count.
+			expect(text).not.toMatch(/\(\d+\/3\)/);
+		}
+	});
+
 	it("5.9: formats merge_failed differently for autonomous vs interactive", () => {
 		const event = {
 			timestamp: "t",


### PR DESCRIPTION
Closes #562.

## The bug

In a polyrepo batch where task-level waves expand into segment-level merge rounds (3 task waves → 6 segment rounds in the reporter's case), the operator-visible merge alerts overflowed their denominator:

```
✅ Wave 1 merged successfully (1/3). Tests pass.
✅ Wave 2 merged successfully (2/3). Tests pass.
✅ Wave 3 merged successfully (3/3). Tests pass.
✅ Wave 4 merged successfully (4/3). Tests pass.   ← stale denominator
✅ Wave 5 merged successfully (5/3). Tests pass.
✅ Wave 6 merged successfully (6/3). Tests pass.
```

Purely cosmetic — every wave merged successfully. Functionality unchanged.

## Root cause

The supervisor's `formatEventNotification` renders `Wave N merged successfully (X/Y)` where:

- **N and X** both derive from `event.waveIndex + 1` (set by the engine to the **segment-round** index 0..5)
- **Y** came from `event.totalWaves` which the engine was populating with `taskLevelWaveCount` (the **pre-expansion** task-wave count = 3)

Once segments expanded, N/X overflowed Y. The fix is to source the denominator from `batchState.totalWaves` (assigned `rawWaves.length` at `engine.ts:2767` — the segment-expanded round count) instead.

## The fix

One-field source-of-truth swap at the `merge_success` event emission site in `engine.ts`:

```diff
- totalWaves: taskLevelWaveCount,
+ totalWaves: batchState.totalWaves,
```

Plus an inline comment explaining the segment/task-wave distinction so a future reader doesn't reintroduce the bug.

## Test

Adds `5.8a` to `supervisor.test.ts`: emits 6 successive `merge_success` events with `waveIndex` 0..5 against `totalWaves: 6` and asserts:

1. Each rendered counter reads `(waveIdx+1)/6`.
2. **None** of the rendered counters contain the buggy `/3` pattern from the report.

## Validation

| Gate | Result |
|---|---|
| `npm run typecheck` | ✅ pass |
| `npm run lint` | ✅ 286 warnings / 671 infos — **identical** to `main` (zero new) |
| `npm run format:check` | ✅ pass |
| `supervisor.test.ts` (114 tests) | ✅ all pass, new 5.8a included |

## Note on the design choice

The reporter offered two options: (a) flip the denominator to segment-level (what this PR does), or (b) reword the alert to disambiguate units. I went with (a) because:

1. The numerator was already segment-level — this just aligns the denominator. Minimal surface area, no message rewording.
2. The supervisor's existing leading `Wave N` is also segment-level (uses `waveIndex + 1`), so changing the denominator gives the whole message a consistent unit system without touching any other emission sites.
3. The reporter explicitly endorsed this as the preferred fix in the issue body ("one-character source-of-truth swap").