### PR TITLE
chore(release): tolerate npm replica lag — poll ~6 min, warn (not fail) on timeout so the GitHub release still lands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,18 +108,30 @@ jobs:
         run: npm publish --provenance --access public
 
       - name: Verify npm publish landed
+        id: verify_npm
+        # v0.30.6: `npm publish` succeeded ("+ taskplane@0.30.6") but the registry's
+        # read replicas took ~5 minutes to serve it. The old 30s poll aborted the
+        # job and the GitHub-release step never ran, leaving a published npm
+        # version with no release. Now: poll ~6 minutes, and treat a timeout as a
+        # WARNING rather than a failure — the publish step above is the authority
+        # on whether publishing succeeded (it fails loudly on E403/EOTP/etc.); a
+        # slow replica must not block the release steps below.
+        continue-on-error: true
         run: |
-          # npm registry can lag a few seconds; poll for up to ~30s.
-          for i in 1 2 3 4 5 6; do
-            REGISTRY_VERSION=$(npm view taskplane version 2>/dev/null || echo "")
-            if [ "$REGISTRY_VERSION" = "${{ steps.version.outputs.tag_version }}" ]; then
-              echo "✅ npm registry shows version $REGISTRY_VERSION"
+          EXPECTED="${{ steps.version.outputs.tag_version }}"
+          for i in $(seq 1 24); do
+            # Query the registry document directly (bypasses npm's client cache).
+            REGISTRY_VERSION=$(curl -fsS https://registry.npmjs.org/taskplane 2>/dev/null \
+              | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{console.log(JSON.parse(d)["dist-tags"].latest)}catch{console.log("")}})' \
+              || echo "")
+            if [ "$REGISTRY_VERSION" = "$EXPECTED" ]; then
+              echo "✅ npm registry shows version $REGISTRY_VERSION (after $((i*15))s)"
               exit 0
             fi
-            echo "Registry shows '$REGISTRY_VERSION', expected '${{ steps.version.outputs.tag_version }}'. Retry $i/6 in 5s..."
-            sleep 5
+            echo "Registry shows '$REGISTRY_VERSION', expected '$EXPECTED'. Retry $i/24 in 15s..."
+            sleep 15
           done
-          echo "::error::npm registry did not propagate the new version within 30s. Check https://www.npmjs.com/package/taskplane manually."
+          echo "::warning::npm registry had not propagated $EXPECTED after ~6 minutes. The publish step succeeded; this is almost certainly replica lag. Verify manually: npm view taskplane version"
           exit 1
 
       - name: Extract changelog section for this version
@@ -168,3 +180,7 @@ jobs:
           echo "- **npm**: https://www.npmjs.com/package/taskplane/v/${{ steps.version.outputs.tag_version }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **GitHub**: https://github.com/${{ github.repository }}/releases/tag/${{ steps.version.outputs.tag_name }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Provenance**: attached (verifiable via \`npm audit signatures\`)" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.verify_npm.outcome }}" != "success" ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> ⚠️ npm registry propagation was not confirmed within the poll window (the publish step itself succeeded). Verify: \`npm view taskplane version\`" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,8 +279,12 @@ consecutive releases).
      `gh run list --workflow=release.yml --limit 1`
 
 8. **Verify everything published correctly.**
-   - `npm view taskplane version` — should show the new version (allow ~10-15s
-     for npm registry propagation)
+   - `npm view taskplane version` — should show the new version. npm read
+     replicas have lagged **~5 minutes** (v0.30.6); the workflow polls ~6 min and
+     treats a timeout as a warning, so the GitHub release is still created. If
+     the registry still lags after that, wait — do NOT re-run the workflow
+     (`npm publish` over an existing version fails with E403) and do NOT publish
+     locally.
    - `gh release view v<version>` — should show the GitHub release with notes
    - Optional: `npm view taskplane versions --json | tail` to confirm the
      version is in the published list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Internal
+
+- **Release workflow:** the npm-propagation check polls ~6 minutes (was 30 s)
+  and a timeout is a warning, not a failure — v0.30.6 published fine but the
+  registry lagged ~5 minutes, the old check aborted the job and the GitHub
+  release step never ran (created by hand afterwards).
+
 ## [0.30.6] - 2026-09-07
 
 ### New


### PR DESCRIPTION
v0.30.6: npm publish succeeded but the registry took ~5 minutes to serve
the version; the 30s verify step aborted the job and the GitHub-release step
never ran. Now: registry document polled directly (bypasses client cache)
for up to 24×15s, continue-on-error so the idempotent release step always
runs, and the step summary flags an unconfirmed propagation. AGENTS.md step 8
updated (do not re-run / do not publish locally on lag).
