### PR TITLE
release: v0.30.2 — Pi CLI resolution + dashboard observability fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.2] - 2026-06-17
+
+### Fixed
+
+- **Pi CLI resolution fails on NVM-Windows and non-canonical installs (#598, #519):**
+  `resolvePiCliPath()` ignored `process.argv[1]` and relied entirely on
+  `npm root -g` plus a small static fallback list. That stranded NVM-on-Windows
+  users (child processes inherit a stripped PATH, so `npm root -g` returns
+  empty and the fallback list doesn't include NVM-versioned dirs) and Nix
+  users (Pi lives at `/nix/store/...`, outside any npm prefix). The fix adds
+  `process.argv[1]` as the authoritative candidate 0 — when Taskplane runs as
+  a Pi extension, the parent process IS Pi and Node sets `process.argv[1]`
+  to Pi's `cli.js` directly. Two sanity guards (`endsWith('cli.js')` +
+  `existsSync()`) keep wrappers and test runners from being mistaken for Pi.
+  Defense in depth: two additional env-var-driven bases (`$NVM_SYMLINK\node_modules`
+  for NVM-for-Windows, `dirname($NVM_BIN)/../lib/node_modules` for NVM-for-Unix)
+  cover the same NVM scenarios in environments where `argv[1]` isn't available.
+  6 new regression tests in `path-resolver-pi-scope.test.ts`. Apologies to
+  `@chenxin-yan` whose PR #520 (closed 2026-05-25) proposed exactly this fix
+  for `resolvePiCliPath` 7 weeks ago — it was incorrectly closed as already-fixed
+  because `process.argv[1]` had been added to the *sibling* `resolveTaskplanePackageFile`
+  resolver, but not to `resolvePiCliPath` itself.
+
+- **Dashboard merge agent telemetry missing for some waves (#509):**
+  Merge snapshot files were keyed on disk by `mergeNumber` alone
+  (`merge-{N}.json`), and `mergeNumber` is derived from `lane.laneNumber`.
+  Because lane numbers reset every wave, wave N+1's lane-1 merge silently
+  overwrote wave N's lane-1 terminal snapshot before the dashboard could
+  read it — surfacing as `—` in the merge telemetry column for any wave
+  whose lane numbers were reused by a subsequent wave. The fix namespaces
+  the filename per wave (`merge-w{waveIndex}-{mergeNumber}.json`) and
+  updates the dashboard server's intermediate map key to a composite
+  (`w{waveIndex}-{mergeNumber}`) so collisions can't reappear at read time.
+  Filename filter remains permissive so legacy snapshots from pre-fix
+  batches still load for back-compat. 4 new regression tests in
+  `process-registry.test.ts` (7.4–7.7) pin the cross-wave invariants.
+
+- **Dashboard briefly flips to history view at batch startup (#507):**
+  A single missed SSE poll during `batch-state.json` write at startup
+  triggered the no-batch handler in `app.js`, which closes the viewer and
+  renders the history panel before the next poll picked up the new batch.
+  The user-visible effect was a flash of stale history between two live
+  batches. The fix adds a 3-consecutive-miss debounce on the no-batch
+  transition (~6s with the 2s `POLL_INTERVAL`) — well past the sub-second
+  `batch-state.json` write window while still cleaning up promptly when a
+  batch genuinely ends.
+
+- **Wave-merge counter `(N/3)` overflow past wave 3 (#562):**
+  In polyrepo batches where task-level waves expand into segment-level
+  merge rounds (3 task waves → 6 segment rounds in the reporter's case),
+  the merge_success alert's `(X/Y)` counter overflowed its denominator:
+  `(1/3)`, `(2/3)`, `(3/3)`, then `(4/3)`, `(5/3)`, `(6/3)`. The supervisor
+  formatter's `(X/Y)` rendering paired a segment-round numerator with a
+  task-level denominator from `taskLevelWaveCount`. The fix swaps the event
+  emission's `totalWaves` source from `taskLevelWaveCount` to
+  `batchState.totalWaves` (the segment-expanded round count), so numerator
+  and denominator share units. Purely cosmetic — functionality was correct.
+  Regression test 5.8a in `supervisor.test.ts`.
+
+### Internal
+
+- **Administrative closeouts for already-shipped fixes:** Closed five stale
+  open issues whose fixes had already shipped in earlier releases but were
+  never marked complete: **#557** (Pi `@earendil-works` rename — fixed by
+  `34b303a4` in v0.29.0), **#538** / **#539** / **#540** (supervisor recovery
+  cluster — all three fixed by TP-187 in v0.29.0), and **#519** (Nix CLI
+  resolution — NOW fixed in v0.30.2; the closeout in May was incorrect).
+  Open issue queue dropped from 16 to 7 across this release cycle.
+
 ## [0.30.1] - 2026-05-11
 
 ### Enhanced

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.30.1",
+      "version": "0.30.2",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Patch release wrapping four shipped bug fixes since v0.30.1.

## Patch justification (semver)

All four entries are bug fixes — no breaking changes, no new features, no schema changes. Patch bump (`0.30.1 → 0.30.2`) is the appropriate semver level.

## Issues closed in this release

| # | Title | PR |
|---|---|---|
| **#598** | Cannot find Pi CLI entrypoint (NVM, non-canonical installs) | #599 |
| **#519** | Worker agent spawn fails when Pi is installed via Nix | #599 (same fix) |
| **#509** | Dashboard merge agent telemetry missing for some waves | #596 |
| **#507** | Dashboard briefly flips to history view during batch startup | #596 |
| **#562** | Wave-merge counter `(N/3)` overflow past wave 3 | #595 |

Administrative closeouts for already-shipped fixes (no code change, just cleaned up the issue tracker): **#557**, **#538**, **#539**, **#540** — all four had landed in earlier releases (v0.28.5 / v0.29.0) but were never closed.

## Highlights

- **#598 / #519 are the headline fix.** Fresh installs on NVM-for-Windows have been completely broken by this bug — all worker / reviewer / merger spawns failed with `Cannot find Pi CLI entrypoint`. The fix trusts `process.argv[1]` as the authoritative source (which it is — when Taskplane runs as a Pi extension, the parent process IS Pi), plus two NVM env-var fallbacks as defense in depth.
- **#509 was a polyrepo-specific dashboard regression** that hid merge telemetry for any wave whose lane numbers were reused by a subsequent wave. The on-disk filename collision was straightforward in retrospect but invisible without comparing snapshots across waves.

## Validation

Run on the merge commit (`21a5094b`):

| Gate | Result |
|---|---|
| `npm run typecheck` | ✅ pass |
| `npm run lint` | ✅ 286 warnings / 671 infos — identical to v0.30.1 |
| `npm run format:check` | ✅ pass |
| `cd extensions && npm run test:fast` | ✅ 3,714 / 3,715 pass, 1 skipped |
| `node bin/taskplane.mjs help` | ✅ pass |
| `node bin/taskplane.mjs doctor` | ✅ pass |
| `npm pack --dry-run` | ✅ 77 files, 678.7 kB, no spurious entries |

## After merge

Per the release workflow, after this PR merges I'll push the `v0.30.2` tag from local. The `.github/workflows/release.yml` workflow handles:
1. Tag/version validation
2. Re-run tests
3. `npm publish --provenance` (Trusted Publishing via OIDC)
4. GitHub release with notes extracted from CHANGELOG

Expected total time after tag push: ~30–60 seconds.