### PR TITLE
release: v0.30.6 — review-boundary supervisor notifications, fail-closed review gate, verified recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.6] - 2026-09-07
+
 ### New
 
 - **Supervisor is now actively notified at every review boundary, with
@@ -150,6 +152,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     registry agents (no registry hand-edit needed; resume reconciles them).
   - `isProcessAlive` treats only ESRCH as dead (EPERM/unknown fail closed).
 
+- **`review_step` could fail OPEN to APPROVE, and every successful review
+  emitted a spurious "Reviewer unavailable"** (#624). The review-boundary
+  path only handled string tool results (structured content → "" → UNKNOWN,
+  conflated with UNAVAILABLE), and the worker-facing gate's APPROVE-first
+  substring fallback flipped REVISE reviews to APPROVE — workers advanced
+  past open P1 findings. One shared, line-oriented `parseReviewVerdict`
+  (heading / bold / plain / bracket / next-line variants; skips the
+  `[APPROVE | REVISE | RETHINK]` placeholder) serves the tool, the
+  lane-runner and the supervisor; APPROVE only from an explicit Verdict
+  line; body-text fallback can guess REVISE/RETHINK but never approve; the
+  review file's verdict is authoritative over the tool-return parse.
+- **A task could finalize over an outstanding REVISE/RETHINK** (#626,
+  minimal cut). Both a worker-written `.DONE` (TP-2037) and the runtime's
+  checkbox heuristic (TP-2039) merged unreviewed work. Before `.DONE` is
+  created or accepted, each gate's LATEST review file must not read
+  REVISE/RETHINK; otherwise the task fails (`review_gate_refusal`) with a
+  steer-delivered `unresolved-verdict` alert and remediation guidance. Steps
+  with no review at all are not blocked by this cut (full coverage gate is
+  the designed follow-up).
+- **A REVISE'd step kept flipping back to `✅ Complete`** — an uncommitted
+  STATUS edit "never authored by the worker". The lane-runner's checkbox
+  heuristic marked any fully-checked step Complete regardless of its review
+  verdict; the worker correctly reverted it per the recovery recipe and the
+  runtime flipped it back on every relaunch (also tripping `review_step`'s
+  complete-step guard). Step completion is now review-gated (same rule as
+  the finalize gate); STATUS logs `Step completion withheld`.
+- **Worktree cleanup could destroy uncommitted work** (#628, minimal cut).
+  `removeWorktree` and `forceCleanupWorktree` now refuse a worktree with
+  uncommitted changes (opt-in `allowDirty` only after preserving progress);
+  a toplevel-identity check keeps corrupted/orphaned-worktree recovery
+  working; engine/resume cleanup paths surface a refusal loudly and never
+  force-clean past it. The takeover state-machine half of #628 remains open.
+- **Supervisor audit-trail timestamps were fabricated by the LLM** (#625).
+  The system prompt literally instructed `echo '{"ts":…}' >> actions.jsonl`.
+  New `log_recovery_action` tool code-stamps `ts` and `batchId` and enforces
+  the entry schema; the prompt and primer now mandate it (including for
+  hand-remediation under operator rulings) and forbid hand-writing the file.
+- **Exit-intercept reply window is configurable:**
+  `taskRunner.worker.exitInterceptTimeoutSec` (`.pi/taskplane-config.json`;
+  YAML `exit_intercept_timeout_sec`; default 60, 15..1800) — a supervisor
+  inside a long tool call could not answer in 60 s. Resume's reconnect and
+  re-execute paths now forward the worker env (model, thinking, tools and
+  this window) — previously dropped on retry+resume.
 - **Worker mail to the supervisor was only surfaced after the worker exited,
   not live during the run.** A worker that mailed the supervisor mid-run
   (via `notify_supervisor`/`escalate_to_supervisor` — e.g. asking for help to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "taskplane",
-  "version": "0.30.5",
+  "version": "0.30.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taskplane",
-      "version": "0.30.5",
+      "version": "0.30.6",
       "license": "MIT",
       "dependencies": {
         "jiti": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskplane",
-  "version": "0.30.5",
+  "version": "0.30.6",
   "description": "AI agent orchestration for pi — parallel task execution with checkpoint discipline",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
## release: v0.30.6

**Patch bump (semver):** bug fixes and additive, backward-compatible behaviour — no breaking API/config changes. The one operational change is fail-closed by design (see migration note).

### Highlights
- **Review-boundary supervisor notifications** — every review start/end surfaced with disposition, round and severity trend; spiral detection + adjudication signals (steer-delivered). Live-verified on Penster (three feedback rounds folded in).
- **Review gate can't fail open** (#624): `review_step` APPROVE only from an explicit Verdict line; no spurious "Reviewer unavailable"; finalize refuses `.DONE` over an outstanding REVISE/RETHINK (#626 minimal) with a real remediation path (#629).
- **Recovery actually works**: retry resets v2 segment records (#629); a replacement supervisor can resume an inherited batch under one verified engine-ownership gate (#631); holds are hold-aware with an explicit acknowledgement contract (#630); pause never skips tasks or completes the batch, and resume merges succeeded-but-unmerged work (#633).
- **Safety**: worktree cleanup refuses to destroy uncommitted work (#628 minimal); audit trail via `log_recovery_action` (#625); engine no longer crashes Pi on a stale ctx (#620); no stale integration prompts (#610).

### Issues closed / advanced
Closes #620, #624, #625, #629, #610, #633. Advances #626, #628, #630, #631 (Tier-2 scope remains open on each; see issue comments).

### Migration note
Batches created before 0.30.6 have no `engine.json`; the first recovery tool or fresh `/orch` against one refuses until `/orch-confirm-engine-shutdown [--batch <id>] <note>` records an out-of-band verification (once per legacy batch). New batches never need it.

### Validation
- Full suite 3957 pass / 0 fail / 1 skip; typecheck, format, lint (284 warnings — below the 286 baseline) clean; CLI `help`/`doctor` OK.
- TP-114 smoke run end-to-end; three Penster live batches (20260906T194514, 221045, follow-up) on the deployed build with no detrimental outcomes.
- Every risky seam Sage-reviewed to sign-off (#631: nine rounds; pause fix: seven).
