### PR TITLE
docs: follow-up sweep on stale @mariozechner/* refs (TP-191 follow-up)

### DIFF
--- a/docs/specifications/cli/CLI-SPEC.md
+++ b/docs/specifications/cli/CLI-SPEC.md
@@ -152,9 +152,9 @@ taskplane/                              ← npm package root (= repo root)
     "templates/"
   ],
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
-    "@mariozechner/pi-tui": "*",
-    "@mariozechner/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
+    "@earendil-works/pi-ai": "*",
     "@sinclair/typebox": "*"
   },
   "dependencies": {
@@ -949,9 +949,9 @@ Clear ownership prevents upgrade conflicts:
 
 | Dependency | Range | Purpose |
 |---|---|---|
-| `@mariozechner/pi-coding-agent` | `*` | Pi extension runtime |
-| `@mariozechner/pi-tui` | `*` | TUI components for widgets |
-| `@mariozechner/pi-ai` | `*` | AI utilities (StringEnum) |
+| `@earendil-works/pi-coding-agent` | `*` | Pi extension runtime |
+| `@earendil-works/pi-tui` | `*` | TUI components for widgets |
+| `@earendil-works/pi-ai` | `*` | AI utilities (StringEnum) |
 | `@sinclair/typebox` | `*` | Schema definitions for tool parameters |
 
 ### Dev

--- a/docs/specifications/framework/33-parallel-task-orchestrator.md
+++ b/docs/specifications/framework/33-parallel-task-orchestrator.md
@@ -1606,7 +1606,7 @@ sudo dnf install git tmux
 sudo pacman -S git tmux
 
 # Pi (via npm)
-npm install -g @mariozechner/pi-coding-agent
+npm install -g @earendil-works/pi-coding-agent
 ```
 
 TMUX and Git are standard packages on all major Linux distributions.
@@ -1619,7 +1619,7 @@ No special configuration needed.
 brew install git tmux
 
 # Pi
-npm install -g @mariozechner/pi-coding-agent
+npm install -g @earendil-works/pi-coding-agent
 ```
 
 macOS ships with Git, but the Homebrew version is typically newer.
@@ -1668,7 +1668,7 @@ Key facts about Git Bash TMUX:
 ```bash
 # Inside WSL:
 sudo apt install tmux git
-npm install -g @mariozechner/pi-coding-agent
+npm install -g @earendil-works/pi-coding-agent
 ```
 
 WSL works but introduces filesystem boundary considerations:

--- a/docs/specifications/taskplane/code-quality-gates.md
+++ b/docs/specifications/taskplane/code-quality-gates.md
@@ -73,7 +73,7 @@ It slipped through:
 
 ```json
 {
-  "// NOTE": "Pi extensions are runtime-transpiled by pi's bundler. This tsconfig is for editor/CI type-checking only. Full tsc --noEmit will report module resolution errors for @mariozechner/* packages (globally installed, not in node_modules).",
+  "// NOTE": "Pi extensions are runtime-transpiled by pi's bundler. This tsconfig is for editor/CI type-checking only. Full tsc --noEmit will report module resolution errors for @earendil-works/* packages — and legacy @mariozechner/* aliases retained for back-compat — because pi packages are globally installed (not in node_modules). See extensions/tsconfig.ci.json for the CI variant that adds pi-shims path mappings.",
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
@@ -93,7 +93,7 @@ It slipped through:
 
 1. The pi packages (`@earendil-works/pi-coding-agent`, `@earendil-works/pi-ai`, `@earendil-works/pi-tui` — and legacy `@mariozechner/*`) are NOT in `node_modules`. They live at `npm root -g/<scope>/<pkg>` and are aliased at runtime by Pi's extension loader. `tsc --noEmit` cannot resolve them.
 2. `include: ["task-orchestrator.ts"]` only covers ONE entry point. The reviewer extension and the rest of `extensions/taskplane/` are excluded from typecheck scope today.
-3. The `// NOTE` comment in this file is **stale** — it still references `@mariozechner/*` only, even though the canonical scope is now `@earendil-works/*` (per issue #560 and Pi v0.74.0). This is a historical reference, not the current canonical scope. **TP-191 will refresh the comment** as part of the tsconfig modernization.
+3. ~~The `// NOTE` comment in this file is **stale** — it still references `@mariozechner/*` only, even though the canonical scope is now `@earendil-works/*` (per issue #560 and Pi v0.74.0). This is a historical reference, not the current canonical scope. **TP-191 will refresh the comment** as part of the tsconfig modernization.~~ **(Addressed 2026-06-17:** the comment now mentions both scopes — `@earendil-works/*` as canonical, `@mariozechner/*` as legacy back-compat — and points readers at `tsconfig.ci.json` for the CI-shim path mappings. This was overlooked during the TP-191 implementation and folded into a follow-up cleanup pass.**)**
 
 ### 4.2 `extensions/tsconfig.test.json`
 

--- a/extensions/tsconfig.json
+++ b/extensions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "// NOTE": "Pi extensions are runtime-transpiled by pi's bundler. This tsconfig is for editor/CI type-checking only. Full tsc --noEmit will report module resolution errors for @mariozechner/* packages (globally installed, not in node_modules).",
+  "// NOTE": "Pi extensions are runtime-transpiled by pi's bundler. This tsconfig is for editor/CI type-checking only. Full tsc --noEmit will report module resolution errors for @earendil-works/* packages — and legacy @mariozechner/* aliases retained for back-compat — because pi packages are globally installed (not in node_modules). See extensions/tsconfig.ci.json for the CI variant that adds pi-shims path mappings.",
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",


### PR DESCRIPTION
Pi was renamed from `@mariozechner/pi-coding-agent` to `@earendil-works/pi-coding-agent` at Pi v0.74.0 (issue #560). TP-191's tsconfig modernization was supposed to refresh the related stale references in spec docs and tsconfigs, but several were overlooked. This is a focused follow-up sweep.

## What's updated (clearly stale)

| File | What changed | Why |
|---|---|---|
| `extensions/tsconfig.json` (`// NOTE` comment) | Updated to mention both scopes (`@earendil-works/*` canonical, legacy `@mariozechner/*` for back-compat) and point readers at `tsconfig.ci.json` | Explicitly flagged stale in `code-quality-gates.md`; TP-191 was supposed to fix it but didn't |
| `docs/specifications/cli/CLI-SPEC.md` | Two locations: `peerDependencies` JSON example + the 'Peer (Extensions)' dependency table | Spec was misleading: current `package.json` uses `@earendil-works/*` peerDeps, not `@mariozechner/*` |
| `docs/specifications/framework/33-parallel-task-orchestrator.md` | 3× `npm install -g @mariozechner/pi-coding-agent` → `@earendil-works` (Arch, macOS, Windows WSL install sections) | Per AGENTS.md and current Pi docs, canonical install command is the new scope |
| `docs/specifications/taskplane/code-quality-gates.md` | Updated the quoted `tsconfig.json` NOTE to match new file content + added 'Addressed 2026-06-17' callout next to the original 'TP-191 will refresh' forward-looking statement | Keeps the spec's audit trail intact |

## What's deliberately left alone (accurate descriptions, not stale)

| File | Why preserved |
|---|---|
| `docs/maintainers/development-setup.md` lines 111-112 | Accurately describes the test loader aliasing `@mariozechner/*` — which it does, because source code still imports from `@mariozechner/*` (Pi maintains both scope aliases at runtime for back-compat) |
| `docs/maintainers/testing.md` lines 105-106 | Same context |
| `docs/specifications/taskplane/migrate-to-node-test-runner.md` | Historical migration spec; quotes are accurate descriptions of pre-migration Vitest config |
| `docs/specifications/taskplane/code-quality-gates.md` lines 106-107, 114 | Accurately describes the current `tsconfig.test.json` state. Fixing would require coordinated updates to `tsconfig.test.json`, `loader-hooks.mjs`, and source imports — out of scope for a docs-only sweep |
| `CHANGELOG.md`, `taskplane-tasks/**` | Historical artifacts |

## Future cleanup (when convenient)

If source code ever migrates from `@mariozechner/*` imports to `@earendil-works/*` (which would match the current `peerDependencies`), a coordinated change to the loader and tsconfigs would be needed. The remaining accurate-as-of-today references in the maintainer docs would then become stale and would need to be swept too. Not urgent — Pi maintains the back-compat aliases.

## Validation

| Gate | Result |
|---|---|
| `npm run typecheck` | ✅ pass |
| `npm run lint` | ✅ 286 warnings / 671 infos — identical to `main` |
| `npm run format:check` | ✅ pass |
| Full test suite | ✅ 3,714 / 3,715 pass, 1 skipped — zero new failures |

No code changes that affect runtime behavior, no release needed.