### PR TITLE
release: v0.30.5 — supervisor in-flight tool_use/tool_result ordering fix (#621)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.5] - 2026-08-27
+
 ### Fixed
 
 - **Supervisor status injection during an in-flight tool call wedged the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.30.4",
+  "version": "0.30.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.30.4",
+      "version": "0.30.5",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.30.4",
+  "version": "0.30.5",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
Patch release wrapping the #621 fix (already merged to main via #622).

## Patch justification (semver)

Bug fix only, no breaking changes or new public API. One bounded behavior note (auto-integration may start at the next `agent_settled` boundary rather than instantly when the agent is mid-turn at batch completion). Patch bump (`0.30.4 → 0.30.5`) is correct.

## Issue included

| # | Title | Severity |
|---|---|---|
| **#621** | Supervisor `pi.sendMessage` status injection during in-flight tool call orphans tool_result → Anthropic 400 wedges interactive session | **P1 / high** |

## Highlights

A mistimed batch-transition banner injected between an assistant `tool_use` and its pending `tool_result` produced an Anthropic 400 that **permanently wedged** the interactive session (every retry re-sent the broken ordering; recovery needed manual `.jsonl` surgery). Fixed with a two-layer defense:

1. **Prevention** — `SupervisorNoticeGate` defers the batch-end epilogue past in-flight tool calls to the next `agent_settled` boundary, with a batch-generation tag so `/orch` and `/orch-resume` both supersede stale deferred work.
2. **Defense-in-depth** — a `context` event handler reorders every outgoing request so each `tool_use` is immediately followed by its `tool_result`(s), covering the other background send sites. Per-request only; the persisted tree is untouched.

Both a Sage strategy review and a Sage code review were done; all findings remediated (the `/orch-resume` supersession gap, repair-algorithm hardening against data loss + result-before-assistant, and a shared helper to prevent future drift). Sage verdict: no blocking issues, confidence ~0.9.

## Validation (on the merged fix commit)

| Gate | Result |
|---|---|
| `npm run typecheck` | ✅ pass |
| `npm run lint` | ✅ 286 warnings / 671 infos (baseline) |
| `npm run format:check` | ✅ clean |
| full test suite | ✅ 3747 pass / 0 fail / 1 skip (+24 new #621 tests) |
| `taskplane help` / `doctor` | ✅ pass |
| `npm pack --dry-run` | ✅ 79 files |

## After merge

I'll push the `v0.30.5` tag from local; `.github/workflows/release.yml` handles tag validation, test re-run, `npm publish --provenance` (Trusted Publishing), and the GitHub release from CHANGELOG notes.