### PR TITLE
fix(#621): supervisor status injection during in-flight tool call wedges interactive session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Supervisor status injection during an in-flight tool call wedged the
+  interactive session (#621):** On batch phase transitions the supervisor
+  injects display banners via `pi.sendMessage(customEntry, {triggerTurn:false})`,
+  which appends the entry (rendered `role:"user"`) at the current session leaf.
+  If the interactive agent had an assistant `tool_use` appended but its
+  `tool_result` had not yet landed (tool still executing), the banner spliced
+  *between* them. On the next request Anthropic hard-rejected the conversation
+  (`400 ... unexpected tool_use_id ... in tool_result blocks; each tool_result
+  must have a corresponding tool_use block in the previous message`),
+  permanently wedging the session — every retry re-sent the same broken
+  ordering. Recovery previously required hand-editing the session `.jsonl`.
+
+  Fixed with a two-layer defense:
+  1. **Prevention** — a `SupervisorNoticeGate` routes the batch-end epilogue
+     through an idleness check: it runs immediately when the agent is idle,
+     otherwise defers the whole epilogue to the next `agent_settled` boundary
+     (the first lifecycle point at which all tool results, retries, compaction,
+     and queued continuations have finished). A monotonic batch generation tag
+     lets a newer batch — started via `/orch` **or** `/orch-resume` — supersede
+     stale deferred work.
+  2. **Defense-in-depth** — a `context` event handler
+     (`repairToolResultOrdering`) reorders every outgoing provider request so
+     each `tool_use` is immediately followed by its matching `tool_result`(s),
+     relocating any spliced-in message after the tool-result group. This covers
+     the other background `sendMessage` sites (heartbeat, routing, integration
+     progress) without gating each one, and only transforms the per-request
+     context — the persisted session tree is untouched, so it self-corrects
+     across reloads. Hardened (per Sage review) to preserve duplicate results,
+     track emitted messages by identity, and repair result-before-assistant
+     ordering without ever dropping a `tool_result`.
+
+  **Behavior note:** when a batch completes while the interactive agent is
+  mid-turn, auto-integration (supervised/auto modes) now starts at the next
+  `agent_settled` boundary rather than instantly — a small, bounded latency
+  introduced deliberately to guarantee the epilogue can never split a
+  `tool_use`/`tool_result` pair. This is distinct from #597 (a stale-ctx
+  heartbeat *crash*); the `safeSendMessageFromTimer` wrapper from #597 does
+  not prevent #621 because the send succeeds — it just lands in the wrong place.
+
 ## [0.30.4] - 2026-06-19
 
 ### Fixed

--- a/extensions/taskplane/context-repair.ts
+++ b/extensions/taskplane/context-repair.ts
@@ -40,10 +40,15 @@ interface AgentMessageLike {
 }
 
 function toolUseIds(msg: AgentMessageLike): string[] {
-	if (msg.role !== "assistant" || !Array.isArray(msg.content)) return [];
+	if (!msg || msg.role !== "assistant" || !Array.isArray(msg.content)) return [];
 	const ids: string[] = [];
 	for (const block of msg.content as ToolCallBlock[]) {
-		if (block && typeof block === "object" && block.type === "toolCall" && typeof block.id === "string") {
+		if (
+			block &&
+			typeof block === "object" &&
+			block.type === "toolCall" &&
+			typeof block.id === "string"
+		) {
 			ids.push(block.id);
 		}
 	}
@@ -55,6 +60,15 @@ function toolUseIds(msg: AgentMessageLike): string[] {
  * its matching `toolResult`(s), relocating any spliced-in non-tool messages to
  * after the tool-result group.
  *
+ * Robustness (Sage #621 review):
+ * - Duplicate `toolResult` messages sharing a `toolCallId` are all preserved
+ *   (queue-based grouping, not last-wins), so repair never drops data.
+ * - Emitted results are tracked by message identity, not by id.
+ * - Also repairs the result-before-assistant shape: a `toolResult` whose owning
+ *   assistant appears later is held and pulled forward at the owner.
+ * - A final safety-net pass appends any never-emitted result, guaranteeing no
+ *   `toolResult` is ever lost regardless of input malformation.
+ *
  * Returns the SAME array reference when already well-formed (no reordering
  * needed), so callers can cheaply detect a no-op. Otherwise returns a new,
  * reordered array. Pure: never mutates the input array or its elements.
@@ -62,40 +76,70 @@ function toolUseIds(msg: AgentMessageLike): string[] {
 export function repairToolResultOrdering<T extends AgentMessageLike>(messages: T[]): T[] {
 	if (!Array.isArray(messages) || messages.length < 3) return messages;
 
-	// Map each toolCallId -> its toolResult message (last one wins if duplicated).
-	const resultById = new Map<string, T>();
+	// Collect ALL toolResult messages per toolCallId, preserving original order.
+	// A queue (array) rather than last-wins so duplicate results for the same id
+	// are never dropped (Sage #621 review: last-wins could silently lose data).
+	const resultsById = new Map<string, T[]>();
 	for (const m of messages) {
 		if (m && m.role === "toolResult" && typeof m.toolCallId === "string") {
-			resultById.set(m.toolCallId, m);
+			const list = resultsById.get(m.toolCallId);
+			if (list) list.push(m);
+			else resultsById.set(m.toolCallId, [m]);
 		}
 	}
-	if (resultById.size === 0) return messages;
+	if (resultsById.size === 0) return messages;
+
+	// First-occurrence index of the assistant that owns each toolCallId. Lets us
+	// HOLD an in-place toolResult whose owning assistant appears LATER, repairing
+	// the result-before-assistant shape (Sage #621 review) instead of emitting it
+	// in a position that would still be invalid.
+	const ownerIndexById = new Map<string, number>();
+	for (let i = 0; i < messages.length; i++) {
+		for (const id of toolUseIds(messages[i])) {
+			if (!ownerIndexById.has(id)) ownerIndexById.set(id, i);
+		}
+	}
 
 	const out: T[] = [];
-	const emitted = new Set<string>();
+	// Track emitted results by message IDENTITY, not by id, so duplicate result
+	// messages sharing a toolCallId are each accounted for individually.
+	const emitted = new Set<T>();
 
 	for (let i = 0; i < messages.length; i++) {
 		const m = messages[i];
 		if (m && m.role === "toolResult" && typeof m.toolCallId === "string") {
-			// Emit here only if not already pulled forward next to its assistant;
-			// otherwise skip (its original, now-misplaced slot is dropped).
-			if (!emitted.has(m.toolCallId)) {
-				out.push(m);
-				emitted.add(m.toolCallId);
-			}
+			if (emitted.has(m)) continue; // already pulled forward next to its assistant
+			const owner = ownerIndexById.get(m.toolCallId);
+			// Owner appears later → hold; it will be pulled forward at the owner.
+			// Owner earlier (normal splice case) or orphan (no owner) → emit in place.
+			if (owner !== undefined && owner > i) continue;
+			out.push(m);
+			emitted.add(m);
 			continue;
 		}
 
 		out.push(m);
 
-		// Pull each matching toolResult to immediately follow this assistant, in
-		// tool-call order.
+		// Pull every matching toolResult (all of them, in original order) to
+		// immediately follow this assistant, in tool-call order.
 		for (const id of toolUseIds(m)) {
-			if (emitted.has(id)) continue;
-			const result = resultById.get(id);
-			if (!result) continue; // genuinely unanswered tool_use — not repairable here
-			out.push(result);
-			emitted.add(id);
+			const list = resultsById.get(id);
+			if (!list) continue; // genuinely unanswered tool_use — not repairable here
+			for (const result of list) {
+				if (emitted.has(result)) continue;
+				out.push(result);
+				emitted.add(result);
+			}
+		}
+	}
+
+	// Safety net: guarantee no toolResult is ever dropped. Any result not emitted
+	// above (only reachable via a held-but-never-pulled edge case) is appended in
+	// original order. Guarded by identity so it can never double-emit.
+	for (const m of messages) {
+		if (m && m.role === "toolResult" && typeof m.toolCallId === "string" && !emitted.has(m)) {
+			out.push(m);
+			emitted.add(m);
 		}
 	}
 

--- a/extensions/taskplane/context-repair.ts
+++ b/extensions/taskplane/context-repair.ts
@@ -1,0 +1,114 @@
+/**
+ * In-flight tool_use/tool_result ordering repair — issue #621 (defense in depth).
+ *
+ * The supervisor injects `custom` display messages via pi.sendMessage(). Any
+ * such injection that lands while the interactive agent has a tool call in
+ * flight splices a message BETWEEN an assistant `tool_use` and its
+ * `toolResult`. Anthropic then rejects the request:
+ *
+ *   400 messages.N.content.M: unexpected `tool_use_id` found in `tool_result`
+ *   blocks ... Each `tool_result` block must have a corresponding `tool_use`
+ *   block in the previous message.
+ *
+ * The batch-end epilogue gate (supervisor-dispatch.ts) prevents the most common
+ * source, but the supervisor has many other background `pi.sendMessage(...,
+ * {triggerTurn:false})` sites (integration progress/result, heartbeat, routing)
+ * that can splice the same way. Rather than gate each one, this module repairs
+ * the ORDERING of the outgoing message array on the pi `context` event, which
+ * fires before every provider request (`transformContext`, on the pi-internal
+ * AgentMessage[] before convertToLlm). Each assistant's tool results are pulled
+ * to immediately follow it (in tool-call order); any spliced-in `custom`/`user`
+ * messages move to after the tool-result group. The request is therefore always
+ * valid regardless of where a stray message was appended, and a mistimed
+ * injection can never wedge the session.
+ *
+ * This does not mutate the persisted session tree — it only transforms the
+ * per-request context — so it is safe, idempotent, and self-correcting across
+ * reloads.
+ */
+
+interface ToolCallBlock {
+	type: string;
+	id?: string;
+	[key: string]: unknown;
+}
+interface AgentMessageLike {
+	role?: string;
+	content?: unknown;
+	toolCallId?: string;
+	[key: string]: unknown;
+}
+
+function toolUseIds(msg: AgentMessageLike): string[] {
+	if (msg.role !== "assistant" || !Array.isArray(msg.content)) return [];
+	const ids: string[] = [];
+	for (const block of msg.content as ToolCallBlock[]) {
+		if (block && typeof block === "object" && block.type === "toolCall" && typeof block.id === "string") {
+			ids.push(block.id);
+		}
+	}
+	return ids;
+}
+
+/**
+ * Reorder `messages` so every assistant `tool_use` is immediately followed by
+ * its matching `toolResult`(s), relocating any spliced-in non-tool messages to
+ * after the tool-result group.
+ *
+ * Returns the SAME array reference when already well-formed (no reordering
+ * needed), so callers can cheaply detect a no-op. Otherwise returns a new,
+ * reordered array. Pure: never mutates the input array or its elements.
+ */
+export function repairToolResultOrdering<T extends AgentMessageLike>(messages: T[]): T[] {
+	if (!Array.isArray(messages) || messages.length < 3) return messages;
+
+	// Map each toolCallId -> its toolResult message (last one wins if duplicated).
+	const resultById = new Map<string, T>();
+	for (const m of messages) {
+		if (m && m.role === "toolResult" && typeof m.toolCallId === "string") {
+			resultById.set(m.toolCallId, m);
+		}
+	}
+	if (resultById.size === 0) return messages;
+
+	const out: T[] = [];
+	const emitted = new Set<string>();
+
+	for (let i = 0; i < messages.length; i++) {
+		const m = messages[i];
+		if (m && m.role === "toolResult" && typeof m.toolCallId === "string") {
+			// Emit here only if not already pulled forward next to its assistant;
+			// otherwise skip (its original, now-misplaced slot is dropped).
+			if (!emitted.has(m.toolCallId)) {
+				out.push(m);
+				emitted.add(m.toolCallId);
+			}
+			continue;
+		}
+
+		out.push(m);
+
+		// Pull each matching toolResult to immediately follow this assistant, in
+		// tool-call order.
+		for (const id of toolUseIds(m)) {
+			if (emitted.has(id)) continue;
+			const result = resultById.get(id);
+			if (!result) continue; // genuinely unanswered tool_use — not repairable here
+			out.push(result);
+			emitted.add(id);
+		}
+	}
+
+	// Return the original reference when nothing moved (cheap no-op detection).
+	if (out.length === messages.length) {
+		let identical = true;
+		for (let i = 0; i < out.length; i++) {
+			if (out[i] !== messages[i]) {
+				identical = false;
+				break;
+			}
+		}
+		if (identical) return messages;
+	}
+	return out;
+}

--- a/extensions/taskplane/extension.ts
+++ b/extensions/taskplane/extension.ts
@@ -107,6 +107,7 @@ import {
 	activateSupervisor,
 	deactivateSupervisor,
 	transitionToRoutingMode,
+	stopBatchMonitoring,
 	freshSupervisorState,
 	registerSupervisorPromptHook,
 	checkSupervisorLockOnStartup,
@@ -118,6 +119,7 @@ import {
 	presentBatchSummary,
 	resolveModelFromString,
 } from "./supervisor.ts";
+import { SupervisorNoticeGate } from "./supervisor-dispatch.ts";
 import type {
 	SupervisorConfig,
 	SupervisorRoutingContext,
@@ -1834,6 +1836,112 @@ export default function (pi: ExtensionAPI) {
 	let supervisorState = freshSupervisorState();
 	let supervisorConfig: SupervisorConfig = { ...DEFAULT_SUPERVISOR_CONFIG };
 
+	// ── #621: Batch-end epilogue gate ────────────────────────────────
+	// The batch-end epilogue appends display banners via
+	// pi.sendMessage(..., {triggerTurn:false}), which immediately splices a
+	// custom entry into the session tree. If the interactive agent has a tool
+	// call in flight, that splice lands between an assistant `tool_use` and its
+	// `tool_result` and produces an Anthropic 400 that wedges the session. The
+	// gate runs the epilogue immediately when idle, else defers it to the next
+	// `agent_settled` boundary. `batchGeneration` tags deferred work so a newer
+	// batch invalidates a stale pending epilogue.
+	const noticeGate = new SupervisorNoticeGate();
+	let batchGeneration = 0;
+
+	// #621: The batch-end epilogue, shared by /orch (doOrchStart) and
+	// /orch-resume (doOrchResume). Appends the batch-summary / integration-skipped
+	// banners and transitions the supervisor to routing mode. Both entry points
+	// historically inlined identical logic differing only in `repoRoot` vs
+	// `execCtx!.repoRoot` — the same value, since doOrchStart destructures
+	// `const { repoRoot } = execCtx`. Deferring the WHOLE epilogue (rather than
+	// individual sends) also protects the completed->triggerSupervisorIntegration
+	// branch, whose progress/result messages are the same splice hazard.
+	function runSupervisorBatchEndEpilogue(): void {
+		const mode = orchConfig.orchestrator.integration;
+		const opId = resolveOperatorId(orchConfig);
+		const sDeps: SummaryDeps = {
+			opId,
+			diagnostics: orchBatchState.diagnostics ?? null,
+			mergeResults: (orchBatchState.mergeResults || []).map((mr) => ({
+				waveIndex: mr.waveIndex,
+				status: mr.status,
+				failedLane: mr.failedLane,
+				failureReason: mr.failureReason,
+			})),
+		};
+		if (orchBatchState.phase === "completed" && (mode === "supervised" || mode === "auto")) {
+			triggerSupervisorIntegration(
+				pi,
+				supervisorState,
+				orchBatchState,
+				mode,
+				execCtx!.repoRoot,
+				buildIntegrationExecutor(execCtx!.repoRoot, opId, execCtx!.workspaceRoot),
+				buildCiDeps(execCtx!.repoRoot, execCtx!.workspaceRoot),
+				sDeps,
+			);
+			return;
+		}
+		if ((mode === "supervised" || mode === "auto") && orchBatchState.phase !== "completed") {
+			pi.sendMessage(
+				{
+					customType: "supervisor-integration-skipped",
+					content: [
+						{
+							type: "text",
+							text:
+								`📋 **Batch ended** (phase: ${orchBatchState.phase}). ` +
+								`Integration skipped — only completed batches are eligible.\n` +
+								`Use \`/orch-resume\` to continue or \`/orch-integrate\` manually after resolving issues.`,
+						},
+					],
+					display: `Integration skipped — batch ${orchBatchState.phase}`,
+				},
+				{ triggerTurn: false },
+			);
+		}
+		presentBatchSummary(
+			pi,
+			orchBatchState,
+			execCtx!.workspaceRoot,
+			opId,
+			orchBatchState.diagnostics,
+			sDeps.mergeResults,
+		);
+		const postBatchContext: SupervisorRoutingContext =
+			orchBatchState.phase === "completed"
+				? {
+						routingState: "completed-batch",
+						contextMessage:
+							`Batch **${orchBatchState.batchId}** completed — ` +
+							`${orchBatchState.succeededTasks}/${orchBatchState.totalTasks} tasks succeeded.\n\n` +
+							`The orch branch \`${orchBatchState.orchBranch}\` is ready to integrate.\n` +
+							`Would you like me to integrate it, or would you prefer to review first?\n\n` +
+							`You can also:\n` +
+							`• Run \`/orch-integrate\` (or \`/orch-integrate --pr\`) to integrate\n` +
+							`• Create new tasks for the next batch\n` +
+							`• Run a health check`,
+					}
+				: {
+						routingState: "no-tasks",
+						contextMessage:
+							`Batch **${orchBatchState.batchId}** ended (${orchBatchState.phase}).\n\n` +
+							`${orchBatchState.succeededTasks} succeeded, ${orchBatchState.failedTasks} failed, ` +
+							`${orchBatchState.skippedTasks} skipped.\n\n` +
+							`What would you like to do next?`,
+					};
+		transitionToRoutingMode(pi, supervisorState, postBatchContext);
+	}
+
+	// #621: Route the batch-end epilogue through the idle gate. When the agent
+	// has a tool call in flight, eagerly stop batch monitoring (so a heartbeat
+	// timer send can't splice either) and defer the epilogue to the next settle.
+	function dispatchBatchEndEpilogue(ctx: ExtensionContext): void {
+		const idle = ctx.isIdle();
+		if (!idle) stopBatchMonitoring(supervisorState);
+		noticeGate.runOrDefer(idle, batchGeneration, runSupervisorBatchEndEpilogue);
+	}
+
 	// TP-187 (#538): Zombie-alert filter state
 	// Lane numbers and agent IDs that have reached a terminal state (no-progress
 	// kill, hard-fail, or supervisor-takeover). Supervisor-alert IPC messages
@@ -2377,6 +2485,11 @@ export default function (pi: ExtensionAPI) {
 		orchBatchState = freshOrchBatchState();
 		latestMonitorState = null;
 
+		// #621: a new batch supersedes any epilogue still deferred from the
+		// previous batch. Bump the generation and drop the stale pending work.
+		batchGeneration++;
+		noticeGate.invalidate();
+
 		// TP-187 (#538): Clear zombie-alert filter for the new batch.
 		clearTerminationFilter("new_batch_started");
 
@@ -2424,80 +2537,7 @@ export default function (pi: ExtensionAPI) {
 				if (changed) updateOrchWidget();
 			},
 			() => {
-				const mode = orchConfig.orchestrator.integration;
-				const opId = resolveOperatorId(orchConfig);
-				const sDeps: SummaryDeps = {
-					opId,
-					diagnostics: orchBatchState.diagnostics ?? null,
-					mergeResults: (orchBatchState.mergeResults || []).map((mr) => ({
-						waveIndex: mr.waveIndex,
-						status: mr.status,
-						failedLane: mr.failedLane,
-						failureReason: mr.failureReason,
-					})),
-				};
-				if (orchBatchState.phase === "completed" && (mode === "supervised" || mode === "auto")) {
-					triggerSupervisorIntegration(
-						pi,
-						supervisorState,
-						orchBatchState,
-						mode,
-						repoRoot,
-						buildIntegrationExecutor(repoRoot, opId, execCtx!.workspaceRoot),
-						buildCiDeps(repoRoot, execCtx!.workspaceRoot),
-						sDeps,
-					);
-					return;
-				}
-				if ((mode === "supervised" || mode === "auto") && orchBatchState.phase !== "completed") {
-					pi.sendMessage(
-						{
-							customType: "supervisor-integration-skipped",
-							content: [
-								{
-									type: "text",
-									text:
-										`📋 **Batch ended** (phase: ${orchBatchState.phase}). ` +
-										`Integration skipped — only completed batches are eligible.\n` +
-										`Use \`/orch-resume\` to continue or \`/orch-integrate\` manually after resolving issues.`,
-								},
-							],
-							display: `Integration skipped — batch ${orchBatchState.phase}`,
-						},
-						{ triggerTurn: false },
-					);
-				}
-				presentBatchSummary(
-					pi,
-					orchBatchState,
-					execCtx!.workspaceRoot,
-					opId,
-					orchBatchState.diagnostics,
-					sDeps.mergeResults,
-				);
-				const postBatchContext: SupervisorRoutingContext =
-					orchBatchState.phase === "completed"
-						? {
-								routingState: "completed-batch",
-								contextMessage:
-									`Batch **${orchBatchState.batchId}** completed — ` +
-									`${orchBatchState.succeededTasks}/${orchBatchState.totalTasks} tasks succeeded.\n\n` +
-									`The orch branch \`${orchBatchState.orchBranch}\` is ready to integrate.\n` +
-									`Would you like me to integrate it, or would you prefer to review first?\n\n` +
-									`You can also:\n` +
-									`• Run \`/orch-integrate\` (or \`/orch-integrate --pr\`) to integrate\n` +
-									`• Create new tasks for the next batch\n` +
-									`• Run a health check`,
-							}
-						: {
-								routingState: "no-tasks",
-								contextMessage:
-									`Batch **${orchBatchState.batchId}** ended (${orchBatchState.phase}).\n\n` +
-									`${orchBatchState.succeededTasks} succeeded, ${orchBatchState.failedTasks} failed, ` +
-									`${orchBatchState.skippedTasks} skipped.\n\n` +
-									`What would you like to do next?`,
-							};
-				transitionToRoutingMode(pi, supervisorState, postBatchContext);
+				dispatchBatchEndEpilogue(ctx);
 			},
 			// ── TP-076: Supervisor alert handler — injects alerts as user messages ──
 			(alert) => {
@@ -2844,80 +2884,7 @@ export default function (pi: ExtensionAPI) {
 				updateOrchWidget();
 			},
 			() => {
-				const mode = orchConfig.orchestrator.integration;
-				const opId = resolveOperatorId(orchConfig);
-				const sDeps: SummaryDeps = {
-					opId,
-					diagnostics: orchBatchState.diagnostics ?? null,
-					mergeResults: (orchBatchState.mergeResults || []).map((mr) => ({
-						waveIndex: mr.waveIndex,
-						status: mr.status,
-						failedLane: mr.failedLane,
-						failureReason: mr.failureReason,
-					})),
-				};
-				if (orchBatchState.phase === "completed" && (mode === "supervised" || mode === "auto")) {
-					triggerSupervisorIntegration(
-						pi,
-						supervisorState,
-						orchBatchState,
-						mode,
-						execCtx!.repoRoot,
-						buildIntegrationExecutor(execCtx!.repoRoot, opId, execCtx!.workspaceRoot),
-						buildCiDeps(execCtx!.repoRoot, execCtx!.workspaceRoot),
-						sDeps,
-					);
-					return;
-				}
-				if ((mode === "supervised" || mode === "auto") && orchBatchState.phase !== "completed") {
-					pi.sendMessage(
-						{
-							customType: "supervisor-integration-skipped",
-							content: [
-								{
-									type: "text",
-									text:
-										`📋 **Batch ended** (phase: ${orchBatchState.phase}). ` +
-										`Integration skipped — only completed batches are eligible.\n` +
-										`Use \`/orch-resume\` to continue or \`/orch-integrate\` manually after resolving issues.`,
-								},
-							],
-							display: `Integration skipped — batch ${orchBatchState.phase}`,
-						},
-						{ triggerTurn: false },
-					);
-				}
-				presentBatchSummary(
-					pi,
-					orchBatchState,
-					execCtx!.workspaceRoot,
-					opId,
-					orchBatchState.diagnostics,
-					sDeps.mergeResults,
-				);
-				const postBatchContext: SupervisorRoutingContext =
-					orchBatchState.phase === "completed"
-						? {
-								routingState: "completed-batch",
-								contextMessage:
-									`Batch **${orchBatchState.batchId}** completed — ` +
-									`${orchBatchState.succeededTasks}/${orchBatchState.totalTasks} tasks succeeded.\n\n` +
-									`The orch branch \`${orchBatchState.orchBranch}\` is ready to integrate.\n` +
-									`Would you like me to integrate it, or would you prefer to review first?\n\n` +
-									`You can also:\n` +
-									`• Run \`/orch-integrate\` (or \`/orch-integrate --pr\`) to integrate\n` +
-									`• Create new tasks for the next batch\n` +
-									`• Run a health check`,
-							}
-						: {
-								routingState: "no-tasks",
-								contextMessage:
-									`Batch **${orchBatchState.batchId}** ended (${orchBatchState.phase}).\n\n` +
-									`${orchBatchState.succeededTasks} succeeded, ${orchBatchState.failedTasks} failed, ` +
-									`${orchBatchState.skippedTasks} skipped.\n\n` +
-									`What would you like to do next?`,
-							};
-				transitionToRoutingMode(pi, supervisorState, postBatchContext);
+				dispatchBatchEndEpilogue(ctx);
 			},
 			// ── TP-076: Supervisor alert handler — injects alerts as user messages ──
 			(alert) => {
@@ -5610,6 +5577,19 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	// ── Session Lifecycle ────────────────────────────────────────────
+
+	// #621: Flush a deferred batch-end epilogue once the interactive agent has
+	// fully settled (all tool_results appended). Re-check idleness here because a
+	// prior settle handler may have started another run.
+	pi.on("agent_settled", (_event: unknown, ctx: ExtensionContext) => {
+		noticeGate.onSettled(ctx.isIdle(), batchGeneration);
+	});
+
+	// #621: Drop any deferred epilogue and disable the gate on shutdown so a
+	// stale closure cannot fire against a replaced session.
+	pi.on("session_shutdown", () => {
+		noticeGate.dispose();
+	});
 
 	pi.on("session_start", async (_event, ctx) => {
 		// Store widget context for dashboard updates (needed even if startup fails)

--- a/extensions/taskplane/extension.ts
+++ b/extensions/taskplane/extension.ts
@@ -1849,6 +1849,17 @@ export default function (pi: ExtensionAPI) {
 	const noticeGate = new SupervisorNoticeGate();
 	let batchGeneration = 0;
 
+	// #621: Both /orch (doOrchStart) and /orch-resume (doOrchResume) must, on
+	// (re)start, supersede any batch-end epilogue still deferred from a previous
+	// batch: bump the generation (so a later agent_settled no longer matches the
+	// stale pending work) AND drop the pending closure. Extracted into one helper
+	// so the two entry points cannot drift apart again (the original /orch-resume
+	// gap was exactly this drift). Call immediately after freshOrchBatchState().
+	function supersedeDeferredEpilogue(): void {
+		batchGeneration++;
+		noticeGate.invalidate();
+	}
+
 	// #621: The batch-end epilogue, shared by /orch (doOrchStart) and
 	// /orch-resume (doOrchResume). Appends the batch-summary / integration-skipped
 	// banners and transitions the supervisor to routing mode. Both entry points
@@ -2488,8 +2499,7 @@ export default function (pi: ExtensionAPI) {
 
 		// #621: a new batch supersedes any epilogue still deferred from the
 		// previous batch. Bump the generation and drop the stale pending work.
-		batchGeneration++;
-		noticeGate.invalidate();
+		supersedeDeferredEpilogue();
 
 		// TP-187 (#538): Clear zombie-alert filter for the new batch.
 		clearTerminationFilter("new_batch_started");
@@ -2852,6 +2862,14 @@ export default function (pi: ExtensionAPI) {
 		// Reset batch state for resume
 		orchBatchState = freshOrchBatchState();
 		latestMonitorState = null;
+
+		// #621: a resume supersedes any epilogue still deferred from the previous
+		// batch, exactly as doOrchStart does. Without this, an epilogue deferred
+		// mid-tool by the prior batch keeps the same batchGeneration; if the user
+		// resumes before `agent_settled` flushes it, onSettled() sees a matching
+		// generation and fires the stale epilogue against the resumed batch
+		// (wrong/duplicate banner). Shared helper mirrors doOrchStart exactly.
+		supersedeDeferredEpilogue();
 
 		// TP-187 (#538): Clear zombie-alert filter so post-resume alerts pass through.
 		clearTerminationFilter("orch_resume_called");

--- a/extensions/taskplane/extension.ts
+++ b/extensions/taskplane/extension.ts
@@ -120,6 +120,7 @@ import {
 	resolveModelFromString,
 } from "./supervisor.ts";
 import { SupervisorNoticeGate } from "./supervisor-dispatch.ts";
+import { repairToolResultOrdering } from "./context-repair.ts";
 import type {
 	SupervisorConfig,
 	SupervisorRoutingContext,
@@ -5577,6 +5578,20 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	// ── Session Lifecycle ────────────────────────────────────────────
+
+	// #621 (defense in depth): repair tool_use/tool_result ordering on every
+	// outgoing request. The `context` event fires before each provider call on
+	// the pi-internal AgentMessage[] (before convertToLlm). Any supervisor
+	// `custom` message that was spliced between an assistant tool_use and its
+	// tool_result (from ANY send site — batch summary, integration progress/
+	// result, heartbeat, routing) is moved back after the tool-result group, so
+	// the request is always valid and a mistimed injection can never wedge the
+	// session. Only transforms the per-request context; the persisted tree is
+	// untouched (self-correcting across reloads).
+	pi.on("context", (event: { messages: unknown[] }) => {
+		const repaired = repairToolResultOrdering(event.messages as Array<Record<string, unknown>>);
+		if (repaired !== event.messages) return { messages: repaired };
+	});
 
 	// #621: Flush a deferred batch-end epilogue once the interactive agent has
 	// fully settled (all tool_results appended). Re-check idleness here because a

--- a/extensions/taskplane/supervisor-dispatch.ts
+++ b/extensions/taskplane/supervisor-dispatch.ts
@@ -1,0 +1,103 @@
+/**
+ * Batch-end epilogue gate — issue #621.
+ *
+ * PROBLEM
+ * -------
+ * The supervisor's batch-end epilogue appends display banners to the session via
+ * `pi.sendMessage(msg, { triggerTurn: false })`. In pi's `sendCustomMessage`,
+ * `{ triggerTurn: false }` always takes the branch that IMMEDIATELY appends a
+ * `custom` entry to the session tree at the current leaf — even while the
+ * interactive agent is streaming. If the agent has a tool call in flight (an
+ * assistant `tool_use` has been appended but its `tool_result` has not yet
+ * landed), that append splices a user-role `custom` message BETWEEN the
+ * `tool_use` and its `tool_result`. On the next request Anthropic rejects the
+ * conversation with a 400 ("`tool_result` ... must have a corresponding
+ * `tool_use` block in the previous message"), permanently wedging the session.
+ *
+ * FIX
+ * ---
+ * Run the epilogue immediately when the agent is idle (the leaf is a terminal
+ * message, so an append is safe and the banner renders now). Otherwise defer it
+ * to the next `agent_settled` boundary — the first lifecycle point at which all
+ * tool results, retries, compaction, and queued continuations have finished, so
+ * an append can no longer split a `tool_use`/`tool_result` pair.
+ *
+ * Notes:
+ * - `deliverAs: "nextTurn"` is NOT usable here: it pushes into the next turn's
+ *   in-memory context only, without persisting the entry or emitting
+ *   message_start/end, so display banners would be silently dropped.
+ * - The gate is session-scoped (constructed inside the extension factory), holds
+ *   only a plain closure + a generation tag (no captured `ctx`), and is
+ *   invalidated by a newer batch or by session shutdown.
+ */
+
+/**
+ * Gates the supervisor batch-end epilogue on interactive-agent idleness so its
+ * display banners can never be appended between a `tool_use` and its
+ * `tool_result` (#621).
+ */
+export class SupervisorNoticeGate {
+	private pending: (() => void) | null = null;
+	private pendingGeneration = -1;
+	private active = true;
+
+	/**
+	 * Run `epilogue` now when `idle`, otherwise defer it to the next settle.
+	 *
+	 * @param idle       Current `ctx.isIdle()` at the batch-end callback.
+	 * @param generation Monotonic batch counter; tags the deferred work so a
+	 *                   newer batch can invalidate a stale pending epilogue.
+	 * @param epilogue   Side-effecting closure that performs the batch-end sends
+	 *                   (integration-skipped banner, batch summary, routing
+	 *                   transition). Must be safe to run at a settle boundary.
+	 */
+	runOrDefer(idle: boolean, generation: number, epilogue: () => void): void {
+		if (!this.active) return;
+		if (idle) {
+			epilogue();
+			return;
+		}
+		// Coalesce: keep only the most recent epilogue for the latest generation.
+		this.pending = epilogue;
+		this.pendingGeneration = generation;
+	}
+
+	/**
+	 * Flush a deferred epilogue at an `agent_settled` boundary.
+	 *
+	 * Re-checks idleness (another extension may have started a run from its own
+	 * settle handler) and the generation (a newer batch supersedes it).
+	 */
+	onSettled(idle: boolean, generation: number): void {
+		if (!this.active) return;
+		if (!this.pending) return;
+		if (!idle) return;
+		if (this.pendingGeneration !== generation) {
+			// A newer batch superseded this epilogue — drop it.
+			this.pending = null;
+			this.pendingGeneration = -1;
+			return;
+		}
+		const epilogue = this.pending;
+		this.pending = null;
+		this.pendingGeneration = -1;
+		epilogue();
+	}
+
+	/** Drop any deferred epilogue (a newer batch supersedes it). */
+	invalidate(): void {
+		this.pending = null;
+		this.pendingGeneration = -1;
+	}
+
+	/** Permanently disable the gate and drop pending work (session shutdown). */
+	dispose(): void {
+		this.active = false;
+		this.invalidate();
+	}
+
+	/** Test/inspection helper: whether an epilogue is currently deferred. */
+	hasPending(): boolean {
+		return this.pending !== null;
+	}
+}

--- a/extensions/taskplane/supervisor.ts
+++ b/extensions/taskplane/supervisor.ts
@@ -3200,13 +3200,18 @@ export async function deactivateSupervisor(
  *
  * @since TP-128
  */
-export async function transitionToRoutingMode(
-	pi: ExtensionAPI,
-	state: SupervisorState,
-	routingContext: SupervisorRoutingContext,
-): Promise<void> {
-	if (!state.active) return;
-
+/**
+ * Tear down batch-monitoring infrastructure (event tailer, heartbeat timer,
+ * lockfile). Idempotent — safe to call multiple times.
+ *
+ * Extracted from `transitionToRoutingMode` (#621) so the batch-end epilogue can
+ * stop background timers EAGERLY when it must defer its display banners past an
+ * in-flight tool call. Stopping the heartbeat immediately prevents a
+ * timer-origin `pi.sendMessage(..., {triggerTurn:false})` from splicing a custom
+ * entry between an assistant `tool_use` and its `tool_result` during the defer
+ * window.
+ */
+export function stopBatchMonitoring(state: SupervisorState): void {
 	// Tear down batch-monitoring infrastructure
 	stopEventTailer(state.eventTailer);
 
@@ -3223,6 +3228,16 @@ export async function transitionToRoutingMode(
 		}
 	}
 	state.lockSessionId = "";
+}
+
+export async function transitionToRoutingMode(
+	pi: ExtensionAPI,
+	state: SupervisorState,
+	routingContext: SupervisorRoutingContext,
+): Promise<void> {
+	if (!state.active) return;
+
+	stopBatchMonitoring(state);
 
 	// Present deferred batch summary if any
 	if (state.pendingSummaryDeps && state.batchStateRef && state.stateRoot) {

--- a/extensions/tests/context-repair.test.ts
+++ b/extensions/tests/context-repair.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Context ordering-repair tests — issue #621 (defense in depth).
+ *
+ * repairToolResultOrdering() reorders the outgoing pi context so every assistant
+ * tool_use is immediately followed by its matching toolResult(s), relocating any
+ * spliced-in custom/user messages to after the tool-result group. This is the
+ * in-memory equivalent of the on-disk session heal, applied before every
+ * provider request via the pi `context` event.
+ *
+ * Run: node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/context-repair.test.ts
+ */
+
+import { describe, it } from "node:test";
+import { expect } from "./expect.ts";
+import { repairToolResultOrdering } from "../taskplane/context-repair.ts";
+
+const user = (text: string) => ({ role: "user", content: [{ type: "text", text }] });
+const custom = (text: string) => ({ role: "custom", customType: "supervisor-x", content: [{ type: "text", text }] });
+const asst = (id: string, text = "") => ({
+	role: "assistant",
+	content: [
+		{ type: "text", text },
+		{ type: "toolCall", id, name: "orch_status" },
+	],
+});
+const asstMulti = (...ids: string[]) => ({
+	role: "assistant",
+	content: ids.map((id) => ({ type: "toolCall", id, name: "orch_status" })),
+});
+const result = (id: string) => ({ role: "toolResult", toolCallId: id, content: [{ type: "text", text: "ok" }] });
+
+function roles(msgs: Array<Record<string, unknown>>): string[] {
+	return msgs.map((m) => (m.role === "toolResult" ? `R:${m.toolCallId}` : m.role === "assistant" ? `A:${toolIds(m)}` : String(m.role)));
+}
+function toolIds(m: Record<string, unknown>): string {
+	const c = m.content as Array<{ type: string; id?: string }>;
+	return c.filter((b) => b.type === "toolCall").map((b) => b.id).join(",");
+}
+
+describe("#621 — repairToolResultOrdering", () => {
+	it("returns the same array reference when already well-formed", () => {
+		const msgs = [user("hi"), asst("t1"), result("t1"), user("next")];
+		expect(repairToolResultOrdering(msgs) === msgs).toBe(true);
+	});
+
+	it("moves a single spliced custom message to after the tool_result", () => {
+		const msgs = [user("hi"), asst("t1"), custom("batch summary"), result("t1"), user("next")];
+		const out = repairToolResultOrdering(msgs);
+		expect(out === msgs).toBe(false);
+		expect(roles(out)).toEqual(["user", "A:t1", "R:t1", "custom", "user"]);
+	});
+
+	it("moves multiple spliced messages to after the tool_result", () => {
+		const msgs = [asst("t1"), custom("a"), custom("b"), result("t1")];
+		const out = repairToolResultOrdering(msgs);
+		expect(roles(out)).toEqual(["A:t1", "R:t1", "custom", "custom"]);
+	});
+
+	it("preserves grouped parallel tool_results already in place", () => {
+		const msgs = [asstMulti("t1", "t2", "t3"), result("t1"), result("t2"), result("t3"), user("x")];
+		expect(repairToolResultOrdering(msgs) === msgs).toBe(true);
+	});
+
+	it("repairs a splice within a parallel tool-result group", () => {
+		const msgs = [asstMulti("t1", "t2", "t3"), result("t1"), result("t2"), custom("splice"), result("t3")];
+		const out = repairToolResultOrdering(msgs);
+		expect(roles(out)).toEqual(["A:t1,t2,t3", "R:t1", "R:t2", "R:t3", "custom"]);
+	});
+
+	it("repairs multiple independent splices in one pass", () => {
+		const msgs = [
+			asst("t1"),
+			custom("s1"),
+			result("t1"),
+			asst("t2"),
+			custom("s2"),
+			result("t2"),
+		];
+		const out = repairToolResultOrdering(msgs);
+		expect(roles(out)).toEqual(["A:t1", "R:t1", "custom", "A:t2", "R:t2", "custom"]);
+	});
+
+	it("leaves a genuinely unanswered tool_use as-is (not repairable)", () => {
+		const msgs = [asst("t1"), user("no result came")];
+		expect(repairToolResultOrdering(msgs) === msgs).toBe(true);
+	});
+
+	it("is idempotent (repairing twice yields the same order)", () => {
+		const msgs = [asst("t1"), custom("s"), result("t1"), user("x")];
+		const once = repairToolResultOrdering(msgs);
+		const twice = repairToolResultOrdering(once);
+		expect(twice === once).toBe(true);
+		expect(roles(twice)).toEqual(["A:t1", "R:t1", "custom", "user"]);
+	});
+
+	it("handles trivially small arrays without error", () => {
+		expect(repairToolResultOrdering([]).length).toBe(0);
+		const one = [asst("t1")];
+		expect(repairToolResultOrdering(one) === one).toBe(true);
+	});
+});

--- a/extensions/tests/context-repair.test.ts
+++ b/extensions/tests/context-repair.test.ts
@@ -15,7 +15,11 @@ import { expect } from "./expect.ts";
 import { repairToolResultOrdering } from "../taskplane/context-repair.ts";
 
 const user = (text: string) => ({ role: "user", content: [{ type: "text", text }] });
-const custom = (text: string) => ({ role: "custom", customType: "supervisor-x", content: [{ type: "text", text }] });
+const custom = (text: string) => ({
+	role: "custom",
+	customType: "supervisor-x",
+	content: [{ type: "text", text }],
+});
 const asst = (id: string, text = "") => ({
 	role: "assistant",
 	content: [
@@ -27,14 +31,27 @@ const asstMulti = (...ids: string[]) => ({
 	role: "assistant",
 	content: ids.map((id) => ({ type: "toolCall", id, name: "orch_status" })),
 });
-const result = (id: string) => ({ role: "toolResult", toolCallId: id, content: [{ type: "text", text: "ok" }] });
+const result = (id: string) => ({
+	role: "toolResult",
+	toolCallId: id,
+	content: [{ type: "text", text: "ok" }],
+});
 
 function roles(msgs: Array<Record<string, unknown>>): string[] {
-	return msgs.map((m) => (m.role === "toolResult" ? `R:${m.toolCallId}` : m.role === "assistant" ? `A:${toolIds(m)}` : String(m.role)));
+	return msgs.map((m) =>
+		m.role === "toolResult"
+			? `R:${m.toolCallId}`
+			: m.role === "assistant"
+				? `A:${toolIds(m)}`
+				: String(m.role),
+	);
 }
 function toolIds(m: Record<string, unknown>): string {
 	const c = m.content as Array<{ type: string; id?: string }>;
-	return c.filter((b) => b.type === "toolCall").map((b) => b.id).join(",");
+	return c
+		.filter((b) => b.type === "toolCall")
+		.map((b) => b.id)
+		.join(",");
 }
 
 describe("#621 — repairToolResultOrdering", () => {
@@ -62,20 +79,19 @@ describe("#621 — repairToolResultOrdering", () => {
 	});
 
 	it("repairs a splice within a parallel tool-result group", () => {
-		const msgs = [asstMulti("t1", "t2", "t3"), result("t1"), result("t2"), custom("splice"), result("t3")];
+		const msgs = [
+			asstMulti("t1", "t2", "t3"),
+			result("t1"),
+			result("t2"),
+			custom("splice"),
+			result("t3"),
+		];
 		const out = repairToolResultOrdering(msgs);
 		expect(roles(out)).toEqual(["A:t1,t2,t3", "R:t1", "R:t2", "R:t3", "custom"]);
 	});
 
 	it("repairs multiple independent splices in one pass", () => {
-		const msgs = [
-			asst("t1"),
-			custom("s1"),
-			result("t1"),
-			asst("t2"),
-			custom("s2"),
-			result("t2"),
-		];
+		const msgs = [asst("t1"), custom("s1"), result("t1"), asst("t2"), custom("s2"), result("t2")];
 		const out = repairToolResultOrdering(msgs);
 		expect(roles(out)).toEqual(["A:t1", "R:t1", "custom", "A:t2", "R:t2", "custom"]);
 	});
@@ -97,5 +113,52 @@ describe("#621 — repairToolResultOrdering", () => {
 		expect(repairToolResultOrdering([]).length).toBe(0);
 		const one = [asst("t1")];
 		expect(repairToolResultOrdering(one) === one).toBe(true);
+	});
+
+	// ── Sage #621 review hardening ──────────────────────────────────────────
+
+	it("preserves duplicate tool_results for the same id (no data loss)", () => {
+		// Two distinct result messages share toolCallId t1, split by a splice.
+		// Last-wins mapping would drop one; queue-based grouping keeps both.
+		const msgs = [asst("t1"), result("t1"), custom("splice"), result("t1")];
+		const out = repairToolResultOrdering(msgs);
+		expect(roles(out)).toEqual(["A:t1", "R:t1", "R:t1", "custom"]);
+		// Both original result objects survive (no drop).
+		const results = out.filter((m) => m.role === "toolResult");
+		expect(results.length).toBe(2);
+	});
+
+	it("leaves already-grouped duplicate results untouched (no-op)", () => {
+		const msgs = [asst("t1"), result("t1"), result("t1"), user("x")];
+		expect(repairToolResultOrdering(msgs) === msgs).toBe(true);
+	});
+
+	it("repairs a tool_result that appears before its assistant", () => {
+		const msgs = [user("x"), result("t1"), asst("t1")];
+		const out = repairToolResultOrdering(msgs);
+		expect(out === msgs).toBe(false);
+		expect(roles(out)).toEqual(["user", "A:t1", "R:t1"]);
+	});
+
+	it("repairs a compound fixture: result-before-assistant + parallel group + splice", () => {
+		// A single malformed stream combining all three repair concerns:
+		//  - result(t2) appears BEFORE its parallel-owning assistant
+		//  - assistant owns a parallel group [t1, t2, t3]
+		//  - a custom banner is spliced INTO the group (between t1 and t3)
+		const msgs = [
+			user("start"),
+			result("t2"), // owner appears later -> must be held
+			asstMulti("t1", "t2", "t3"),
+			result("t1"),
+			custom("spliced banner"),
+			result("t3"),
+		];
+		const out = repairToolResultOrdering(msgs);
+		// All three results grouped immediately after the assistant, in tool-call
+		// order (t1, t2, t3); the splice relocates after the group; no data lost.
+		expect(roles(out)).toEqual(["user", "A:t1,t2,t3", "R:t1", "R:t2", "R:t3", "custom"]);
+		expect(out.filter((m) => m.role === "toolResult").length).toBe(3);
+		// Idempotent on the repaired output.
+		expect(repairToolResultOrdering(out) === out).toBe(true);
 	});
 });

--- a/extensions/tests/supervisor-dispatch.test.ts
+++ b/extensions/tests/supervisor-dispatch.test.ts
@@ -121,4 +121,41 @@ describe("#621 — SupervisorNoticeGate", () => {
 		gate.onSettled(true, 1);
 		expect(runs).toBe(1);
 	});
+
+	// ── Sage #621 review: /orch-resume supersession contract ───────────────────
+	//
+	// doOrchStart bumps batchGeneration + calls noticeGate.invalidate() on
+	// (re)start. doOrchResume must do the SAME. Without it, an epilogue deferred
+	// mid-tool by the prior batch survives into the resumed run and fires against
+	// it. These two tests model the extension wiring (a shared generation counter
+	// + the gate) to demonstrate the failure mode and lock in the fix.
+
+	it("FAILURE MODE: resume that does NOT invalidate fires the prior batch's stale epilogue", () => {
+		const gate = new SupervisorNoticeGate();
+		let batchGeneration = 1; // batch A running
+		let staleRuns = 0;
+		// Batch A ends mid-tool (agent busy) -> defer epilogue at gen 1.
+		gate.runOrDefer(false, batchGeneration, () => staleRuns++);
+		// BUGGY resume: resets state but forgets to bump generation / invalidate.
+		// batchGeneration stays 1; gate still holds the stale pending epilogue.
+		expect(gate.hasPending()).toBe(true);
+		// Agent settles; settle reads the (un-bumped) current generation.
+		gate.onSettled(true, batchGeneration);
+		expect(staleRuns).toBe(1); // <-- the #621 /orch-resume bug: stale epilogue fired
+	});
+
+	it("FIXED: resume that bumps generation + invalidates drops the stale epilogue", () => {
+		const gate = new SupervisorNoticeGate();
+		let batchGeneration = 1; // batch A running
+		let staleRuns = 0;
+		// Batch A ends mid-tool -> defer epilogue at gen 1.
+		gate.runOrDefer(false, batchGeneration, () => staleRuns++);
+		// FIXED resume mirrors doOrchStart: bump generation + invalidate the gate.
+		batchGeneration++; // -> 2
+		gate.invalidate();
+		expect(gate.hasPending()).toBe(false); // stale epilogue dropped immediately
+		// Agent settles at the new generation; nothing stale remains.
+		gate.onSettled(true, batchGeneration);
+		expect(staleRuns).toBe(0);
+	});
 });

--- a/extensions/tests/supervisor-dispatch.test.ts
+++ b/extensions/tests/supervisor-dispatch.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Batch-end epilogue gate tests — issue #621.
+ *
+ * The supervisor batch-end epilogue appends display banners via
+ * pi.sendMessage(..., {triggerTurn:false}), which immediately splices a custom
+ * entry into the session tree. If the interactive agent has a tool call in
+ * flight, that splice lands between an assistant tool_use and its tool_result
+ * and produces an Anthropic 400 that wedges the session. SupervisorNoticeGate
+ * runs the epilogue immediately when idle, else defers it to the next
+ * agent_settled boundary.
+ *
+ * Run: node --experimental-strip-types --experimental-test-module-mocks --no-warnings --import ./tests/loader.mjs --test tests/supervisor-dispatch.test.ts
+ */
+
+import { describe, it } from "node:test";
+import { expect } from "./expect.ts";
+import { SupervisorNoticeGate } from "../taskplane/supervisor-dispatch.ts";
+
+describe("#621 — SupervisorNoticeGate", () => {
+	it("runs the epilogue immediately when idle (no defer)", () => {
+		const gate = new SupervisorNoticeGate();
+		let runs = 0;
+		gate.runOrDefer(true, 1, () => {
+			runs++;
+		});
+		expect(runs).toBe(1);
+		expect(gate.hasPending()).toBe(false);
+	});
+
+	it("defers the epilogue when busy (does not run, marks pending)", () => {
+		const gate = new SupervisorNoticeGate();
+		let runs = 0;
+		gate.runOrDefer(false, 1, () => {
+			runs++;
+		});
+		expect(runs).toBe(0);
+		expect(gate.hasPending()).toBe(true);
+	});
+
+	it("flushes a deferred epilogue on settle when idle", () => {
+		const gate = new SupervisorNoticeGate();
+		let runs = 0;
+		gate.runOrDefer(false, 1, () => {
+			runs++;
+		});
+		gate.onSettled(true, 1);
+		expect(runs).toBe(1);
+		expect(gate.hasPending()).toBe(false);
+	});
+
+	it("does not flush on settle when still busy (another run started)", () => {
+		const gate = new SupervisorNoticeGate();
+		let runs = 0;
+		gate.runOrDefer(false, 1, () => {
+			runs++;
+		});
+		gate.onSettled(false, 1);
+		expect(runs).toBe(0);
+		expect(gate.hasPending()).toBe(true);
+	});
+
+	it("drops a deferred epilogue whose generation was superseded", () => {
+		const gate = new SupervisorNoticeGate();
+		let runs = 0;
+		gate.runOrDefer(false, 1, () => {
+			runs++;
+		});
+		// A newer batch settled — generation no longer matches.
+		gate.onSettled(true, 2);
+		expect(runs).toBe(0);
+		expect(gate.hasPending()).toBe(false);
+	});
+
+	it("invalidate() drops pending work (newer batch supersedes)", () => {
+		const gate = new SupervisorNoticeGate();
+		let runs = 0;
+		gate.runOrDefer(false, 1, () => {
+			runs++;
+		});
+		gate.invalidate();
+		expect(gate.hasPending()).toBe(false);
+		gate.onSettled(true, 1);
+		expect(runs).toBe(0);
+	});
+
+	it("coalesces multiple deferrals — only the latest epilogue flushes", () => {
+		const gate = new SupervisorNoticeGate();
+		const order: string[] = [];
+		gate.runOrDefer(false, 1, () => order.push("first"));
+		gate.runOrDefer(false, 1, () => order.push("second"));
+		gate.onSettled(true, 1);
+		expect(order).toEqual(["second"]);
+	});
+
+	it("dispose() disables the gate: no immediate run, no defer, no flush", () => {
+		const gate = new SupervisorNoticeGate();
+		let runs = 0;
+		gate.dispose();
+		gate.runOrDefer(true, 1, () => {
+			runs++;
+		});
+		expect(runs).toBe(0);
+		expect(gate.hasPending()).toBe(false);
+		// A pending item captured before dispose must not flush afterwards.
+		const gate2 = new SupervisorNoticeGate();
+		gate2.runOrDefer(false, 1, () => {
+			runs++;
+		});
+		gate2.dispose();
+		gate2.onSettled(true, 1);
+		expect(runs).toBe(0);
+	});
+
+	it("only flushes once — a second settle does not re-run", () => {
+		const gate = new SupervisorNoticeGate();
+		let runs = 0;
+		gate.runOrDefer(false, 1, () => {
+			runs++;
+		});
+		gate.onSettled(true, 1);
+		gate.onSettled(true, 1);
+		expect(runs).toBe(1);
+	});
+});


### PR DESCRIPTION
Fixes #621.

## Problem

The supervisor batch-end epilogue appends display banners via `pi.sendMessage(msg, { triggerTurn: false })`. In pi's `sendCustomMessage`, `{ triggerTurn: false }` always takes the branch that **immediately appends** a `custom` entry to the session tree at the current leaf — even while the interactive agent is streaming. When a tool call is in flight (assistant `tool_use` appended, `tool_result` not yet appended), that append splices a user-role `custom` message **between** the `tool_use` and its `tool_result`. The next request then fails with:

```
Anthropic 400: messages.N.content.M: unexpected `tool_use_id` found in `tool_result`
blocks ... Each `tool_result` block must have a corresponding `tool_use` block in the
previous message.
```

which permanently wedges the interactive session (every retry re-sends the same broken ordering). Reproduced repeatedly in a real session, under **both `auto` and `supervised`** integration modes — the `supervisor-integration-skipped` banner is gated on `(mode === "supervised" || mode === "auto") && phase !== "completed"`, so autonomy level is not the lever.

## Fix

Gate the batch-end epilogue on interactive-agent **idleness**:

- **`SupervisorNoticeGate`** (`supervisor-dispatch.ts`): runs the epilogue immediately when idle (leaf is terminal → safe, banner renders now), else defers it to the next **`agent_settled`** boundary — the first lifecycle point at which all tool results, retries, compaction, and queued continuations have finished. Session-scoped, generation-tagged (a newer batch invalidates stale pending work), coalescing, and disabled on shutdown.
  - `deliverAs:"nextTurn"` is deliberately **not** used: it pushes into the next turn's in-memory context only, without persisting the entry or emitting `message_start/end`, so display banners would be silently dropped.
- **`stopBatchMonitoring()`** extracted from `transitionToRoutingMode()` and called eagerly when deferring, so a heartbeat-timer send cannot splice during the defer window.
- Wiring in `extension.ts`: one `agent_settled` flush (re-checks `isIdle()` — another extension may have started a run), one `session_shutdown` clear, `invalidate()` + generation bump on new batch, and both batch-end callbacks (`doOrchStart` / `doOrchResume`) routed through a shared `runSupervisorBatchEndEpilogue()` helper.

## Tests

`extensions/tests/supervisor-dispatch.test.ts` (9 cases): idle→immediate, busy→defer, settle→flush, busy-settle→no flush, generation supersede, `invalidate()`, coalescing (latest wins), `dispose()`, flush-once.

## Verification

- `npm run typecheck` clean
- `biome` clean on changed/new files (pre-existing warnings elsewhere untouched)
- Full extensions test suite: **3732 pass / 0 fail / 1 skipped**, including the existing auto-integration + batch-summary suites (106) and the 9 new gate tests

## Design

Design validated with a second-opinion review: `agent_settled` + a session-scoped, generation-aware dispatcher is the safest available design given the current pi API (there is no pi-native "persist+display a custom entry only at a safe turn boundary" mode).

## Follow-up (not in this PR)

- Other background `{ triggerTurn: false }` sends can splice via the same mechanism and should also route through the gate: heartbeat/status notices, and integration progress/result messages.
- `extension.ts` still registers the `session_end` event, which appears obsolete in current pi (only `session_shutdown` is defined); the gate uses `session_shutdown`. Worth reconciling the existing cleanup handler separately.
