### PR TITLE
release: v0.30.4 — supervisor stale-ctx hardening + docs sweeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.4] - 2026-06-19
+
+### Fixed
+
+- **Supervisor heartbeat timer crashed pi with stale extension ctx (#597,
+  reported by @beettlle):** Pi throws `"This extension ctx is stale after
+  session replacement or reload"` from its `assertActive` guard when an
+  extension uses a captured `pi: ExtensionAPI` handle after `ctx.newSession()`,
+  `ctx.fork()`, `ctx.switchSession()`, or `ctx.reload()`. Two background
+  timers in `supervisor.ts` (`startHeartbeat` takeover-detection branch,
+  `startEventTailer.notify` callback) captured `pi` in their closures and
+  called `pi.sendMessage()` at arbitrary times — when the captured handle
+  went stale between ticks, the throw became a process-fatal
+  `uncaughtException` that killed the entire Pi process during normal
+  batch startup, taking the operator's supervisor UI and monitoring down
+  with it.
+
+  Fix introduces two helpers (`isStaleExtensionCtx` and
+  `safeSendMessageFromTimer`) and rewires three `pi.sendMessage` call sites
+  through the never-throw wrapper: the two known timer-context sites plus
+  `presentBatchSummary` (reachable indirectly via `startHeartbeat →
+  deactivateSupervisor → presentBatchSummary` when `state.pendingSummaryDeps`
+  is set — caught by Sage's code review as a blocking gap in the initial
+  fix). Also adds defensive timer teardown at the top of
+  `activateSupervisor` so re-activation paths can't orphan timers holding
+  stale `pi` references. 9 new regression tests in `supervisor.test.ts`
+  including a behavioral test (8.22) that mutation-verifies it actually
+  catches regressions in the indirect path.
+
+### Docs
+
+- **Pi GitHub URL sweep + install tutorial PATH co-location (#604):** Five
+  references to the legacy `https://github.com/badlogic/pi-mono` URL in
+  `README.md`, `CONTRIBUTING.md`, `docs/specifications/cli/CLI-SPEC.md`,
+  and `docs/tutorials/install.md` updated to Pi's canonical repo at
+  `https://github.com/earendil-works/pi`. Install tutorial's Option A
+  also gains the PATH-setup snippets (bash/zsh + PowerShell) co-located
+  with the install command, so users hit the complete unified-update
+  recipe (`pi install` → add bin dir to PATH → `pi update` is the single
+  source of truth) at the natural decision point rather than only in
+  the later 'taskplane not on PATH' troubleshooting section.
+- **`@mariozechner/*` stale-references follow-up sweep (#605):** Pi was
+  renamed from `@mariozechner/pi-coding-agent` to
+  `@earendil-works/pi-coding-agent` at Pi v0.74.0 (issue #560). TP-191's
+  tsconfig modernization was supposed to refresh related stale references
+  but several were overlooked. This sweep updates the truly stale items
+  (the `extensions/tsconfig.json` `// NOTE` comment that the
+  `code-quality-gates.md` spec explicitly flagged as awaiting refresh,
+  the CLI-SPEC peerDependencies examples, and three `npm install -g
+  @mariozechner/pi-coding-agent` install commands in the framework spec)
+  while preserving accurate descriptions of back-compat behavior in
+  maintainer docs (the test loader genuinely still aliases
+  `@mariozechner/*` because Taskplane source code still imports under
+  those names — Pi maintains both scope aliases at runtime).
+
 ## [0.30.3] - 2026-06-17
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.30.3",
+  "version": "0.30.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.30.3",
+      "version": "0.30.4",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.30.3",
+  "version": "0.30.4",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Patch release wrapping one high-severity bug fix and two coordinated documentation sweeps since v0.30.3.

## Patch justification (semver)

- **Fixed:** real bug fix (process-crashing supervisor stale-ctx), no breaking changes.
- **Docs:** repo URL and stale package-scope reference sweeps — non-code.

No public API or behavior changes beyond the bug remediation. Patch bump (`0.30.3 → 0.30.4`) is the appropriate semver level.

## Issues / PRs included

| # | Title | Severity |
|---|---|---|
| **#597** | Supervisor heartbeat timer crashes pi with stale extension ctx | **High** — process-fatal during normal batch startup |
| #604 | Pi GitHub URL sweep (badlogic → earendil-works) + install tutorial PATH co-location | Docs |
| #605 | `@mariozechner/*` stale-references follow-up sweep | Docs |

## Highlights

- **#597 was the headline fix.** External reporter (@beettlle) provided an excellent root-cause analysis with stack trace and proposed three-part remediation. The implementation followed their fix sketch and went through Sage code review, which caught a blocking gap in the initial PR (an indirect call chain via `presentBatchSummary` that was missed). Final PR addresses both the direct timer call sites AND the indirect path, with 9 regression tests including a mutation-verified behavioral test.
- The two docs sweeps clean up post-rename hygiene from Pi's repo and package-scope migrations earlier in the project's history.

## Validation

Run on the merge commit (`54ddf91a`):

| Gate | Result |
|---|---|
| `npm run typecheck` | ✅ pass |
| `npm run lint` | ✅ 286 warnings / 671 infos — identical to v0.30.3 |
| `npm run format:check` | ✅ pass |
| `cd extensions && npm run test:fast` | ✅ 3,723 / 3,724 pass, 1 skipped |
| `node bin/taskplane.mjs help` | ✅ pass |
| `node bin/taskplane.mjs doctor` | ✅ pass |
| `npm pack --dry-run` | ✅ 77 files |

## After merge

Per the release workflow, I'll push the `v0.30.4` tag from local after this PR merges. The `.github/workflows/release.yml` workflow handles tag validation, test re-run, `npm publish --provenance` via Trusted Publishing, and the GitHub release with notes extracted from CHANGELOG.

Expected total time after tag push: ~30–60 seconds.