### PR TITLE
release: v0.30.3 — version banner fix + doctor duplication check + install docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.3] - 2026-06-17
+
+### Fixed
+
+- **`taskplane --version` displayed "vundefined, initialized unknown" placeholders
+  for `.pi/taskplane.json` files lacking `version` / `installedAt` fields:**
+  Reproducible in any repo where `.pi/taskplane.json` exists for a non-init
+  purpose (e.g. taskplane's own source repo, where the file carries only
+  migration history). `cmdVersion()` now defensively renders only the fields
+  that are actually present and non-empty; falls through to `(metadata only)`
+  when neither field is set. Cosmetic but operator-visible.
+
+### Enhanced
+
+- **`taskplane doctor` detects duplicate Pi-private / npm-global installs:**
+  Pi 0.75.0 (2026-05-17) moved user-scoped pi extensions from npm's global
+  root to `~/.pi/agent/npm/node_modules/`. Operators who had previously
+  installed via `npm install -g taskplane` now have two on-disk copies that
+  drift independently: `pi update` refreshes only the Pi-private one, so the
+  system-wide CLI silently runs stale code. The new
+  `detectDuplicateTaskplaneInstall()` helper in `cmdDoctor` identifies this
+  state (both copies present + versions differ) and emits a WARN with both
+  paths, both versions, and a platform-aware remediation (PowerShell snippet
+  on Windows, bash form on Linux/macOS, both inline on either). Same-version
+  pairs are silently tolerated. Best-effort: 5s timeout on `npm root -g`,
+  silently returns null on errors so doctor never crashes on this side
+  check. Doctor's failure-summary line is also context-aware now: when
+  duplication is the issue it points at `npm uninstall -g taskplane`
+  instead of the generic `taskplane init` (which was actively misleading
+  remediation for this case).
+
+### Docs
+
+- **`README.md` Installation section:** documents the PATH requirement for
+  Pi 0.75.0+ (bash/zsh + PowerShell snippets) so the `taskplane` CLI is
+  callable on the shell after `pi install npm:taskplane`. Adds a
+  duplication-caveat note for users who previously ran
+  `npm install -g taskplane` under older docs.
+- **`docs/tutorials/install.md`:** Reframes Option A (Global install) to
+  explicitly steer users away from `npm install -g taskplane` as the
+  primary install command, citing the Pi 0.75.0 install-location change
+  and the duplication caveat. Expands the "taskplane not on PATH"
+  troubleshooting section into three labeled options (npx, direct bin
+  invocation, PATH addition) with platform-specific snippets for each.
+
 ## [0.30.2] - 2026-06-17
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.30.2",
+      "version": "0.30.3",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Patch release wrapping three observability/polish improvements since v0.30.2.

## Patch justification (semver)

All three entries are non-breaking improvements:
- **Fixed:** `taskplane --version` placeholder cosmetic bug — display-only.
- **Enhanced:** `taskplane doctor` gains a new advisory check; existing checks unchanged.
- **Docs:** README + install tutorial guidance updates.

No code changes affect `/orch` or `/task` execution. Patch bump (`0.30.2 → 0.30.3`) is the appropriate semver level.

## Issues / PRs included

| # | Title |
|---|---|
| #601 | version-banner placeholders + doctor duplication check + install docs |
| #602 | Sage review follow-up: context-aware doctor summary, PowerShell remediation, execSync timeout |

No issues are 'closed by' this release directly — both PRs were operator-experience polish in response to today's workflow discoveries around Pi 0.75.0's install-location change.

## Highlights

- **Doctor now warns about the Pi-private vs npm-global duplication state** that silently strands users with stale CLI versions. Includes platform-aware remediation (PowerShell on Windows, bash elsewhere). This is the actual fix for the operator-pain root cause we identified today: `pi update` reporting success while the system-wide CLI stays stale.
- **`taskplane --version` no longer shows "(vundefined, initialized unknown)"** for repos where `.pi/taskplane.json` exists for non-init purposes (e.g. taskplane's own source repo).
- **Documentation steers new users toward the Pi-managed install** (single-source via `pi update`) and away from `npm install -g taskplane` (which creates the duplication state in the first place).

## Validation

Run on `54009550` (the version-bump commit):

| Gate | Result |
|---|---|
| `npm run typecheck` | ✅ pass |
| `npm run lint` | ✅ identical to v0.30.2 |
| `npm run format:check` | ✅ pass |
| `cd extensions && npm run test:fast` | ✅ 3,714 / 3,715 pass, 1 skipped |
| `node bin/taskplane.mjs help` | ✅ pass |
| `node bin/taskplane.mjs doctor` | ✅ all checks pass |
| `npm pack --dry-run` | ✅ 77 files, no spurious entries |

## After merge

Per the release workflow, after this PR merges I'll push the `v0.30.3` tag from local. The `.github/workflows/release.yml` workflow handles tag validation, test re-run, `npm publish --provenance` via Trusted Publishing, and the GitHub release with notes extracted from CHANGELOG.

Expected total time after tag push: ~30–60 seconds.