### PR TITLE
fix(doctor): address Sage review findings on duplication-check PR #601

### DIFF
--- a/bin/taskplane.mjs
+++ b/bin/taskplane.mjs
@@ -2797,8 +2797,10 @@ function cmdDoctor() {
 	// npm's global root to `~/.pi/agent/npm/` to avoid system-Node permission
 	// errors. Users who installed via `npm install -g taskplane` before that
 	// landed (or who installed via both paths) end up with two on-disk copies.
+	let duplicationDetected = false;
 	const duplication = detectDuplicateTaskplaneInstall();
 	if (duplication) {
+		duplicationDetected = true;
 		console.log();
 		console.log(`  ${WARN} taskplane is installed in TWO locations with different versions:`);
 		for (const loc of duplication.locations) {
@@ -2813,9 +2815,24 @@ function cmdDoctor() {
 			`     ${c.dim}→ Recommended fix: drop the npm-global copy and put Pi's bin dir on PATH:${c.reset}`,
 		);
 		console.log(`     ${c.cyan}    npm uninstall -g taskplane${c.reset}`);
-		console.log(
-			`     ${c.cyan}    export PATH="$HOME/.pi/agent/npm/node_modules/.bin:$PATH"${c.reset}  ${c.dim}# add to ~/.bashrc / ~/.zshrc${c.reset}`,
-		);
+		// Platform-aware PATH guidance: PowerShell on Windows, bash/zsh elsewhere.
+		// Linux & macOS users running PowerShell can still copy the bash form;
+		// Windows users running Git Bash can still copy the PowerShell form. The
+		// platform check picks the line most likely to match a fresh shell on
+		// the host OS so the inline copy/paste path is one-line on the common
+		// case.
+		if (process.platform === "win32") {
+			console.log(
+				`     ${c.cyan}    $env:PATH = "$HOME\\.pi\\agent\\npm\\node_modules\\.bin;" + $env:PATH${c.reset}  ${c.dim}# PowerShell, add to $PROFILE${c.reset}`,
+			);
+			console.log(
+				`     ${c.dim}    or, for Git Bash:${c.reset} ${c.cyan}export PATH="$HOME/.pi/agent/npm/node_modules/.bin:$PATH"${c.reset}  ${c.dim}# ~/.bashrc${c.reset}`,
+			);
+		} else {
+			console.log(
+				`     ${c.cyan}    export PATH="$HOME/.pi/agent/npm/node_modules/.bin:$PATH"${c.reset}  ${c.dim}# add to ~/.bashrc / ~/.zshrc${c.reset}`,
+			);
+		}
 		issues++;
 	}
 
@@ -3345,9 +3362,21 @@ function cmdDoctor() {
 	if (issues === 0) {
 		console.log(`${OK} ${c.green}All checks passed!${c.reset}\n`);
 	} else {
-		console.log(
-			`${FAIL} ${issues} issue(s) found. Run ${c.cyan}taskplane init${c.reset} to fix config issues.\n`,
-		);
+		// Each check above prints its own inline remediation hint, so the
+		// summary points back to those rather than recommending a single
+		// generic fix. The previous summary always recommended
+		// `taskplane init`, which was misleading when the underlying issue
+		// was a duplicate install (whose remediation is
+		// `npm uninstall -g taskplane`, not init).
+		if (duplicationDetected) {
+			console.log(
+				`${FAIL} ${issues} issue(s) found. See remediation hints above (${c.cyan}npm uninstall -g taskplane${c.reset} for the duplicate install).\n`,
+			);
+		} else {
+			console.log(
+				`${FAIL} ${issues} issue(s) found. See remediation hints above; run ${c.cyan}taskplane init${c.reset} to fix config issues.\n`,
+			);
+		}
 		process.exit(1);
 	}
 }
@@ -3434,9 +3463,16 @@ function detectDuplicateTaskplaneInstall() {
 
 	let npmRootGlobal = null;
 	try {
+		// 5s timeout guards against the rare case where `npm` is on PATH but
+		// hangs (slow registry probe, misconfigured custom prefix, etc.).
+		// `taskplane doctor` is a diagnostic — it should never make the CLI
+		// itself feel hung. On timeout, execSync throws and we fall back to
+		// the catch branch, returning null and silently skipping the
+		// duplication check (best-effort by design).
 		npmRootGlobal = execSync("npm root -g", {
 			encoding: "utf-8",
 			stdio: ["pipe", "pipe", "pipe"],
+			timeout: 5000,
 		})
 			.toString()
 			.trim();


### PR DESCRIPTION
Follow-up to PR #601. Sage's review flagged three minor issues; all three are addressed here.

## Findings addressed

### 1. Summary message no longer recommends `taskplane init` for duplicate installs ([minor], confidence high)

**Sage's finding:** the duplication block increments `issues`, so doctor exits non-zero and the final line was `'$N issue(s) found. Run taskplane init to fix config issues.'` — actively misleading when the underlying issue is a duplicate install (whose fix is `npm uninstall -g taskplane`, not init).

**Fix:** track a separate `duplicationDetected` flag; emit a context-aware summary:

- with duplication: `'See remediation hints above (npm uninstall -g taskplane for the duplicate install)'`
- without: `'See remediation hints above; run taskplane init to fix config issues'`

Either way the FAIL exit code is preserved so CI gates on doctor still catch the issue.

### 2. PowerShell-aware remediation in the duplication block ([minor], confidence high)

**Sage's finding:** the inline fix only showed bash syntax (`export PATH=...`), even though Taskplane is cross-platform and the duplicate-install issue is especially common on Windows + NVM-for-Windows (see #598). Windows users would copy/paste a non-working command.

**Fix:** branches on `process.platform`:
- Windows: shows the `$env:PATH = '$HOME\.pi\...'` PowerShell snippet first with the Git Bash equivalent as a secondary `'or, for Git Bash:'` line
- Non-Windows: shows the bash form as before

### 3. 5-second timeout on `execSync('npm root -g')` ([question], medium confidence — verify)

**Sage's finding:** `execSync` had no timeout, raising potential hang risk if npm is slow or misconfigured.

**Fix:** added `timeout: 5000` to the execSync options. On timeout the catch branch runs, returning null and silently skipping the duplication check (best-effort by design).

## Findings deliberately NOT addressed

### Sage's centralization suggestion (part of finding 3)

Sage suggested centralizing npm-root probing by sharing logic with `extensions/taskplane/path-resolver.ts`. **I'm not doing this**, with reasoning:

- `bin/taskplane.mjs` is a self-contained CLI script with no cross-module imports from the extensions tree
- Pulling in the resolver would expand the import surface for what amounts to a 5-line `execSync` call
- The two functions have distinct purposes: the path resolver **finds** Pi/Taskplane for spawning; this helper **detects** on-disk duplication for diagnostics
- Sage flagged this as 'medium confidence — verify'; on verification, the local copy is the right call

### Out-of-scope: `docs/specifications/**` references to `npm install -g taskplane`

Sage correctly labeled this as out-of-scope. Leaving it for a future docs consistency sweep.

## Validation

| Gate | Result |
|---|---|
| `npm run typecheck` | ✅ pass |
| `npm run format:check` | ✅ pass |
| Full test suite | ✅ 3,714 / 3,715 pass, 1 skipped — zero new failures |
| Doctor smoke (no duplication) | ✅ clean output, summary unchanged |
| Doctor smoke (simulated dup, Windows) | ✅ WARN block fires, PowerShell line first, Git Bash secondary, FAIL summary references `npm uninstall` instead of `taskplane init` |

## Diff summary

Single file: `bin/taskplane.mjs`, +42 −6.