### PR TITLE
docs: install tutorial PATH co-location + Pi GitHub URL sweep

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.
 
 - [Node.js](https://nodejs.org/) ≥ 20.0.0
 - [Git](https://git-scm.com/)
-- [pi](https://github.com/badlogic/pi-mono) (the AI coding agent Taskplane extends)
+- [pi](https://github.com/earendil-works/pi) (the AI coding agent Taskplane extends)
 - [just](https://github.com/casey/just) (optional — task runner for common commands)
 
 ### Clone and Install

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Taskplane
 
-Multi-agent AI orchestration for coding with [pi](https://github.com/badlogic/pi-mono) — parallel task execution, mono- and poly-repo support, fresh-context worker loops, cross-model reviews, automated merges and a killer dashboard! 
+Multi-agent AI orchestration for coding with [pi](https://github.com/earendil-works/pi) — parallel task execution, mono- and poly-repo support, fresh-context worker loops, cross-model reviews, automated merges and a killer dashboard! 
 
 > **Status:** Initial release.
 
@@ -50,7 +50,7 @@ Taskplane is a pi package. You need Node.js 22+, pi and Git installed first.
 | Dependency | Required | Notes |
 |-----------|----------|-------|
 | [Node.js](https://nodejs.org/) ≥ 22 | Yes | Runtime |
-| [pi](https://github.com/badlogic/pi-mono) | Yes | Agent framework |
+| [pi](https://github.com/earendil-works/pi) | Yes | Agent framework |
 | [Git](https://git-scm.com/) | Yes | Version control, worktrees |
 
 IMPORTANT: If you just installed pi, make sure you've configured at least one model provider and tested before installing Taskplane.

--- a/docs/specifications/cli/CLI-SPEC.md
+++ b/docs/specifications/cli/CLI-SPEC.md
@@ -9,7 +9,7 @@
 
 ## 1. Problem Statement
 
-Taskplane is an AI agent orchestration system built as a set of [pi](https://github.com/badlogic/pi-mono) extensions. It provides:
+Taskplane is an AI agent orchestration system built as a set of [pi](https://github.com/earendil-works/pi) extensions. It provides:
 
 - **Task Runner** (`/task`) — Autonomous single-task execution with checkpoint discipline, fresh-context worker loops, and cross-model reviews
 - **Task Orchestrator** (`/orch`) — Parallel multi-task execution using git worktrees, dependency-aware wave scheduling, and automated merges

--- a/docs/tutorials/install.md
+++ b/docs/tutorials/install.md
@@ -5,7 +5,7 @@ This tutorial gets Taskplane running in a project and verifies that `/orch` is a
 ## Prerequisites
 
 - Node.js **22+**
-- [pi](https://github.com/badlogic/pi-mono)
+- [pi](https://github.com/earendil-works/pi)
 - Git
 
 ---
@@ -22,7 +22,25 @@ Use this if you want Taskplane commands available in every pi session.
 pi install npm:taskplane
 ```
 
-> **Recommended.** This registers the package for pi extension/skill auto-discovery AND keeps Taskplane updateable via `pi update` (a single source of truth).
+As of pi `0.75.0`, this installs Taskplane into pi's private extension directory (`~/.pi/agent/npm/node_modules/`) rather than the system npm-global root. To make the `taskplane` CLI callable from your shell, add pi's bin dir to PATH once:
+
+```bash
+# bash / zsh — add to ~/.bashrc or ~/.zshrc
+export PATH="$HOME/.pi/agent/npm/node_modules/.bin:$PATH"
+```
+
+```powershell
+# PowerShell — persistent across sessions (set the user-scope env var once)
+[Environment]::SetEnvironmentVariable(
+  "PATH",
+  "$HOME\.pi\agent\npm\node_modules\.bin;" + [Environment]::GetEnvironmentVariable("PATH", "User"),
+  "User"
+)
+```
+
+With Pi's bin dir on PATH, `pi update` keeps Taskplane current automatically — a single source of truth, no second update command needed.
+
+> **Recommended.** This pattern registers the package for pi extension/skill auto-discovery AND keeps Taskplane updateable via `pi update`.
 
 > **Avoid `npm install -g taskplane`** unless you have a specific reason. As of pi `0.75.0`, `pi install` puts Taskplane in pi's private extension directory (`~/.pi/agent/npm/node_modules/`). A separate `npm install -g taskplane` creates a **second** on-disk copy in the system npm-global root, and the two drift independently — `pi update` only refreshes the pi-private copy. If you're already in this state, `taskplane doctor` detects it and prints a remediation.
 


### PR DESCRIPTION
Two coordinated documentation changes.

## 1. `docs/tutorials/install.md` — PATH setup co-located with install command

Option A (Global install) now shows the PATH setup snippets (bash/zsh AND PowerShell) directly under the `pi install npm:taskplane` command, rather than only in the 'taskplane not on your PATH' troubleshooting section several headings later.

A user reading top-to-bottom now hits the complete unified-update recipe at the natural decision point: *install, then put pi's bin dir on PATH, and `pi update` is your single source of truth.*

The 'taskplane not on PATH' section later in the file still has the three-option troubleshooting menu (npx, direct invocation, PATH addition) for users who reach that section without having read Option A.

## 2. Pi GitHub URL sweep — `badlogic/pi-mono` → `earendil-works/pi`

Pi's canonical repository is now at `https://github.com/earendil-works/pi` per Pi's own `package.json`:

```json
"repository": {
  "type": "git",
  "url": "git+https://github.com/earendil-works/pi.git"
}
```

Four user-facing docs still pointed at the legacy `badlogic/pi-mono` location. Sweep update:

| File | Refs updated |
|---|---|
| `README.md` | 2 |
| `CONTRIBUTING.md` | 1 |
| `docs/specifications/cli/CLI-SPEC.md` | 1 |
| `docs/tutorials/install.md` | 1 |

All five replaced with the canonical `https://github.com/earendil-works/pi` URL. Verified post-change: zero `badlogic/pi-mono` references remain in the `.md` tree.

## Out of scope (noticed during sweep)

There are still several `@mariozechner/*` package-name references in maintainer and specification docs:

- `docs/maintainers/development-setup.md` (loader mock docs)
- `docs/maintainers/testing.md` (loader mock docs)
- `docs/specifications/cli/CLI-SPEC.md` (peerDeps example)
- `docs/specifications/framework/33-parallel-task-orchestrator.md` (3x `npm install -g @mariozechner/pi-coding-agent`)
- `docs/specifications/taskplane/code-quality-gates.md` (already self-aware about staleness; flagged 'TP-191 will refresh')
- `docs/specifications/taskplane/migrate-to-node-test-runner.md` (test alias docs)

These are about the npm **package scope** (Pi was renamed from `@mariozechner/pi-coding-agent` to `@earendil-works/pi-coding-agent` at Pi v0.74.0), distinct from the GitHub URL change this PR addresses. Some are accurately documenting back-compat for legacy scopes (the test loader DOES need to recognize both for tests to run against historical Pi versions), others are stale. Worth a follow-up cleanup pass; not in scope for this PR per your request scope.

## Validation

| Gate | Result |
|---|---|
| `npm run format:check` | ✅ pass |
| `grep -rn 'badlogic/pi-mono' --include='*.md' .` | ✅ no matches |
| Install tutorial Option A reads coherently top-to-bottom | ✅ visually verified |

No code changes, no release needed.