### PR TITLE
chore(deps): consolidate GitHub Actions version bumps (supersedes #591, #592, #593, #608)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,16 +38,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Taskplane Overview artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/taskplane-overview
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           fi
 
       - name: Checkout tagged commit
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ steps.ref.outputs.ref }}
           fetch-depth: 0


### PR DESCRIPTION
Consolidates four separate Dependabot PRs that each touched `.github/workflows/pages.yml` and would have cascade-conflicted on sequential merge.

## Why consolidate instead of merging the Dependabot PRs

- **#591** (deploy-pages 4→5), **#592** (configure-pages 5→6), **#593** (upload-pages-artifact 3→5), **#608** (checkout 4→7) all edit `pages.yml`. `configure-pages` (line 44) and `upload-pages-artifact` (line 47) share a diff hunk, so merging one forces the others to rebase — 3–4 rounds of `@dependabot rebase`.
- Doing it in one commit also lets me fix a **checkout version skew**: PR #590 (merged earlier today) bumped `ci.yml` and `release.yml` from v4→v6 but left `pages.yml` on v4. Landing `pages.yml` on v7 while the others stayed v6 would leave three workflows at v6/v6/v7. This PR aligns all three to **v7**.

## Changes

| File | Action | From → To |
|---|---|---|
| `pages.yml` | actions/checkout | v4 → **v7** |
| `pages.yml` | actions/configure-pages | v5 → **v6** |
| `pages.yml` | actions/upload-pages-artifact | v3 → **v5** |
| `pages.yml` | actions/deploy-pages | v4 → **v5** |
| `ci.yml` | actions/checkout | v6 → **v7** |
| `release.yml` | actions/checkout | v6 → **v7** |

## Compatibility note

`upload-pages-artifact` v3 → v5 crosses the **artifact-backend change** (same generation as `actions/upload-artifact` v4). It's compatible only when `deploy-pages` moves up in lockstep — which is exactly why the Pages trio is bumped **together** here rather than piecemeal.

## ⚠️ CI green ≠ Pages deploy validated

The `ci` check is `ci.yml`, which does **not** exercise `pages.yml` (that only runs on push to `main` touching `docs/taskplane-overview/**`, or via `workflow_dispatch`). So this PR's green CI does not validate the Pages deploy. **I will verify the actual deploy via `workflow_dispatch` immediately after merge** — if the new action versions break the microsite publish, I'll catch it then and roll back.

## Follow-up

After merge + Pages-deploy verification, Dependabot PRs #591, #592, #593, #608 will be closed as superseded. The `yaml` bump (#579, npm ecosystem, different file) is handled separately.